### PR TITLE
Fix ClickhouseClient database name handling

### DIFF
--- a/crates/clickhouse/src/lib.rs
+++ b/crates/clickhouse/src/lib.rs
@@ -242,7 +242,7 @@ impl ClickhouseClient {
             .with_user(username)
             .with_password(password);
 
-        Ok(Self { base: client, db_name: "taikoscope".into() })
+        Ok(Self { base: client, db_name })
     }
 
     /// Create database and optionally drop existing tables if reset is true


### PR DESCRIPTION
## Summary
- use the passed database name in `ClickhouseClient::new`

## Testing
- `cargo fmt --all` *(fails: `rustfmt` not installed)*
- `cargo clippy --examples --tests --benches --all-features --locked` *(fails: `clippy` not installed)*
- `cargo test` *(fails: could not download dependencies)*