### PR TITLE
I've improved test coverage for the incident package.

### DIFF
--- a/crates/incident/src/base_monitor.rs
+++ b/crates/incident/src/base_monitor.rs
@@ -193,3 +193,442 @@ impl<K: Clone + Debug + Eq + std::hash::Hash> BaseMonitor<K> {
     /// Mark the monitor as unhealthy, dropping the healthy counter behavior.
     pub const fn mark_unhealthy(&mut self) {}
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::monitor::{ComponentStatus, IncidentState, NewIncident, ResolveIncident};
+    use async_trait::async_trait;
+    use chrono::Utc;
+    use clickhouse::ClickhouseClient as ActualClickhouseClient; // Renamed to avoid conflict
+    use mockall::mock;
+    use std::sync::Arc;
+    use tokio::sync::Mutex;
+    use uuid::Uuid; // Added for generating test incident IDs
+
+    // Mock for ClickhouseClient
+    mock! {
+        pub ClickhouseClient { // Matches the name used in BaseMonitor
+            fn new(url: &str) -> Self; // Assuming a new method, adjust if different
+            // Add other methods used by BaseMonitor if any, for now, keeping it simple
+        }
+    }
+
+    // Mock for IncidentClient
+    mock! {
+        pub Client { // Matches the name used in BaseMonitor (Client as IncidentClient)
+            fn new(server_url: &str, api_key: &str) -> Self; // Assuming a new method
+
+            async fn create_incident(&self, incident: &NewIncident) -> Result<String>;
+            async fn resolve_incident(&self, incident_id: &str, resolution: &ResolveIncident) -> Result<()>;
+            async fn open_incident(&self, component_id: &str) -> Result<Option<String>>;
+            // Add other methods if BaseMonitor starts using them
+        }
+    }
+
+    // Helper function to create a mock IncidentClient
+    fn mock_incident_client() -> Client {
+        MockClient::new()
+    }
+
+    // Helper function to create a mock ClickhouseClient
+    fn mock_clickhouse_client() -> ActualClickhouseClient {
+        // ActualClickhouseClient::new("dummy_url") // This might need adjustment based on actual ClickhouseClient constructor
+        // For now, if BaseMonitor only needs the type, we might not need to fully construct it,
+        // or use a simpler mock if direct construction is complex / has side effects.
+        // Using a default mock for now.
+        MockClickhouseClient::new("dummy_url").into() // into() might be needed if MockClickhouseClient doesn't directly return ActualClickhouseClient
+    }
+
+
+    #[test]
+    fn test_base_monitor_new() {
+        let mock_ch_client = mock_clickhouse_client();
+        let mock_incident_client = mock_incident_client();
+        let component_id = "test_component".to_string();
+        let interval = std::time::Duration::from_secs(60);
+
+        let monitor: BaseMonitor<u64> = BaseMonitor::new(
+            mock_ch_client,
+            mock_incident_client,
+            component_id.clone(),
+            interval,
+        );
+
+        assert_eq!(monitor.component_id, component_id);
+        assert_eq!(monitor.interval, interval);
+        assert!(monitor.active_incidents.is_empty());
+        // Cannot directly compare clients as they are mocks.
+        // We trust that they are stored if the other fields are correct.
+    }
+
+    #[test]
+    fn test_create_incident_payload() {
+        let mock_ch_client = mock_clickhouse_client();
+        let mock_incident_client = mock_incident_client();
+        let component_id = "payload_test_component".to_string();
+        let interval = std::time::Duration::from_secs(60);
+        let monitor: BaseMonitor<u64> = BaseMonitor::new(
+            mock_ch_client,
+            mock_incident_client,
+            component_id.clone(),
+            interval,
+        );
+
+        let name = "Test Incident".to_string();
+        let message = "This is a test incident message.".to_string();
+        let start_time = Utc::now();
+
+        let payload = monitor.create_incident_payload(name.clone(), message.clone(), start_time);
+
+        assert_eq!(payload.name, name);
+        assert_eq!(payload.message, message);
+        assert_eq!(payload.status, IncidentState::Investigating);
+        assert_eq!(payload.components, vec![component_id.clone()]);
+        assert_eq!(
+            payload.statuses,
+            vec![ComponentStatus::major_outage(&component_id)]
+        );
+        assert!(payload.notify);
+        assert_eq!(payload.started, Some(start_time.to_rfc3339()));
+    }
+
+    #[test]
+    fn test_create_resolve_payload() {
+        let mock_ch_client = mock_clickhouse_client();
+        let mock_incident_client = mock_incident_client();
+        let component_id = "resolve_payload_test_component".to_string();
+        let interval = std::time::Duration::from_secs(60);
+        let monitor: BaseMonitor<u64> = BaseMonitor::new(
+            mock_ch_client,
+            mock_incident_client,
+            component_id.clone(),
+            interval,
+        );
+
+        let payload = monitor.create_resolve_payload();
+
+        assert_eq!(payload.status, IncidentState::Resolved);
+        assert_eq!(payload.components, vec![component_id.clone()]);
+        assert_eq!(
+            payload.statuses,
+            vec![ComponentStatus::operational(&component_id)]
+        );
+        assert!(payload.notify);
+        assert!(payload.started.is_some()); // Check that a start time is set
+    }
+
+    #[tokio::test]
+    async fn test_create_incident_with_payload_success() {
+        let mock_ch_client = mock_clickhouse_client();
+        let mut mock_incident_client = mock_incident_client(); // Mutable to set expectations
+        let component_id = "create_with_payload_test".to_string();
+        let interval = std::time::Duration::from_secs(60);
+
+        let expected_incident_id = "incident_123".to_string();
+        let incident_name = "High CPU Usage".to_string();
+        let incident_message = "CPU usage is above 90%".to_string();
+        let start_time = Utc::now();
+
+        let payload = NewIncident {
+            name: incident_name.clone(),
+            message: incident_message.clone(),
+            status: IncidentState::Investigating,
+            components: vec![component_id.clone()],
+            statuses: vec![ComponentStatus::major_outage(&component_id)],
+            notify: true,
+            started: Some(start_time.to_rfc3339()),
+        };
+
+        // Expect create_incident to be called once with any NewIncident payload,
+        // and return the expected ID.
+        // We'll check the payload details if possible, or rely on the function's internal logic
+        // which we assume is correct if it passes the payload along.
+        let expected_id_clone = expected_incident_id.clone();
+        mock_incident_client
+            .expect_create_incident()
+            .withf(move |p: &NewIncident| {
+                p.name == incident_name && p.message == incident_message
+                // It's a bit tricky to compare the whole payload due to potential subtle differences
+                // like component_id clone, so we focus on key fields or trust BaseMonitor to construct it right.
+            })
+            .times(1)
+            .returning(move |_| Ok(expected_id_clone.clone()));
+
+        let monitor: BaseMonitor<u64> = BaseMonitor::new(
+            mock_ch_client,
+            mock_incident_client,
+            component_id.clone(),
+            interval,
+        );
+
+        let result = monitor.create_incident_with_payload(&payload).await;
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), expected_incident_id);
+    }
+
+    #[tokio::test]
+    async fn test_create_incident_with_payload_error() {
+        let mock_ch_client = mock_clickhouse_client();
+        let mut mock_incident_client = mock_incident_client();
+        let component_id = "create_error_test".to_string();
+        let interval = std::time::Duration::from_secs(60);
+
+        let incident_name = "Error Incident".to_string();
+        let incident_message = "This should fail".to_string();
+        let start_time = Utc::now();
+
+        let payload = NewIncident {
+            name: incident_name.clone(),
+            message: incident_message.clone(),
+            status: IncidentState::Investigating,
+            components: vec![component_id.clone()],
+            statuses: vec![ComponentStatus::major_outage(&component_id)],
+            notify: true,
+            started: Some(start_time.to_rfc3339()),
+        };
+
+        mock_incident_client
+            .expect_create_incident()
+            .times(1)
+            .returning(|_| Err(eyre::eyre!("Failed to create incident")));
+
+        let monitor: BaseMonitor<u64> = BaseMonitor::new(
+            mock_ch_client,
+            mock_incident_client,
+            component_id.clone(),
+            interval,
+        );
+
+        let result = monitor.create_incident_with_payload(&payload).await;
+
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_resolve_incident_with_payload_success() {
+        let mock_ch_client = mock_clickhouse_client();
+        let mut mock_incident_client = mock_incident_client();
+        let component_id = "resolve_with_payload_test".to_string();
+        let interval = std::time::Duration::from_secs(60);
+        let incident_id = "incident_to_resolve_123".to_string();
+
+        let payload = ResolveIncident {
+            status: IncidentState::Resolved,
+            components: vec![component_id.clone()],
+            statuses: vec![ComponentStatus::operational(&component_id)],
+            notify: true,
+            started: Some(Utc::now().to_rfc3339()), // Actual time doesn't matter much for mock
+        };
+
+        let id_clone = incident_id.clone();
+        mock_incident_client
+            .expect_resolve_incident()
+            .withf(move |id: &str, p: &ResolveIncident| {
+                id == id_clone && p.status == IncidentState::Resolved
+                // Similar to create_incident, detailed payload check can be tricky.
+                // Focusing on key fields.
+            })
+            .times(1)
+            .returning(|_, _| Ok(()));
+
+        let monitor: BaseMonitor<u64> = BaseMonitor::new(
+            mock_ch_client,
+            mock_incident_client,
+            component_id.clone(),
+            interval,
+        );
+
+        let result = monitor
+            .resolve_incident_with_payload(&incident_id, &payload)
+            .await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_resolve_incident_with_payload_error() {
+        let mock_ch_client = mock_clickhouse_client();
+        let mut mock_incident_client = mock_incident_client();
+        let component_id = "resolve_error_test".to_string();
+        let interval = std::time::Duration::from_secs(60);
+        let incident_id = "incident_to_fail_resolve_123".to_string();
+
+        let payload = ResolveIncident {
+            status: IncidentState::Resolved,
+            components: vec![component_id.clone()],
+            statuses: vec![ComponentStatus::operational(&component_id)],
+            notify: true,
+            started: Some(Utc::now().to_rfc3339()),
+        };
+
+        mock_incident_client
+            .expect_resolve_incident()
+            .times(1)
+            .returning(|_, _| Err(eyre::eyre!("Failed to resolve incident")));
+
+        let monitor: BaseMonitor<u64> = BaseMonitor::new(
+            mock_ch_client,
+            mock_incident_client,
+            component_id.clone(),
+            interval,
+        );
+
+        let result = monitor
+            .resolve_incident_with_payload(&incident_id, &payload)
+            .await;
+
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_check_existing_incidents_found() {
+        let mock_ch_client = mock_clickhouse_client();
+        let mut mock_incident_client = mock_incident_client();
+        let component_id = "check_existing_found_test".to_string();
+        let interval = std::time::Duration::from_secs(60);
+        let existing_incident_id = "existing_incident_456".to_string();
+        let default_key: u64 = 1;
+
+        let comp_id_clone = component_id.clone();
+        let existing_id_clone = existing_incident_id.clone();
+        mock_incident_client
+            .expect_open_incident()
+            .withf(move |id: &str| id == comp_id_clone)
+            .times(1)
+            .returning(move |_| Ok(Some(existing_id_clone.clone())));
+
+        let mut monitor: BaseMonitor<u64> = BaseMonitor::new(
+            mock_ch_client,
+            mock_incident_client,
+            component_id.clone(),
+            interval,
+        );
+
+        let result = monitor.check_existing_incidents(default_key).await;
+
+        assert!(result.is_ok());
+        assert_eq!(monitor.active_incidents.len(), 1);
+        assert_eq!(
+            monitor.active_incidents.get(&default_key),
+            Some(&existing_incident_id)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_check_existing_incidents_not_found() {
+        let mock_ch_client = mock_clickhouse_client();
+        let mut mock_incident_client = mock_incident_client();
+        let component_id = "check_existing_not_found_test".to_string();
+        let interval = std::time::Duration::from_secs(60);
+        let default_key: u64 = 1;
+
+        let comp_id_clone = component_id.clone();
+        mock_incident_client
+            .expect_open_incident()
+            .withf(move |id: &str| id == comp_id_clone)
+            .times(1)
+            .returning(|_| Ok(None));
+
+        let mut monitor: BaseMonitor<u64> = BaseMonitor::new(
+            mock_ch_client,
+            mock_incident_client,
+            component_id.clone(),
+            interval,
+        );
+
+        let result = monitor.check_existing_incidents(default_key).await;
+
+        assert!(result.is_ok());
+        assert!(monitor.active_incidents.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_mark_healthy_incident_exists() {
+        let mock_ch_client = mock_clickhouse_client();
+        let mut mock_incident_client = mock_incident_client();
+        let component_id = "mark_healthy_exists_test".to_string();
+        let interval = std::time::Duration::from_secs(60);
+        let incident_key: u64 = 1;
+        let incident_id = "active_incident_789".to_string();
+
+        // Expect resolve_incident to be called
+        let id_clone = incident_id.clone();
+        mock_incident_client
+            .expect_resolve_incident()
+            .withf(move |id: &str, p: &ResolveIncident| {
+                id == id_clone && p.status == IncidentState::Resolved // Basic check
+            })
+            .times(1)
+            .returning(|_, _| Ok(()));
+
+        let mut monitor: BaseMonitor<u64> = BaseMonitor::new(
+            mock_ch_client,
+            mock_incident_client,
+            component_id.clone(),
+            interval,
+        );
+
+        // Manually add an active incident
+        monitor
+            .active_incidents
+            .insert(incident_key, incident_id.clone());
+
+        let result = monitor.mark_healthy(&incident_key).await;
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), true); // Incident was resolved
+        assert!(monitor.active_incidents.is_empty()); // Incident removed
+    }
+
+    #[tokio::test]
+    async fn test_mark_healthy_no_incident() {
+        let mock_ch_client = mock_clickhouse_client();
+        let mut mock_incident_client = mock_incident_client(); // mut is not strictly needed here as no calls are expected
+        let component_id = "mark_healthy_none_test".to_string();
+        let interval = std::time::Duration::from_secs(60);
+        let incident_key: u64 = 1; // An arbitrary key
+
+        // No calls to resolve_incident are expected
+        mock_incident_client.expect_resolve_incident().never();
+
+        let mut monitor: BaseMonitor<u64> = BaseMonitor::new(
+            mock_ch_client,
+            mock_incident_client,
+            component_id.clone(),
+            interval,
+        );
+
+        // active_incidents is empty by default
+        let result = monitor.mark_healthy(&incident_key).await;
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), false); // No incident was resolved
+        assert!(monitor.active_incidents.is_empty()); // Still empty
+    }
+
+    #[test]
+    fn test_mark_unhealthy() {
+        let mock_ch_client = mock_clickhouse_client();
+        let mock_incident_client = mock_incident_client();
+        let component_id = "mark_unhealthy_test".to_string();
+        let interval = std::time::Duration::from_secs(60);
+
+        let mut monitor: BaseMonitor<u64> = BaseMonitor::new(
+            mock_ch_client,
+            mock_incident_client,
+            component_id.clone(),
+            interval,
+        );
+
+        // Call the function - the main test is that it doesn't panic
+        // and completes. Since it's a `const fn` with an empty body currently,
+        // there's no state change to assert.
+        monitor.mark_unhealthy();
+
+        // Optionally, assert that active_incidents is still empty,
+        // though mark_unhealthy is not expected to change it.
+        assert!(monitor.active_incidents.is_empty());
+    }
+}

--- a/crates/incident/src/monitor.rs
+++ b/crates/incident/src/monitor.rs
@@ -800,17 +800,1796 @@ impl Monitor for BatchVerifyTimeoutMonitor {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::client::Client as IncidentClient;
-    use clickhouse::ClickhouseClient as ClickhouseInternalClient;
-    use mockito::ServerGuard;
+    use crate::client::Client as ActualIncidentClient; // Renamed for clarity
+    use crate::base_monitor::BaseMonitor; // For instantiating InstatusL1Monitor
+    use clickhouse::ClickhouseClient as ActualClickhouseClient; // Renamed for clarity
+    use mockall::mock;
+    use mockito::ServerGuard; // Keep for existing tests if any, or remove if replacing all
     use std::time::Duration;
-    use url::Url;
+    use chrono::{DateTime, Utc, TimeZone};
+    use url::Url; // Keep for existing tests
+
+    // --- Mocks using mockall for InstatusL1Monitor unit tests ---
+    mock! {
+        pub ClickhouseClient { // Mock for the ClickhouseClient used by monitors
+            // Define methods of ActualClickhouseClient that InstatusL1Monitor uses:
+            // - get_last_batch_time() -> Result<Option<DateTime<Utc>>>
+            // - get_last_l2_head_time() -> Result<Option<DateTime<Utc>>>
+            // Add pub if methods are public in the actual client
+            pub async fn get_last_batch_time(&self) -> Result<Option<DateTime<Utc>>>;
+            pub async fn get_last_l2_head_time(&self) -> Result<Option<DateTime<Utc>>>;
+
+            // Methods used by BatchProofTimeoutMonitor and BatchVerifyTimeoutMonitor
+            pub async fn get_proved_batch_ids(&self) -> Result<Vec<u64>>;
+            pub async fn get_unproved_batches_older_than(&self, cutoff: DateTime<Utc>) -> Result<Vec<(u64, u64, DateTime<Utc>)>>; // l1_block_number, batch_id, posted_at
+            pub async fn get_verified_batch_ids(&self) -> Result<Vec<u64>>; // For BatchVerifyTimeoutMonitor later
+            pub async fn get_unverified_batches_older_than(&self, cutoff: DateTime<Utc>) -> Result<Vec<(u64, u64, DateTime<Utc>)>>; // For BatchVerifyTimeoutMonitor later
+
+
+            // Constructor mock, if needed for BaseMonitor::new
+            // pub fn new(url: &str, database: String, user: String, pass: String) -> Result<Self> where Self: Sized;
+        }
+    }
+
+    mock! {
+        pub IncidentClient { // Mock for the IncidentClient (aliased as Client)
+            // Define methods of ActualIncidentClient that BaseMonitor (used by InstatusL1Monitor) uses:
+            // - create_incident(payload: &NewIncident) -> Result<String>
+            // - resolve_incident(id: &str, payload: &ResolveIncident) -> Result<()>
+            // - open_incident(component_id: &str) -> Result<Option<String>>
+            pub async fn create_incident(&self, incident: &NewIncident) -> Result<String>;
+            pub async fn resolve_incident(&self, incident_id: &str, resolution: &ResolveIncident) -> Result<()>;
+            pub async fn open_incident(&self, component_id: &str) -> Result<Option<String>>;
+
+            // Constructor mock, if needed.
+            // pub fn new(api_key: String, page_id: String) -> Self where Self: Sized;
+            // pub fn with_base_url(api_key: String, page_id: String, base_url: Url) -> Self where Self: Sized;
+        }
+    }
+
+    // Helper to create InstatusL1Monitor with mock clients
+    fn instatus_l1_monitor_with_mocks(
+        mock_ch_client: MockClickhouseClient,
+        mock_incident_client: MockIncidentClient,
+        component_id: String,
+        threshold_seconds: u64,
+        interval_seconds: u64,
+    ) -> InstatusL1Monitor {
+        InstatusL1Monitor::new(
+            mock_ch_client.into(), // Convert mock to the actual type expected by BaseMonitor
+            mock_incident_client.into(),
+            component_id,
+            Duration::from_secs(threshold_seconds),
+            Duration::from_secs(interval_seconds),
+        )
+    }
+
+    // Helper to create BatchVerifyTimeoutMonitor with mock clients
+    fn batch_verify_timeout_monitor_with_mocks(
+        mock_ch_client: MockClickhouseClient,
+        mock_incident_client: MockIncidentClient,
+        component_id: String,
+        verify_timeout_hours: u64,
+        interval_seconds: u64,
+    ) -> BatchVerifyTimeoutMonitor {
+        BatchVerifyTimeoutMonitor::new(
+            mock_ch_client.into(),
+            mock_incident_client.into(),
+            component_id,
+            Duration::from_secs(verify_timeout_hours * 60 * 60),
+            Duration::from_secs(interval_seconds),
+        )
+    }
+
+    // Helper to create BatchProofTimeoutMonitor with mock clients
+    fn batch_proof_timeout_monitor_with_mocks(
+        mock_ch_client: MockClickhouseClient,
+        mock_incident_client: MockIncidentClient,
+        component_id: String,
+        proof_timeout_hours: u64,
+        interval_seconds: u64,
+    ) -> BatchProofTimeoutMonitor {
+        BatchProofTimeoutMonitor::new(
+            mock_ch_client.into(),
+            mock_incident_client.into(),
+            component_id,
+            Duration::from_secs(proof_timeout_hours * 60 * 60),
+            Duration::from_secs(interval_seconds),
+        )
+    }
+
+    // Helper to create InstatusMonitor with mock clients
+    fn instatus_monitor_with_mocks(
+        mock_ch_client: MockClickhouseClient,
+        mock_incident_client: MockIncidentClient,
+        component_id: String,
+        threshold_seconds: u64,
+        interval_seconds: u64,
+    ) -> InstatusMonitor {
+        InstatusMonitor::new(
+            mock_ch_client.into(),
+            mock_incident_client.into(),
+            component_id,
+            Duration::from_secs(threshold_seconds),
+            Duration::from_secs(interval_seconds),
+        )
+    }
+
+
+    // --- Existing mockito helpers (can be kept if other tests use them) ---
+
+    // --- Tests for InstatusL1Monitor ---
+
+    // Helper to create a DateTime<Utc> from seconds ago
+    fn time_secs_ago(secs: i64) -> DateTime<Utc> {
+        Utc::now() - ChronoDuration::seconds(secs)
+    }
+
+    #[tokio::test]
+    async fn test_handle_scenario1_no_incident_batch_unhealthy_l2_healthy_opens_incident() {
+        let mut mock_ch = MockClickhouseClient::new(); // Not used directly by handle, but BaseMonitor needs it
+        let mut mock_incident = MockIncidentClient::new();
+        let component_id = "l1_test_component".to_string();
+        let threshold_seconds = 60;
+        let interval_seconds = 30;
+        let expected_incident_id = "incident_opened_123".to_string();
+
+        // Expectations
+        let expected_id_clone = expected_incident_id.clone();
+        mock_incident.expect_create_incident()
+            .times(1)
+            .returning(move |_payload| Ok(expected_id_clone.clone()));
+        // get_last_batch_time and get_last_l2_head_time are not called by `handle` directly,
+        // but by check_batch_and_l2 which calls handle. For direct handle test, we pass times.
+
+        let mut monitor = instatus_l1_monitor_with_mocks(
+            mock_ch,
+            mock_incident,
+            component_id,
+            threshold_seconds,
+            interval_seconds,
+        );
+
+        assert!(monitor.base.active_incidents.is_empty(), "Should start with no active incidents");
+
+        let last_batch_time = time_secs_ago(threshold_seconds + 10); // Older than threshold -> unhealthy
+        let last_l2_time = time_secs_ago(threshold_seconds - 10);   // Younger than threshold -> healthy
+
+        let result = monitor.handle(last_batch_time, last_l2_time).await;
+
+        assert!(result.is_ok());
+        assert_eq!(monitor.base.active_incidents.len(), 1, "Incident should be opened");
+        assert_eq!(monitor.base.active_incidents.get(&()), Some(&expected_incident_id), "Correct incident ID should be stored");
+    }
+
+    #[tokio::test]
+    async fn test_handle_scenario2_active_incident_batch_unhealthy_remains_unhealthy() {
+        let mut mock_ch = MockClickhouseClient::new();
+        let mut mock_incident = MockIncidentClient::new();
+        let component_id = "l1_test_s2".to_string();
+        let threshold_seconds = 60;
+        let existing_incident_id = "incident_active_456".to_string();
+
+        // Expectations: No client calls to create or resolve
+        mock_incident.expect_create_incident().never();
+        mock_incident.expect_resolve_incident().never();
+
+        let mut monitor = instatus_l1_monitor_with_mocks(
+            mock_ch,
+            mock_incident,
+            component_id,
+            threshold_seconds,
+            30, // interval
+        );
+
+        // Setup active incident
+        monitor.base.active_incidents.insert((), existing_incident_id.clone());
+
+        // Batch unhealthy (age > threshold), L2 can be anything (e.g., also unhealthy for this case)
+        let last_batch_time = time_secs_ago(threshold_seconds + 20);
+        let last_l2_time = time_secs_ago(threshold_seconds + 5); // L2 also unhealthy
+
+        let result = monitor.handle(last_batch_time, last_l2_time).await;
+
+        assert!(result.is_ok());
+        assert_eq!(monitor.base.active_incidents.len(), 1, "Incident should remain active");
+        assert_eq!(monitor.base.active_incidents.get(&()), Some(&existing_incident_id), "Existing incident ID should still be stored");
+        // BaseMonitor::mark_unhealthy() is called, which is a no-op. We're verifying no other side effects.
+    }
+
+    #[tokio::test]
+    async fn test_handle_scenario3_active_incident_batch_healthy_resolves_incident() {
+        let mut mock_ch = MockClickhouseClient::new();
+        let mut mock_incident = MockIncidentClient::new();
+        let component_id = "l1_test_s3".to_string();
+        let threshold_seconds = 60;
+        let existing_incident_id = "incident_to_resolve_789".to_string();
+
+        // Expectations: resolve_incident should be called
+        mock_incident.expect_resolve_incident()
+            .withf(move |id, _payload| id == existing_incident_id)
+            .times(1)
+            .returning(|_, _| Ok(()));
+        mock_incident.expect_create_incident().never();
+
+
+        let mut monitor = instatus_l1_monitor_with_mocks(
+            mock_ch,
+            mock_incident,
+            component_id,
+            threshold_seconds,
+            30, // interval
+        );
+
+        // Setup active incident
+        monitor.base.active_incidents.insert((), existing_incident_id.clone());
+
+        // Batch healthy (age < threshold)
+        let last_batch_time = time_secs_ago(threshold_seconds - 10); // Younger than threshold
+        let last_l2_time = time_secs_ago(threshold_seconds - 20);   // L2 also healthy
+
+        let result = monitor.handle(last_batch_time, last_l2_time).await;
+
+        assert!(result.is_ok());
+        assert!(monitor.base.active_incidents.is_empty(), "Incident should be resolved and removed");
+    }
+
+    #[tokio::test]
+    async fn test_handle_scenario4_no_incident_both_healthy_no_action() {
+        let mut mock_ch = MockClickhouseClient::new();
+        let mut mock_incident = MockIncidentClient::new();
+        let component_id = "l1_test_s4".to_string();
+        let threshold_seconds = 60;
+
+        // Expectations: No client calls
+        mock_incident.expect_create_incident().never();
+        mock_incident.expect_resolve_incident().never();
+
+        let mut monitor = instatus_l1_monitor_with_mocks(
+            mock_ch,
+            mock_incident,
+            component_id,
+            threshold_seconds,
+            30, // interval
+        );
+
+        assert!(monitor.base.active_incidents.is_empty(), "Should start with no active incidents");
+
+        // Both batch and L2 healthy (age < threshold)
+        let last_batch_time = time_secs_ago(threshold_seconds - 30);
+        let last_l2_time = time_secs_ago(threshold_seconds - 25);
+
+        let result = monitor.handle(last_batch_time, last_l2_time).await;
+
+        assert!(result.is_ok());
+        assert!(monitor.base.active_incidents.is_empty(), "No incident should be opened");
+    }
+
+    #[tokio::test]
+    async fn test_handle_scenario5_no_incident_both_unhealthy_no_action() {
+        let mut mock_ch = MockClickhouseClient::new();
+        let mut mock_incident = MockIncidentClient::new();
+        let component_id = "l1_test_s5".to_string();
+        let threshold_seconds = 60;
+
+        // Expectations: No client calls
+        mock_incident.expect_create_incident().never();
+        mock_incident.expect_resolve_incident().never();
+
+        let mut monitor = instatus_l1_monitor_with_mocks(
+            mock_ch,
+            mock_incident,
+            component_id,
+            threshold_seconds,
+            30, // interval
+        );
+
+        assert!(monitor.base.active_incidents.is_empty(), "Should start with no active incidents");
+
+        // Both batch and L2 unhealthy (age > threshold)
+        let last_batch_time = time_secs_ago(threshold_seconds + 40);
+        let last_l2_time = time_secs_ago(threshold_seconds + 35);
+
+        let result = monitor.handle(last_batch_time, last_l2_time).await;
+
+        assert!(result.is_ok());
+        assert!(monitor.base.active_incidents.is_empty(), "No incident should be opened when L2 is also unhealthy");
+    }
+
+    #[tokio::test]
+    async fn test_initialize_no_existing_incident() {
+        let mut mock_ch = MockClickhouseClient::new();
+        let mut mock_incident = MockIncidentClient::new();
+        let component_id = "l1_init_test_no_existing".to_string();
+        let threshold_seconds = 60;
+
+        // Expect open_incident to be called by base.check_existing_incidents
+        let comp_id_clone = component_id.clone();
+        mock_incident.expect_open_incident()
+            .withf(move |id: &str| id == comp_id_clone) // BaseMonitor calls with its component_id
+            .times(1)
+            .returning(|_| Ok(None)); // No existing incident
+
+        // check_initial_health is called. If no active incidents, it does not query CH.
+        // So, no CH client calls are expected here.
+        mock_ch.expect_get_last_batch_time().never();
+        mock_ch.expect_get_last_l2_head_time().never();
+
+
+        let mut monitor = instatus_l1_monitor_with_mocks(
+            mock_ch,
+            mock_incident,
+            component_id,
+            threshold_seconds,
+            30, // interval
+        );
+
+        let result = monitor.initialize().await;
+        assert!(result.is_ok());
+        // Mockall automatically verifies that expectations were met (open_incident called once, CH calls never)
+    }
+
+    #[tokio::test]
+    async fn test_initialize_with_existing_incident_resolves_if_healthy() {
+        let mut mock_ch = MockClickhouseClient::new();
+        let mut mock_incident = MockIncidentClient::new();
+        let component_id = "l1_init_test_existing_resolves".to_string();
+        let threshold_seconds = 60;
+        let existing_incident_id = "existing_id_for_init_resolve".to_string();
+
+        // 1. base.check_existing_incidents finds an incident
+        let comp_id_clone1 = component_id.clone();
+        let existing_id_clone1 = existing_incident_id.clone();
+        mock_incident.expect_open_incident()
+            .withf(move |id: &str| id == comp_id_clone1)
+            .times(1)
+            .returning(move |_| Ok(Some(existing_id_clone1.clone())));
+
+        // 2. check_initial_health calls CH, gets healthy times
+        let healthy_batch_time = time_secs_ago(threshold_seconds - 10);
+        let healthy_l2_time = time_secs_ago(threshold_seconds - 15);
+        mock_ch.expect_get_last_batch_time()
+            .times(1)
+            .returning(move || Ok(Some(healthy_batch_time)));
+        mock_ch.expect_get_last_l2_head_time()
+            .times(1)
+            .returning(move || Ok(Some(healthy_l2_time)));
+
+        // 3. handle (called by check_initial_health) resolves the incident
+        let existing_id_clone2 = existing_incident_id.clone();
+        mock_incident.expect_resolve_incident()
+            .withf(move |id, _payload| id == existing_id_clone2)
+            .times(1)
+            .returning(|_, _| Ok(()));
+
+        let mut monitor = instatus_l1_monitor_with_mocks(
+            mock_ch,
+            mock_incident,
+            component_id,
+            threshold_seconds,
+            30, // interval
+        );
+
+        let result = monitor.initialize().await;
+        assert!(result.is_ok());
+        assert!(monitor.base.active_incidents.is_empty(), "Existing incident should be resolved and removed");
+    }
+
+    #[tokio::test]
+    async fn test_initialize_with_existing_incident_remains_if_unhealthy() {
+        let mut mock_ch = MockClickhouseClient::new();
+        let mut mock_incident = MockIncidentClient::new();
+        let component_id = "l1_init_test_existing_unhealthy".to_string();
+        let threshold_seconds = 60;
+        let existing_incident_id = "existing_id_for_init_unhealthy".to_string();
+
+        // 1. base.check_existing_incidents finds an incident
+        let comp_id_clone1 = component_id.clone();
+        let existing_id_clone1 = existing_incident_id.clone();
+        mock_incident.expect_open_incident()
+            .withf(move |id: &str| id == comp_id_clone1)
+            .times(1)
+            .returning(move |_| Ok(Some(existing_id_clone1.clone())));
+
+        // 2. check_initial_health calls CH, gets unhealthy times
+        let unhealthy_batch_time = time_secs_ago(threshold_seconds + 20); // Older than threshold
+        let unhealthy_l2_time = time_secs_ago(threshold_seconds + 25);   // Older than threshold
+        mock_ch.expect_get_last_batch_time()
+            .times(1)
+            .returning(move || Ok(Some(unhealthy_batch_time)));
+        mock_ch.expect_get_last_l2_head_time()
+            .times(1)
+            .returning(move || Ok(Some(unhealthy_l2_time)));
+
+        // 3. handle (called by check_initial_health) should not resolve. No create either.
+        mock_incident.expect_resolve_incident().never();
+        mock_incident.expect_create_incident().never();
+
+
+        let mut monitor = instatus_l1_monitor_with_mocks(
+            mock_ch,
+            mock_incident,
+            component_id,
+            threshold_seconds,
+            30, // interval
+        );
+
+        let result = monitor.initialize().await;
+        assert!(result.is_ok());
+        assert_eq!(monitor.base.active_incidents.len(), 1, "Incident should remain");
+        assert_eq!(monitor.base.active_incidents.get(&()), Some(&existing_incident_id), "Existing incident ID should still be stored");
+    }
+
+    #[tokio::test]
+    async fn test_check_initial_health_active_incident_resolves_if_healthy() {
+        let mut mock_ch = MockClickhouseClient::new();
+        let mut mock_incident = MockIncidentClient::new();
+        let component_id = "l1_check_initial_healthy_resolve".to_string();
+        let threshold_seconds = 60;
+        let existing_incident_id = "existing_id_for_check_initial_resolve".to_string();
+
+        // Pre-condition: An incident is already active
+        // (This would have been set by base.check_existing_incidents in a real initialize call)
+
+        // 1. check_initial_health calls CH, gets healthy times
+        let healthy_batch_time = time_secs_ago(threshold_seconds - 10);
+        let healthy_l2_time = time_secs_ago(threshold_seconds - 15);
+        mock_ch.expect_get_last_batch_time()
+            .times(1)
+            .returning(move || Ok(Some(healthy_batch_time)));
+        mock_ch.expect_get_last_l2_head_time()
+            .times(1)
+            .returning(move || Ok(Some(healthy_l2_time)));
+
+        // 2. handle (called by check_initial_health) resolves the incident
+        let existing_id_clone = existing_incident_id.clone();
+        mock_incident.expect_resolve_incident()
+            .withf(move |id, _payload| id == existing_id_clone)
+            .times(1)
+            .returning(|_, _| Ok(()));
+        mock_incident.expect_create_incident().never(); // No new incident should be created
+
+
+        let mut monitor = instatus_l1_monitor_with_mocks(
+            mock_ch,
+            mock_incident,
+            component_id,
+            threshold_seconds,
+            30, // interval
+        );
+        // Manually set active incident as check_existing_incidents is not called here
+        monitor.base.active_incidents.insert((), existing_incident_id.clone());
+
+
+        let result = monitor.check_initial_health().await;
+        assert!(result.is_ok());
+        assert!(monitor.base.active_incidents.is_empty(), "Existing incident should be resolved and removed by check_initial_health via handle");
+    }
+
+    #[tokio::test]
+    async fn test_check_initial_health_active_incident_remains_if_unhealthy() {
+        let mut mock_ch = MockClickhouseClient::new();
+        let mut mock_incident = MockIncidentClient::new();
+        let component_id = "l1_check_initial_unhealthy_remain".to_string();
+        let threshold_seconds = 60;
+        let existing_incident_id = "existing_id_for_check_initial_unhealthy".to_string();
+
+        // 1. check_initial_health calls CH, gets unhealthy times
+        let unhealthy_batch_time = time_secs_ago(threshold_seconds + 20);
+        let unhealthy_l2_time = time_secs_ago(threshold_seconds + 25);
+        mock_ch.expect_get_last_batch_time()
+            .times(1)
+            .returning(move || Ok(Some(unhealthy_batch_time)));
+        mock_ch.expect_get_last_l2_head_time()
+            .times(1)
+            .returning(move || Ok(Some(unhealthy_l2_time)));
+
+        // 2. handle (called by check_initial_health) should not resolve or create.
+        mock_incident.expect_resolve_incident().never();
+        mock_incident.expect_create_incident().never();
+
+
+        let mut monitor = instatus_l1_monitor_with_mocks(
+            mock_ch,
+            mock_incident,
+            component_id,
+            threshold_seconds,
+            30, // interval
+        );
+        monitor.base.active_incidents.insert((), existing_incident_id.clone());
+
+
+        let result = monitor.check_initial_health().await;
+        assert!(result.is_ok());
+        assert_eq!(monitor.base.active_incidents.len(), 1, "Incident should remain active");
+        assert_eq!(monitor.base.active_incidents.get(&()), Some(&existing_incident_id), "Correct incident ID should still be stored");
+    }
+
+    // --- Tests for Monitor trait methods on InstatusL1Monitor ---
+
+    #[tokio::test]
+    async fn test_instatus_l1_monitor_create_incident() {
+        let mut mock_ch = MockClickhouseClient::new();
+        let mut mock_incident_client = MockIncidentClient::new();
+        let component_id = "l1_trait_create_test".to_string();
+        let threshold_seconds = 60;
+        let expected_incident_id = "trait_created_incident_1".to_string();
+
+        let expected_id_clone = expected_incident_id.clone();
+        mock_incident_client.expect_create_incident()
+            .withf(move |p: &NewIncident| {
+                p.name == "No BatchProposed events - Possible Outage" &&
+                p.message.contains(&format!("No batch event for {}s", threshold_seconds))
+            })
+            .times(1)
+            .returning(move |_| Ok(expected_id_clone.clone()));
+
+        let monitor = instatus_l1_monitor_with_mocks(
+            mock_ch,
+            mock_incident_client,
+            component_id,
+            threshold_seconds,
+            30, // interval
+        );
+
+        // The key for InstatusL1Monitor is ()
+        let result = monitor.create_incident(&()).await;
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), expected_incident_id);
+        // Note: create_incident on the trait doesn't add to monitor.base.active_incidents itself.
+        // That's typically done by the calling logic (e.g., in handle).
+    }
+
+    #[tokio::test]
+    async fn test_instatus_l1_monitor_resolve_incident() {
+        let mut mock_ch = MockClickhouseClient::new();
+        let mut mock_incident_client = MockIncidentClient::new();
+        let component_id = "l1_trait_resolve_test".to_string();
+        let incident_id_to_resolve = "trait_resolving_incident_2".to_string();
+
+        let id_clone = incident_id_to_resolve.clone();
+        mock_incident_client.expect_resolve_incident()
+            .withf(move |id: &str, p: &ResolveIncident| {
+                id == id_clone && p.status == IncidentState::Resolved
+            })
+            .times(1)
+            .returning(|_, _| Ok(()));
+
+        let monitor = instatus_l1_monitor_with_mocks(
+            mock_ch,
+            mock_incident_client,
+            component_id,
+            60, // threshold
+            30, // interval
+        );
+
+        let result = monitor.resolve_incident(&incident_id_to_resolve).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_instatus_l1_monitor_check_health_opens_incident_on_unhealthy() {
+        let mut mock_ch = MockClickhouseClient::new();
+        let mut mock_incident_client = MockIncidentClient::new();
+        let component_id = "l1_trait_check_health_open".to_string();
+        let threshold_seconds = 60;
+        let expected_incident_id = "check_health_opened_3".to_string();
+
+        // 1. CH returns batch unhealthy, L2 healthy
+        let unhealthy_batch_time = time_secs_ago(threshold_seconds + 30);
+        let healthy_l2_time = time_secs_ago(threshold_seconds - 30);
+        mock_ch.expect_get_last_batch_time()
+            .times(1)
+            .returning(move || Ok(Some(unhealthy_batch_time)));
+        mock_ch.expect_get_last_l2_head_time()
+            .times(1)
+            .returning(move || Ok(Some(healthy_l2_time)));
+
+        // 2. Handle (called by check_batch_and_l2) should open an incident
+        let expected_id_clone = expected_incident_id.clone();
+        mock_incident_client.expect_create_incident()
+            .times(1)
+            .returning(move |_| Ok(expected_id_clone.clone()));
+
+
+        let mut monitor = instatus_l1_monitor_with_mocks(
+            mock_ch,
+            mock_incident_client,
+            component_id,
+            threshold_seconds,
+            30, // interval
+        );
+
+        let result = monitor.check_health().await;
+        assert!(result.is_ok());
+        assert_eq!(monitor.base.active_incidents.len(), 1, "Incident should be opened by check_health");
+        assert_eq!(monitor.base.active_incidents.get(&()), Some(&expected_incident_id));
+    }
+
+    // --- Tests for InstatusMonitor ---
+
+    #[tokio::test]
+    async fn test_instatusmonitor_handle_scenario1_no_incident_l2_unhealthy_opens_incident() {
+        let mut mock_ch = MockClickhouseClient::new(); // Not used by InstatusMonitor::handle directly
+        let mut mock_incident = MockIncidentClient::new();
+        let component_id = "instatus_test_component".to_string();
+        let threshold_seconds = 120; // e.g., 2 minutes
+        let expected_incident_id = "incident_l2_down_1".to_string();
+
+        // Expectations for IncidentClient: create_incident should be called
+        let expected_id_clone = expected_incident_id.clone();
+        mock_incident.expect_create_incident()
+            .withf(move |p: &NewIncident| {
+                p.name == "No L2 head events - Possible Outage" &&
+                p.message.contains(&format!("No L2 head event for {}s", threshold_seconds))
+            })
+            .times(1)
+            .returning(move |_| Ok(expected_id_clone.clone()));
+
+        let mut monitor = instatus_monitor_with_mocks(
+            mock_ch,
+            mock_incident,
+            component_id,
+            threshold_seconds,
+            30, // interval
+        );
+
+        assert!(monitor.base.active_incidents.is_empty(), "Should start with no active incidents");
+
+        // L2 event delayed (unhealthy)
+        let last_l2_time = time_secs_ago(threshold_seconds + 30); // 30s older than threshold
+
+        let result = monitor.handle(last_l2_time).await;
+
+        assert!(result.is_ok());
+        assert_eq!(monitor.base.active_incidents.len(), 1, "Incident should be opened");
+        assert_eq!(monitor.base.active_incidents.get(&()), Some(&expected_incident_id), "Correct incident ID should be stored");
+    }
+
+    #[tokio::test]
+    async fn test_instatusmonitor_handle_scenario2_active_incident_l2_unhealthy_remains_unhealthy() {
+        let mut mock_ch = MockClickhouseClient::new();
+        let mut mock_incident = MockIncidentClient::new();
+        let component_id = "instatus_test_s2".to_string();
+        let threshold_seconds = 120;
+        let existing_incident_id = "incident_l2_still_down_2".to_string();
+
+        // Expectations: No client calls to create or resolve
+        mock_incident.expect_create_incident().never();
+        mock_incident.expect_resolve_incident().never();
+
+        let mut monitor = instatus_monitor_with_mocks(
+            mock_ch,
+            mock_incident,
+            component_id,
+            threshold_seconds,
+            30, // interval
+        );
+
+        // Setup active incident
+        monitor.base.active_incidents.insert((), existing_incident_id.clone());
+
+        // L2 event still delayed (unhealthy)
+        let last_l2_time = time_secs_ago(threshold_seconds + 45); // 45s older than threshold
+
+        let result = monitor.handle(last_l2_time).await;
+
+        assert!(result.is_ok());
+        assert_eq!(monitor.base.active_incidents.len(), 1, "Incident should remain active");
+        assert_eq!(monitor.base.active_incidents.get(&()), Some(&existing_incident_id), "Existing incident ID should still be stored");
+        // BaseMonitor::mark_unhealthy() is called, which is a no-op. We're verifying no other side effects.
+    }
+
+    #[tokio::test]
+    async fn test_instatusmonitor_handle_scenario3_active_incident_l2_healthy_resolves_incident() {
+        let mut mock_ch = MockClickhouseClient::new();
+        let mut mock_incident = MockIncidentClient::new();
+        let component_id = "instatus_test_s3".to_string();
+        let threshold_seconds = 120;
+        let existing_incident_id = "incident_l2_recovers_3".to_string();
+
+        // Expectations: resolve_incident should be called
+        mock_incident.expect_resolve_incident()
+            .withf(move |id, _payload| id == existing_incident_id)
+            .times(1)
+            .returning(|_, _| Ok(()));
+        mock_incident.expect_create_incident().never(); // No new incident
+
+        let mut monitor = instatus_monitor_with_mocks(
+            mock_ch,
+            mock_incident,
+            component_id,
+            threshold_seconds,
+            30, // interval
+        );
+
+        // Setup active incident
+        monitor.base.active_incidents.insert((), existing_incident_id.clone());
+
+        // L2 event now recent (healthy)
+        let last_l2_time = time_secs_ago(threshold_seconds - 60); // 60s younger than threshold
+
+        let result = monitor.handle(last_l2_time).await;
+
+        assert!(result.is_ok());
+        assert!(monitor.base.active_incidents.is_empty(), "Incident should be resolved and removed");
+    }
+
+    #[tokio::test]
+    async fn test_instatusmonitor_handle_scenario4_no_incident_l2_healthy_no_action() {
+        let mut mock_ch = MockClickhouseClient::new();
+        let mut mock_incident = MockIncidentClient::new();
+        let component_id = "instatus_test_s4".to_string();
+        let threshold_seconds = 120;
+
+        // Expectations: No client calls
+        mock_incident.expect_create_incident().never();
+        mock_incident.expect_resolve_incident().never();
+
+        let mut monitor = instatus_monitor_with_mocks(
+            mock_ch,
+            mock_incident,
+            component_id,
+            threshold_seconds,
+            30, // interval
+        );
+
+        assert!(monitor.base.active_incidents.is_empty(), "Should start with no active incidents");
+
+        // L2 event recent (healthy)
+        let last_l2_time = time_secs_ago(threshold_seconds - 90); // 90s younger than threshold
+
+        let result = monitor.handle(last_l2_time).await;
+
+        assert!(result.is_ok());
+        assert!(monitor.base.active_incidents.is_empty(), "No incident should be opened");
+    }
+
+    #[tokio::test]
+    async fn test_instatusmonitor_initialize_no_existing_incident() {
+        let mut mock_ch = MockClickhouseClient::new();
+        let mut mock_incident = MockIncidentClient::new();
+        let component_id = "instatus_init_no_existing".to_string();
+        let threshold_seconds = 120;
+
+        // Expect open_incident from base.check_existing_incidents
+        let comp_id_clone = component_id.clone();
+        mock_incident.expect_open_incident()
+            .withf(move |id: &str| id == comp_id_clone)
+            .times(1)
+            .returning(|_| Ok(None)); // No existing incident
+
+        // InstatusMonitor::check_initial_health, if no active_incidents, does nothing.
+        mock_ch.expect_get_last_l2_head_time().never();
+
+        let mut monitor = instatus_monitor_with_mocks(
+            mock_ch,
+            mock_incident,
+            component_id,
+            threshold_seconds,
+            30, // interval
+        );
+
+        let result = monitor.initialize().await;
+        assert!(result.is_ok());
+        // mockall verifies expectations automatically
+    }
+
+    #[tokio::test]
+    async fn test_instatusmonitor_initialize_existing_incident_resolves_if_healthy() {
+        let mut mock_ch = MockClickhouseClient::new();
+        let mut mock_incident = MockIncidentClient::new();
+        let component_id = "instatus_init_existing_healthy".to_string();
+        let threshold_seconds = 120;
+        let existing_incident_id = "existing_l2_incident_resolve".to_string();
+
+        // 1. base.check_existing_incidents finds an incident
+        let comp_id_clone = component_id.clone();
+        let existing_id_clone1 = existing_incident_id.clone();
+        mock_incident.expect_open_incident()
+            .withf(move |id: &str| id == comp_id_clone)
+            .times(1)
+            .returning(move |_| Ok(Some(existing_id_clone1.clone())));
+
+        // 2. check_initial_health calls CH, gets healthy L2 time
+        let healthy_l2_time = time_secs_ago(threshold_seconds - 30); // Younger than threshold
+        mock_ch.expect_get_last_l2_head_time()
+            .times(1)
+            .returning(move || Ok(Some(healthy_l2_time)));
+
+        // 3. handle (called by check_initial_health) resolves the incident
+        let existing_id_clone2 = existing_incident_id.clone();
+        mock_incident.expect_resolve_incident()
+            .withf(move |id, _payload| id == existing_id_clone2)
+            .times(1)
+            .returning(|_, _| Ok(()));
+        mock_incident.expect_create_incident().never();
+
+
+        let mut monitor = instatus_monitor_with_mocks(
+            mock_ch,
+            mock_incident,
+            component_id,
+            threshold_seconds,
+            30, // interval
+        );
+
+        let result = monitor.initialize().await;
+        assert!(result.is_ok());
+        assert!(monitor.base.active_incidents.is_empty(), "Existing incident should be resolved");
+    }
+
+    #[tokio::test]
+    async fn test_instatusmonitor_initialize_existing_incident_remains_if_unhealthy() {
+        let mut mock_ch = MockClickhouseClient::new();
+        let mut mock_incident = MockIncidentClient::new();
+        let component_id = "instatus_init_existing_unhealthy".to_string();
+        let threshold_seconds = 120;
+        let existing_incident_id = "existing_l2_incident_unhealthy".to_string();
+
+        // 1. base.check_existing_incidents finds an incident
+        let comp_id_clone = component_id.clone();
+        let existing_id_clone1 = existing_incident_id.clone();
+        mock_incident.expect_open_incident()
+            .withf(move |id: &str| id == comp_id_clone)
+            .times(1)
+            .returning(move |_| Ok(Some(existing_id_clone1.clone())));
+
+        // 2. check_initial_health calls CH, gets unhealthy L2 time
+        let unhealthy_l2_time = time_secs_ago(threshold_seconds + 60); // Older than threshold
+        mock_ch.expect_get_last_l2_head_time()
+            .times(1)
+            .returning(move || Ok(Some(unhealthy_l2_time)));
+
+        // 3. handle (called by check_initial_health) should not resolve or create
+        mock_incident.expect_resolve_incident().never();
+        mock_incident.expect_create_incident().never();
+
+
+        let mut monitor = instatus_monitor_with_mocks(
+            mock_ch,
+            mock_incident,
+            component_id,
+            threshold_seconds,
+            30, // interval
+        );
+
+        let result = monitor.initialize().await;
+        assert!(result.is_ok());
+        assert_eq!(monitor.base.active_incidents.len(), 1, "Incident should remain");
+        assert_eq!(monitor.base.active_incidents.get(&()), Some(&existing_incident_id));
+    }
+
+    #[tokio::test]
+    async fn test_instatusmonitor_check_initial_health_active_incident_resolves_if_healthy() {
+        let mut mock_ch = MockClickhouseClient::new();
+        let mut mock_incident = MockIncidentClient::new();
+        let component_id = "instatus_check_init_healthy_resolve".to_string();
+        let threshold_seconds = 120;
+        let existing_incident_id = "existing_l2_for_check_init_resolve".to_string();
+
+        // 1. check_initial_health calls CH, gets healthy L2 time
+        let healthy_l2_time = time_secs_ago(threshold_seconds - 45); // Younger than threshold
+        mock_ch.expect_get_last_l2_head_time()
+            .times(1)
+            .returning(move || Ok(Some(healthy_l2_time)));
+
+        // 2. handle (called by check_initial_health) resolves the incident
+        let existing_id_clone = existing_incident_id.clone();
+        mock_incident.expect_resolve_incident()
+            .withf(move |id, _payload| id == existing_id_clone)
+            .times(1)
+            .returning(|_, _| Ok(()));
+        mock_incident.expect_create_incident().never();
+
+
+        let mut monitor = instatus_monitor_with_mocks(
+            mock_ch,
+            mock_incident,
+            component_id,
+            threshold_seconds,
+            30, // interval
+        );
+        // Manually set active incident
+        monitor.base.active_incidents.insert((), existing_incident_id.clone());
+
+        let result = monitor.check_initial_health().await;
+        assert!(result.is_ok());
+        assert!(monitor.base.active_incidents.is_empty(), "Existing incident should be resolved by check_initial_health");
+    }
+
+    #[tokio::test]
+    async fn test_instatusmonitor_check_initial_health_active_incident_remains_if_unhealthy() {
+        let mut mock_ch = MockClickhouseClient::new();
+        let mut mock_incident = MockIncidentClient::new();
+        let component_id = "instatus_check_init_unhealthy_remain".to_string();
+        let threshold_seconds = 120;
+        let existing_incident_id = "existing_l2_for_check_init_unhealthy".to_string();
+
+        // 1. check_initial_health calls CH, gets unhealthy L2 time
+        let unhealthy_l2_time = time_secs_ago(threshold_seconds + 75); // Older than threshold
+        mock_ch.expect_get_last_l2_head_time()
+            .times(1)
+            .returning(move || Ok(Some(unhealthy_l2_time)));
+
+        // 2. handle (called by check_initial_health) should not resolve or create
+        mock_incident.expect_resolve_incident().never();
+        mock_incident.expect_create_incident().never();
+
+
+        let mut monitor = instatus_monitor_with_mocks(
+            mock_ch,
+            mock_incident,
+            component_id,
+            threshold_seconds,
+            30, // interval
+        );
+        monitor.base.active_incidents.insert((), existing_incident_id.clone());
+
+        let result = monitor.check_initial_health().await;
+        assert!(result.is_ok());
+        assert_eq!(monitor.base.active_incidents.len(), 1, "Incident should remain");
+        assert_eq!(monitor.base.active_incidents.get(&()), Some(&existing_incident_id));
+    }
+
+    // --- Tests for Monitor trait methods on InstatusMonitor ---
+
+    #[tokio::test]
+    async fn test_instatusmonitor_trait_create_incident() {
+        let mut mock_ch = MockClickhouseClient::new();
+        let mut mock_incident_client = MockIncidentClient::new();
+        let component_id = "instatus_trait_create_test".to_string();
+        let threshold_seconds = 120; // Matches InstatusMonitor's threshold use in open()
+        let expected_incident_id = "trait_l2_created_incident_1".to_string();
+
+        let expected_id_clone = expected_incident_id.clone();
+        mock_incident_client.expect_create_incident()
+            .withf(move |p: &NewIncident| {
+                p.name == "No L2 head events - Possible Outage" &&
+                p.message.contains(&format!("No L2 head event for {}s", threshold_seconds))
+            })
+            .times(1)
+            .returning(move |_| Ok(expected_id_clone.clone()));
+
+        let monitor = instatus_monitor_with_mocks(
+            mock_ch,
+            mock_incident_client,
+            component_id,
+            threshold_seconds,
+            30, // interval
+        );
+
+        // The key for InstatusMonitor is ()
+        let result = monitor.create_incident(&()).await;
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), expected_incident_id);
+    }
+
+    #[tokio::test]
+    async fn test_instatusmonitor_trait_resolve_incident() {
+        let mut mock_ch = MockClickhouseClient::new();
+        let mut mock_incident_client = MockIncidentClient::new();
+        let component_id = "instatus_trait_resolve_test".to_string();
+        let incident_id_to_resolve = "trait_l2_resolving_incident_2".to_string();
+
+        let id_clone = incident_id_to_resolve.clone();
+        mock_incident_client.expect_resolve_incident()
+            .withf(move |id: &str, p: &ResolveIncident| {
+                id == id_clone && p.status == IncidentState::Resolved
+            })
+            .times(1)
+            .returning(|_, _| Ok(()));
+
+        let monitor = instatus_monitor_with_mocks(
+            mock_ch,
+            mock_incident_client,
+            component_id,
+            120, // threshold
+            30, // interval
+        );
+
+        let result = monitor.resolve_incident(&incident_id_to_resolve).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_instatusmonitor_trait_check_health_opens_incident_on_unhealthy() {
+        let mut mock_ch = MockClickhouseClient::new();
+        let mut mock_incident_client = MockIncidentClient::new();
+        let component_id = "instatus_trait_check_health_open".to_string();
+        let threshold_seconds = 120;
+        let expected_incident_id = "check_health_l2_opened_3".to_string();
+
+        // 1. CH returns L2 head time as unhealthy
+        let unhealthy_l2_time = time_secs_ago(threshold_seconds + 60); // Older than threshold
+        mock_ch.expect_get_last_l2_head_time()
+            .times(1)
+            .returning(move || Ok(Some(unhealthy_l2_time)));
+
+        // 2. Handle (called by check_l2_head) should open an incident
+        let expected_id_clone = expected_incident_id.clone();
+        mock_incident_client.expect_create_incident()
+             .withf(move |p: &NewIncident| { // Verify payload details specific to InstatusMonitor::open
+                p.name == "No L2 head events - Possible Outage" &&
+                p.message.contains(&format!("No L2 head event for {}s", threshold_seconds))
+            })
+            .times(1)
+            .returning(move |_| Ok(expected_id_clone.clone()));
+
+
+        let mut monitor = instatus_monitor_with_mocks(
+            mock_ch,
+            mock_incident_client,
+            component_id,
+            threshold_seconds,
+            30, // interval
+        );
+
+        let result = monitor.check_health().await; // This calls check_l2_head -> handle
+        assert!(result.is_ok());
+        assert_eq!(monitor.base.active_incidents.len(), 1, "Incident should be opened by check_health");
+        assert_eq!(monitor.base.active_incidents.get(&()), Some(&expected_incident_id));
+    }
+
+    // --- Tests for BatchProofTimeoutMonitor ---
+
+    #[tokio::test]
+    async fn test_check_unproven_batches_scenario1_new_overdue_batches_open_incidents() {
+        let mut mock_ch = MockClickhouseClient::new();
+        let mut mock_incident = MockIncidentClient::new();
+        let component_id = "proof_timeout_s1".to_string();
+        let proof_timeout_hours = 3;
+        let proof_timeout_duration = Duration::from_secs(proof_timeout_hours * 60 * 60);
+
+        let now = Utc::now();
+        let overdue_batch_1_posted_at = now - ChronoDuration::from_std(proof_timeout_duration).unwrap() - ChronoDuration::hours(1);
+        let overdue_batch_2_posted_at = now - ChronoDuration::from_std(proof_timeout_duration).unwrap() - ChronoDuration::hours(2);
+
+        let unproven_batches_from_ch = vec![
+            (1001u64, 1u64, overdue_batch_1_posted_at), // (l1_block_number, batch_id, posted_at)
+            (1002u64, 2u64, overdue_batch_2_posted_at),
+        ];
+
+        // CH: get_unproved_batches_older_than returns two overdue batches
+        let batches_clone = unproven_batches_from_ch.clone();
+        mock_ch.expect_get_unproved_batches_older_than()
+            .times(1)
+            // .withf(move |cutoff| { (*cutoff < overdue_batch_1_posted_at) && (*cutoff < overdue_batch_2_posted_at)}) // Ensure cutoff is correctly calculated
+            .returning(move |_cutoff| Ok(batches_clone.clone()));
+
+        // CH: get_proved_batch_ids (called for each active incident, none initially, then for the two new ones if they were added and checked in same run)
+        // For this scenario, assume no pre-existing active incidents.
+        // If check_unproven_batches re-checks status of newly created incidents in the same run,
+        // then we need to account for those calls. The current code iterates a snapshot.
+        // For simplicity here, assume it won't immediately re-check proof status of just-created incidents.
+        // If it does, then proved_batch_ids might be called for batch 1 and 2.
+        // The current code does: 1. get unproven. 2. create for new. 3. iterate active. 4. check proof for active.
+        // So, it *will* call get_proved_batch_ids for the newly created ones.
+        mock_ch.expect_get_proved_batch_ids()
+            .times(1) // It's called once with a list of active incidents.
+            .returning(|| Ok(vec![])); // Assume they are not yet proven
+
+        // IncidentClient: create_incident should be called for each new overdue batch
+        mock_incident.expect_create_incident()
+            .withf(move |p: &NewIncident| p.message.contains("Batch #1 has been waiting for proof"))
+            .times(1)
+            .returning(|_p| Ok("incident_id_1".to_string()));
+        mock_incident.expect_create_incident()
+            .withf(move |p: &NewIncident| p.message.contains("Batch #2 has been waiting for proof"))
+            .times(1)
+            .returning(|_p| Ok("incident_id_2".to_string()));
+
+
+        let mut monitor = batch_proof_timeout_monitor_with_mocks(
+            mock_ch,
+            mock_incident,
+            component_id,
+            proof_timeout_hours,
+            60, // interval
+        );
+
+        let result = monitor.check_unproven_batches().await;
+        assert!(result.is_ok());
+        assert_eq!(monitor.base.active_incidents.len(), 2, "Two incidents should be active");
+        assert!(monitor.base.active_incidents.contains_key(&(1001, 1)));
+        assert!(monitor.base.active_incidents.contains_key(&(1002, 2)));
+    }
+
+    #[tokio::test]
+    async fn test_check_unproven_batches_scenario2_active_incidents_some_proven_resolve() {
+        let mut mock_ch = MockClickhouseClient::new();
+        let mut mock_incident = MockIncidentClient::new();
+        let component_id = "proof_timeout_s2".to_string();
+        let proof_timeout_hours = 3;
+
+        let active_incident_key_1 = (2001u64, 10u64); // (l1_block_number, batch_id) - Proven
+        let active_incident_id_1 = "incident_id_10_proven".to_string();
+        let active_incident_key_2 = (2002u64, 20u64); // Still unproven
+        let active_incident_id_2 = "incident_id_20_unproven".to_string();
+
+        // CH: get_unproved_batches_older_than returns no new overdue batches
+        mock_ch.expect_get_unproved_batches_older_than()
+            .times(1)
+            .returning(|_cutoff| Ok(vec![]));
+
+        // CH: get_proved_batch_ids returns that batch 10 is proven
+        mock_ch.expect_get_proved_batch_ids()
+            .times(1)
+            .returning(|| Ok(vec![10u64])); // Batch 10 is proven
+
+        // IncidentClient: resolve_incident should be called for batch 10
+        let id_1_clone = active_incident_id_1.clone();
+        mock_incident.expect_resolve_incident()
+            .withf(move |id, _payload| id == id_1_clone)
+            .times(1)
+            .returning(|_, _| Ok(()));
+        // No call to create_incident
+        mock_incident.expect_create_incident().never();
+
+
+        let mut monitor = batch_proof_timeout_monitor_with_mocks(
+            mock_ch,
+            mock_incident,
+            component_id,
+            proof_timeout_hours,
+            60, // interval
+        );
+
+        // Setup active incidents
+        monitor.base.active_incidents.insert(active_incident_key_1, active_incident_id_1.clone());
+        monitor.base.active_incidents.insert(active_incident_key_2, active_incident_id_2.clone());
+
+        let result = monitor.check_unproven_batches().await;
+        assert!(result.is_ok());
+
+        assert_eq!(monitor.base.active_incidents.len(), 1, "One incident should remain active");
+        assert!(!monitor.base.active_incidents.contains_key(&active_incident_key_1), "Proven incident should be removed");
+        assert!(monitor.base.active_incidents.contains_key(&active_incident_key_2), "Unproven incident should remain");
+        assert_eq!(monitor.base.active_incidents.get(&active_incident_key_2), Some(&active_incident_id_2));
+    }
+
+    #[tokio::test]
+    async fn test_check_unproven_batches_scenario3_new_and_existing_overdue_batches() {
+        let mut mock_ch = MockClickhouseClient::new();
+        let mut mock_incident = MockIncidentClient::new();
+        let component_id = "proof_timeout_s3".to_string();
+        let proof_timeout_hours = 3;
+        let proof_timeout_duration = Duration::from_secs(proof_timeout_hours * 60 * 60);
+
+        let now = Utc::now();
+        // Batch 30: Overdue, already has an active incident
+        let batch_30_posted_at = now - ChronoDuration::from_std(proof_timeout_duration).unwrap() - ChronoDuration::hours(1);
+        let existing_incident_key_30 = (3001u64, 30u64);
+        let existing_incident_id_30 = "incident_id_30_existing".to_string();
+
+        // Batch 40: Overdue, new, should trigger incident creation
+        let batch_40_posted_at = now - ChronoDuration::from_std(proof_timeout_duration).unwrap() - ChronoDuration::hours(2);
+
+        let unproven_batches_from_ch = vec![
+            (existing_incident_key_30.0, existing_incident_key_30.1, batch_30_posted_at),
+            (4001u64, 40u64, batch_40_posted_at),
+        ];
+
+        // CH: get_unproved_batches_older_than returns these two
+        let batches_clone = unproven_batches_from_ch.clone();
+        mock_ch.expect_get_unproved_batches_older_than()
+            .times(1)
+            .returning(move |_| Ok(batches_clone.clone()));
+
+        // CH: get_proved_batch_ids for active incidents (batch 30 and newly created 40)
+        // Assume neither are proven yet for this scenario.
+        mock_ch.expect_get_proved_batch_ids()
+            .times(1)
+            .returning(|| Ok(vec![])); // Neither 30 nor 40 are proven
+
+        // IncidentClient: create_incident should be called only for batch 40
+        mock_incident.expect_create_incident()
+            .withf(move |p: &NewIncident| p.message.contains("Batch #40 has been waiting for proof"))
+            .times(1)
+            .returning(|_p| Ok("incident_id_40_new".to_string()));
+        // No create_incident for batch 30 (already active)
+        mock_incident.expect_create_incident()
+            .withf(move |p: &NewIncident| p.message.contains("Batch #30"))
+            .never();
+        // No resolve_incident calls
+        mock_incident.expect_resolve_incident().never();
+
+
+        let mut monitor = batch_proof_timeout_monitor_with_mocks(
+            mock_ch,
+            mock_incident,
+            component_id,
+            proof_timeout_hours,
+            60, // interval
+        );
+
+        // Setup existing active incident for batch 30
+        monitor.base.active_incidents.insert(existing_incident_key_30, existing_incident_id_30.clone());
+
+        let result = monitor.check_unproven_batches().await;
+        assert!(result.is_ok());
+
+        assert_eq!(monitor.base.active_incidents.len(), 2, "Two incidents should be active");
+        // Existing incident for batch 30 should remain
+        assert_eq!(monitor.base.active_incidents.get(&existing_incident_key_30), Some(&existing_incident_id_30));
+        // New incident for batch 40 should be added
+        assert!(monitor.base.active_incidents.contains_key(&(4001, 40)));
+        assert_eq!(monitor.base.active_incidents.get(&(4001, 40)), Some(&"incident_id_40_new".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_check_unproven_batches_scenario4_catch_all_incident_resolution() {
+        let mut mock_ch = MockClickhouseClient::new();
+        let mut mock_incident = MockIncidentClient::new();
+        let component_id = "proof_timeout_s4_catch_all".to_string();
+        let proof_timeout_hours = 3;
+
+        let catch_all_key = (0u64, 0u64);
+        let catch_all_incident_id = "incident_id_catch_all".to_string();
+
+        // CH: get_unproved_batches_older_than returns no new overdue batches
+        mock_ch.expect_get_unproved_batches_older_than()
+            .times(1)
+            .returning(|_cutoff| Ok(vec![]));
+
+        // CH: get_proved_batch_ids might be called if there were other active incidents.
+        // Since we only have the catch-all, and its batch_id is 0, it's skipped in the loop.
+        // So, get_proved_batch_ids might not be called, or if called with an empty list of specific batches to check, it's fine.
+        // For this specific path, it's called once before the loop for active_incidents_snapshot.
+        // The loop `for (key, incident_id) in active_incidents_snapshot` will see the catch-all,
+        // batch_id is 0, so it continues. Then the special case check happens.
+        mock_ch.expect_get_proved_batch_ids().times(1).returning(|| Ok(vec![]));
+
+
+        // IncidentClient: resolve_incident should be called for the catch-all incident
+        let id_catch_all_clone = catch_all_incident_id.clone();
+        mock_incident.expect_resolve_incident()
+            .withf(move |id, _payload| id == id_catch_all_clone)
+            .times(1)
+            .returning(|_, _| Ok(()));
+        mock_incident.expect_create_incident().never();
+
+
+        let mut monitor = batch_proof_timeout_monitor_with_mocks(
+            mock_ch,
+            mock_incident,
+            component_id,
+            proof_timeout_hours,
+            60, // interval
+        );
+
+        // Setup catch-all active incident. This is the *only* active incident.
+        monitor.base.active_incidents.insert(catch_all_key, catch_all_incident_id.clone());
+        assert_eq!(monitor.base.active_incidents.len(), 1, "Pre-condition: Only catch-all incident is active");
+
+
+        let result = monitor.check_unproven_batches().await;
+        assert!(result.is_ok());
+
+        assert!(monitor.base.active_incidents.is_empty(), "Catch-all incident should be resolved and removed");
+    }
+
+    #[tokio::test]
+    async fn test_batch_proof_timeout_monitor_initialize_finds_catch_all() {
+        let mut mock_ch = MockClickhouseClient::new(); // Not directly used by initialize's primary path
+        let mut mock_incident = MockIncidentClient::new();
+        let component_id = "proof_timeout_init_catch_all".to_string();
+        let proof_timeout_hours = 3;
+        let catch_all_incident_id = "init_catch_all_id_found".to_string();
+        let catch_all_key = (0u64, 0u64);
+
+        // IncidentClient: open_incident (called by base.check_existing_incidents) finds the catch-all.
+        let comp_id_clone = component_id.clone();
+        let id_clone = catch_all_incident_id.clone();
+        mock_incident.expect_open_incident()
+            .withf(move |cid: &str| cid == comp_id_clone) // check_existing_incidents calls with component_id
+            .times(1)
+            .returning(move |_| Ok(Some(id_clone.clone())));
+
+
+        let mut monitor = batch_proof_timeout_monitor_with_mocks(
+            mock_ch,
+            mock_incident,
+            component_id,
+            proof_timeout_hours,
+            60, // interval
+        );
+
+        let result = monitor.initialize().await;
+        assert!(result.is_ok());
+
+        assert_eq!(monitor.base.active_incidents.len(), 1, "Catch-all incident should be active");
+        assert!(monitor.base.active_incidents.contains_key(&catch_all_key));
+        assert_eq!(monitor.base.active_incidents.get(&catch_all_key), Some(&catch_all_incident_id));
+    }
+
+    // --- Tests for Monitor trait methods on BatchProofTimeoutMonitor ---
+
+    #[tokio::test]
+    async fn test_batch_proof_timeout_monitor_trait_create_incident() {
+        let mut mock_ch = MockClickhouseClient::new(); // Not directly used by this path of create_incident
+        let mut mock_incident_client = MockIncidentClient::new();
+        let component_id = "proof_timeout_trait_create".to_string();
+        let proof_timeout_hours = 3;
+        let expected_incident_id = "trait_proof_timeout_created_1".to_string();
+        let batch_key_to_create = (5001u64, 50u64); // (l1_block_number, batch_id)
+
+        let expected_id_clone = expected_incident_id.clone();
+        mock_incident_client.expect_create_incident()
+            .withf(move |p: &NewIncident| {
+                p.name == format!("Batch #{} Not Proven - Timeout", batch_key_to_create.1) &&
+                // age_hours is 0 in this direct call via trait
+                p.message == format!("Batch #{} has been waiting for proof for 0h (threshold: {}h)", batch_key_to_create.1, proof_timeout_hours)
+            })
+            .times(1)
+            .returning(move |_| Ok(expected_id_clone.clone()));
+
+        let monitor = batch_proof_timeout_monitor_with_mocks(
+            mock_ch,
+            mock_incident_client,
+            component_id,
+            proof_timeout_hours,
+            60, // interval
+        );
+
+        let result = monitor.create_incident(&batch_key_to_create).await;
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), expected_incident_id);
+    }
+
+    #[tokio::test]
+    async fn test_batch_proof_timeout_monitor_trait_resolve_incident() {
+        let mut mock_ch = MockClickhouseClient::new();
+        let mut mock_incident_client = MockIncidentClient::new();
+        let component_id = "proof_timeout_trait_resolve".to_string();
+        let incident_id_to_resolve = "trait_proof_timeout_resolving_2".to_string();
+
+        let id_clone = incident_id_to_resolve.clone();
+        mock_incident_client.expect_resolve_incident()
+            .withf(move |id: &str, p: &ResolveIncident| {
+                id == id_clone && p.status == IncidentState::Resolved
+            })
+            .times(1)
+            .returning(|_, _| Ok(()));
+
+        let monitor = batch_proof_timeout_monitor_with_mocks(
+            mock_ch,
+            mock_incident_client,
+            component_id,
+            3, // proof_timeout_hours
+            60, // interval
+        );
+
+        let result = monitor.resolve_incident(&incident_id_to_resolve).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_batch_proof_timeout_monitor_trait_check_health_opens_incident() {
+        let mut mock_ch = MockClickhouseClient::new();
+        let mut mock_incident = MockIncidentClient::new();
+        let component_id = "proof_timeout_trait_check_health".to_string();
+        let proof_timeout_hours = 3;
+        let proof_timeout_duration = Duration::from_secs(proof_timeout_hours * 60 * 60);
+        let expected_incident_id = "trait_check_health_proof_timeout_opened".to_string();
+
+        let now = Utc::now();
+        let overdue_batch_posted_at = now - ChronoDuration::from_std(proof_timeout_duration).unwrap() - ChronoDuration::hours(1);
+        let unproven_batch_from_ch = vec![(6001u64, 60u64, overdue_batch_posted_at)]; // (l1, batch_id, posted_at)
+
+        // CH: get_unproved_batches_older_than returns one overdue batch
+        let batch_clone = unproven_batch_from_ch.clone();
+        mock_ch.expect_get_unproved_batches_older_than()
+            .times(1)
+            .returning(move |_| Ok(batch_clone.clone()));
+
+        // CH: get_proved_batch_ids for the (now active) incident for batch 60
+        mock_ch.expect_get_proved_batch_ids()
+            .times(1)
+            .returning(|| Ok(vec![])); // Batch 60 is not proven
+
+        // IncidentClient: create_incident for batch 60
+        let expected_id_clone = expected_incident_id.clone();
+        mock_incident.expect_create_incident()
+            .withf(move |p: &NewIncident| p.message.contains("Batch #60 has been waiting for proof"))
+            .times(1)
+            .returning(move |_| Ok(expected_id_clone.clone()));
+
+
+        let mut monitor = batch_proof_timeout_monitor_with_mocks(
+            mock_ch,
+            mock_incident,
+            component_id,
+            proof_timeout_hours,
+            60, // interval
+        );
+
+        let result = monitor.check_health().await; // This calls check_unproven_batches
+        assert!(result.is_ok());
+        assert_eq!(monitor.base.active_incidents.len(), 1, "Incident should be opened by check_health");
+        assert!(monitor.base.active_incidents.contains_key(&(6001, 60)));
+        assert_eq!(monitor.base.active_incidents.get(&(6001, 60)), Some(&expected_incident_id));
+    }
+
+    // --- Tests for BatchVerifyTimeoutMonitor ---
+
+    #[tokio::test]
+    async fn test_check_unverified_batches_scenario1_new_overdue_batches_open_incidents() {
+        let mut mock_ch = MockClickhouseClient::new();
+        let mut mock_incident = MockIncidentClient::new();
+        let component_id = "verify_timeout_s1".to_string();
+        let verify_timeout_hours = 1; // Using a smaller timeout for verify
+        let verify_timeout_duration = Duration::from_secs(verify_timeout_hours * 60 * 60);
+
+        let now = Utc::now();
+        // Note: BatchVerifyTimeoutMonitor uses just batch_id as key
+        let overdue_batch_70_posted_at = now - ChronoDuration::from_std(verify_timeout_duration).unwrap() - ChronoDuration::hours(1);
+        let overdue_batch_80_posted_at = now - ChronoDuration::from_std(verify_timeout_duration).unwrap() - ChronoDuration::hours(2);
+
+        // CH returns these batches as unverified and older than cutoff
+        let unverified_batches_from_ch = vec![
+            (7001u64, 70u64, overdue_batch_70_posted_at), // (l1_block_number, batch_id, posted_at)
+            (8001u64, 80u64, overdue_batch_80_posted_at),
+        ];
+        let batches_clone = unverified_batches_from_ch.clone();
+        mock_ch.expect_get_unverified_batches_older_than()
+            .times(1)
+            .returning(move |_cutoff| Ok(batches_clone.clone()));
+
+        // CH: get_verified_batch_ids (called for active incidents)
+        // Since these are new, they won't be in active_incidents yet for the first part of the function.
+        // The loop for resolving active incidents will run on a snapshot.
+        // If new incidents are added and then immediately checked, this mock needs to reflect they are not verified.
+        mock_ch.expect_get_verified_batch_ids()
+            .times(1) // Called once when iterating active incidents (which are now 70 and 80)
+            .returning(|| Ok(vec![])); // Neither 70 nor 80 are verified yet
+
+        // IncidentClient: create_incident for 70 and 80
+        mock_incident.expect_create_incident()
+            .withf(move |p: &NewIncident| p.message.contains("Batch #70 has been waiting for verification"))
+            .times(1)
+            .returning(|_p| Ok("incident_id_70".to_string()));
+        mock_incident.expect_create_incident()
+            .withf(move |p: &NewIncident| p.message.contains("Batch #80 has been waiting for verification"))
+            .times(1)
+            .returning(|_p| Ok("incident_id_80".to_string()));
+
+
+        let mut monitor = batch_verify_timeout_monitor_with_mocks(
+            mock_ch,
+            mock_incident,
+            component_id,
+            verify_timeout_hours,
+            60, // interval
+        );
+
+        let result = monitor.check_unverified_batches().await;
+        assert!(result.is_ok());
+        assert_eq!(monitor.base.active_incidents.len(), 2, "Two incidents should be active");
+        assert!(monitor.base.active_incidents.contains_key(&70u64));
+        assert!(monitor.base.active_incidents.contains_key(&80u64));
+    }
+
+    #[tokio::test]
+    async fn test_check_unverified_batches_scenario2_active_incidents_some_verified_resolve() {
+        let mut mock_ch = MockClickhouseClient::new();
+        let mut mock_incident = MockIncidentClient::new();
+        let component_id = "verify_timeout_s2".to_string();
+        let verify_timeout_hours = 1;
+
+        let active_incident_key_70 = 70u64; // Verified
+        let active_incident_id_70 = "incident_id_70_verified".to_string();
+        let active_incident_key_80 = 80u64; // Still unverified
+        let active_incident_id_80 = "incident_id_80_unverified".to_string();
+
+        // CH: get_unverified_batches_older_than returns no new overdue batches
+        mock_ch.expect_get_unverified_batches_older_than()
+            .times(1)
+            .returning(|_cutoff| Ok(vec![]));
+
+        // CH: get_verified_batch_ids returns that batch 70 is verified
+        mock_ch.expect_get_verified_batch_ids()
+            .times(1)
+            .returning(|| Ok(vec![70u64])); // Batch 70 is verified
+
+        // IncidentClient: resolve_incident should be called for batch 70
+        let id_70_clone = active_incident_id_70.clone();
+        mock_incident.expect_resolve_incident()
+            .withf(move |id, _payload| id == id_70_clone)
+            .times(1)
+            .returning(|_, _| Ok(()));
+        mock_incident.expect_create_incident().never();
+
+
+        let mut monitor = batch_verify_timeout_monitor_with_mocks(
+            mock_ch,
+            mock_incident,
+            component_id,
+            verify_timeout_hours,
+            60, // interval
+        );
+
+        // Setup active incidents
+        monitor.base.active_incidents.insert(active_incident_key_70, active_incident_id_70.clone());
+        monitor.base.active_incidents.insert(active_incident_key_80, active_incident_id_80.clone());
+
+        let result = monitor.check_unverified_batches().await;
+        assert!(result.is_ok());
+
+        assert_eq!(monitor.base.active_incidents.len(), 1, "One incident should remain active");
+        assert!(!monitor.base.active_incidents.contains_key(&active_incident_key_70), "Verified incident should be removed");
+        assert!(monitor.base.active_incidents.contains_key(&active_incident_key_80), "Unverified incident should remain");
+        assert_eq!(monitor.base.active_incidents.get(&active_incident_key_80), Some(&active_incident_id_80));
+    }
+
+    #[tokio::test]
+    async fn test_check_unverified_batches_scenario3_new_and_existing_overdue_batches() {
+        let mut mock_ch = MockClickhouseClient::new();
+        let mut mock_incident = MockIncidentClient::new();
+        let component_id = "verify_timeout_s3".to_string();
+        let verify_timeout_hours = 1;
+        let verify_timeout_duration = Duration::from_secs(verify_timeout_hours * 60 * 60);
+
+        let now = Utc::now();
+        // Batch 90: Overdue, already has an active incident
+        let batch_90_posted_at = now - ChronoDuration::from_std(verify_timeout_duration).unwrap() - ChronoDuration::hours(1);
+        let existing_incident_key_90 = 90u64;
+        let existing_incident_id_90 = "incident_id_90_existing".to_string();
+
+        // Batch 100: Overdue, new, should trigger incident creation
+        let batch_100_posted_at = now - ChronoDuration::from_std(verify_timeout_duration).unwrap() - ChronoDuration::hours(2);
+
+        let unverified_batches_from_ch = vec![
+            (9001u64, existing_incident_key_90, batch_90_posted_at), // (l1_block_number, batch_id, posted_at)
+            (10001u64, 100u64, batch_100_posted_at),
+        ];
+
+        // CH: get_unverified_batches_older_than returns these two
+        let batches_clone = unverified_batches_from_ch.clone();
+        mock_ch.expect_get_unverified_batches_older_than()
+            .times(1)
+            .returning(move |_| Ok(batches_clone.clone()));
+
+        // CH: get_verified_batch_ids for active incidents (batch 90 and newly created 100)
+        // Assume neither are verified yet for this scenario.
+        mock_ch.expect_get_verified_batch_ids()
+            .times(1)
+            .returning(|| Ok(vec![])); // Neither 90 nor 100 are verified
+
+        // IncidentClient: create_incident should be called only for batch 100
+        mock_incident.expect_create_incident()
+            .withf(move |p: &NewIncident| p.message.contains("Batch #100 has been waiting for verification"))
+            .times(1)
+            .returning(|_p| Ok("incident_id_100_new".to_string()));
+        // No create_incident for batch 90 (already active)
+        mock_incident.expect_create_incident()
+            .withf(move |p: &NewIncident| p.message.contains("Batch #90"))
+            .never();
+        mock_incident.expect_resolve_incident().never();
+
+
+        let mut monitor = batch_verify_timeout_monitor_with_mocks(
+            mock_ch,
+            mock_incident,
+            component_id,
+            verify_timeout_hours,
+            60, // interval
+        );
+
+        // Setup existing active incident for batch 90
+        monitor.base.active_incidents.insert(existing_incident_key_90, existing_incident_id_90.clone());
+
+        let result = monitor.check_unverified_batches().await;
+        assert!(result.is_ok());
+
+        assert_eq!(monitor.base.active_incidents.len(), 2, "Two incidents should be active");
+        assert_eq!(monitor.base.active_incidents.get(&existing_incident_key_90), Some(&existing_incident_id_90));
+        assert!(monitor.base.active_incidents.contains_key(&100u64));
+        assert_eq!(monitor.base.active_incidents.get(&100u64), Some(&"incident_id_100_new".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_check_unverified_batches_scenario4_catch_all_incident_resolution() {
+        let mut mock_ch = MockClickhouseClient::new();
+        let mut mock_incident = MockIncidentClient::new();
+        let component_id = "verify_timeout_s4_catch_all".to_string();
+        let verify_timeout_hours = 1;
+
+        let catch_all_key = 0u64;
+        let catch_all_incident_id = "incident_id_verify_catch_all".to_string();
+
+        // CH: get_unverified_batches_older_than returns no new overdue batches
+        mock_ch.expect_get_unverified_batches_older_than()
+            .times(1)
+            .returning(|_cutoff| Ok(vec![])); // Crucial: no specific unverified batches
+
+        // CH: get_verified_batch_ids. The loop for specific batches won't run if active_incidents only has catch-all.
+        // If it were called (e.g. if the snapshot was taken earlier), it should return empty or irrelevant.
+        // The current code takes snapshot, then iterates. The batch_id == 0 check prevents call for catch-all.
+        mock_ch.expect_get_verified_batch_ids().times(1).returning(|| Ok(vec![]));
+
+
+        // IncidentClient: resolve_incident should be called for the catch-all incident
+        let id_catch_all_clone = catch_all_incident_id.clone();
+        mock_incident.expect_resolve_incident()
+            .withf(move |id, _payload| id == id_catch_all_clone)
+            .times(1)
+            .returning(|_, _| Ok(()));
+        mock_incident.expect_create_incident().never();
+
+
+        let mut monitor = batch_verify_timeout_monitor_with_mocks(
+            mock_ch,
+            mock_incident,
+            component_id,
+            verify_timeout_hours,
+            60, // interval
+        );
+
+        // Setup catch-all active incident. This is the *only* active incident.
+        monitor.base.active_incidents.insert(catch_all_key, catch_all_incident_id.clone());
+        assert_eq!(monitor.base.active_incidents.len(), 1, "Pre-condition: Only catch-all incident is active");
+
+        let result = monitor.check_unverified_batches().await;
+        assert!(result.is_ok());
+
+        assert!(monitor.base.active_incidents.is_empty(), "Catch-all verify incident should be resolved and removed");
+    }
+
+    #[tokio::test]
+    async fn test_batch_verify_timeout_monitor_initialize_finds_catch_all() {
+        let mut mock_ch = MockClickhouseClient::new(); // Not directly used by initialize's primary path
+        let mut mock_incident = MockIncidentClient::new();
+        let component_id = "verify_timeout_init_catch_all".to_string();
+        let verify_timeout_hours = 1;
+        let catch_all_incident_id = "init_verify_catch_all_id_found".to_string();
+        let catch_all_key = 0u64; // Key for BatchVerifyTimeoutMonitor's catch-all
+
+        // IncidentClient: open_incident (called by base.check_existing_incidents) finds the catch-all.
+        let comp_id_clone = component_id.clone();
+        let id_clone = catch_all_incident_id.clone();
+        mock_incident.expect_open_incident()
+            .withf(move |cid: &str| cid == comp_id_clone) // check_existing_incidents calls with component_id
+            .times(1)
+            .returning(move |_| Ok(Some(id_clone.clone())));
+
+
+        let mut monitor = batch_verify_timeout_monitor_with_mocks(
+            mock_ch,
+            mock_incident,
+            component_id,
+            verify_timeout_hours,
+            60, // interval
+        );
+
+        let result = monitor.initialize().await;
+        assert!(result.is_ok());
+
+        assert_eq!(monitor.base.active_incidents.len(), 1, "Catch-all incident should be active");
+        assert!(monitor.base.active_incidents.contains_key(&catch_all_key));
+        assert_eq!(monitor.base.active_incidents.get(&catch_all_key), Some(&catch_all_incident_id));
+    }
+
+    // --- Tests for Monitor trait methods on BatchVerifyTimeoutMonitor ---
+
+    #[tokio::test]
+    async fn test_batch_verify_timeout_monitor_trait_create_incident() {
+        let mut mock_ch = MockClickhouseClient::new(); // Not directly used by this path
+        let mut mock_incident_client = MockIncidentClient::new();
+        let component_id = "verify_timeout_trait_create".to_string();
+        let verify_timeout_hours = 1;
+        let expected_incident_id = "trait_verify_timeout_created_1".to_string();
+        let batch_id_to_create = 110u64;
+
+        let expected_id_clone = expected_incident_id.clone();
+        mock_incident_client.expect_create_incident()
+            .withf(move |p: &NewIncident| {
+                p.name == format!("Batch #{} Not Verified - Timeout", batch_id_to_create) &&
+                p.message == format!("Batch #{} has been waiting for verification for over 0h (threshold: {}h)", batch_id_to_create, verify_timeout_hours)
+            })
+            .times(1)
+            .returning(move |_| Ok(expected_id_clone.clone()));
+
+        let monitor = batch_verify_timeout_monitor_with_mocks(
+            mock_ch,
+            mock_incident_client,
+            component_id,
+            verify_timeout_hours,
+            60, // interval
+        );
+
+        let result = monitor.create_incident(&batch_id_to_create).await;
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), expected_incident_id);
+    }
+
+    #[tokio::test]
+    async fn test_batch_verify_timeout_monitor_trait_resolve_incident() {
+        let mut mock_ch = MockClickhouseClient::new();
+        let mut mock_incident_client = MockIncidentClient::new();
+        let component_id = "verify_timeout_trait_resolve".to_string();
+        let incident_id_to_resolve = "trait_verify_timeout_resolving_2".to_string();
+
+        let id_clone = incident_id_to_resolve.clone();
+        mock_incident_client.expect_resolve_incident()
+            .withf(move |id: &str, p: &ResolveIncident| {
+                id == id_clone && p.status == IncidentState::Resolved
+            })
+            .times(1)
+            .returning(|_, _| Ok(()));
+
+        let monitor = batch_verify_timeout_monitor_with_mocks(
+            mock_ch,
+            mock_incident_client,
+            component_id,
+            1, // verify_timeout_hours
+            60, // interval
+        );
+
+        let result = monitor.resolve_incident(&incident_id_to_resolve).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_batch_verify_timeout_monitor_trait_check_health_opens_incident() {
+        let mut mock_ch = MockClickhouseClient::new();
+        let mut mock_incident = MockIncidentClient::new();
+        let component_id = "verify_timeout_trait_check_health".to_string();
+        let verify_timeout_hours = 1;
+        let verify_timeout_duration = Duration::from_secs(verify_timeout_hours * 60 * 60);
+        let expected_incident_id = "trait_check_health_verify_timeout_opened".to_string();
+
+        let now = Utc::now();
+        let overdue_batch_posted_at = now - ChronoDuration::from_std(verify_timeout_duration).unwrap() - ChronoDuration::hours(1);
+        // (l1_block_number, batch_id, posted_at) - l1_block_number isn't used by BatchVerifyTimeoutMonitor's key directly
+        let unverified_batch_from_ch = vec![(12001u64, 120u64, overdue_batch_posted_at)];
+
+        // CH: get_unverified_batches_older_than returns one overdue batch
+        let batch_clone = unverified_batch_from_ch.clone();
+        mock_ch.expect_get_unverified_batches_older_than()
+            .times(1)
+            .returning(move |_| Ok(batch_clone.clone()));
+
+        // CH: get_verified_batch_ids for the (now active) incident for batch 120
+        mock_ch.expect_get_verified_batch_ids()
+            .times(1)
+            .returning(|| Ok(vec![])); // Batch 120 is not verified
+
+        // IncidentClient: create_incident for batch 120
+        let expected_id_clone = expected_incident_id.clone();
+        mock_incident.expect_create_incident()
+            .withf(move |p: &NewIncident| p.message.contains("Batch #120 has been waiting for verification"))
+            .times(1)
+            .returning(move |_| Ok(expected_id_clone.clone()));
+
+
+        let mut monitor = batch_verify_timeout_monitor_with_mocks(
+            mock_ch,
+            mock_incident,
+            component_id,
+            verify_timeout_hours,
+            60, // interval
+        );
+
+        let result = monitor.check_health().await; // This calls check_unverified_batches
+        assert!(result.is_ok());
+        assert_eq!(monitor.base.active_incidents.len(), 1, "Incident should be opened by check_health");
+        assert!(monitor.base.active_incidents.contains_key(&120u64));
+        assert_eq!(monitor.base.active_incidents.get(&120u64), Some(&expected_incident_id));
+    }
 
     // Helper to create a ClickhouseClient for tests
-    fn mock_clickhouse_client() -> (ClickhouseInternalClient, ServerGuard) {
+    fn mock_clickhouse_client() -> (ActualClickhouseClient, ServerGuard) { // Renamed return type
         let server = mockito::Server::new();
         let url = Url::parse(&server.url()).unwrap();
-        let client = ClickhouseInternalClient::new(
+        // This is ActualClickhouseClient, not the mock.
+        // The mock_clickhouse_client name is now ambiguous.
+        // Let's assume this is for other tests and keep it, but our new tests will use MockClickhouseClient.
+        let client = ActualClickhouseClient::new(
             url,
             "test_db".to_string(),
             "user".to_string(),
@@ -821,10 +2600,11 @@ mod tests {
     }
 
     // Helper to create an IncidentClient for tests
-    fn mock_incident_client() -> (IncidentClient, ServerGuard) {
+    fn mock_incident_client() -> (ActualIncidentClient, ServerGuard) { // Renamed return type
         let server = mockito::Server::new();
         let url = Url::parse(&server.url()).unwrap();
-        let client = IncidentClient::with_base_url(
+        // This is ActualIncidentClient, not the mock.
+        let client = ActualIncidentClient::with_base_url(
             "test_api_key".to_string(),
             "test_page_id".to_string(),
             url,


### PR DESCRIPTION
I added unit tests for the following components in the `crates/incident` module:

- `base_monitor.rs`:
    - `BaseMonitor::new`
    - `BaseMonitor::create_incident_payload`
    - `BaseMonitor::create_resolve_payload`
    - `BaseMonitor::create_incident_with_payload`
    - `BaseMonitor::resolve_incident_with_payload`
    - `BaseMonitor::check_existing_incidents`
    - `BaseMonitor::mark_healthy`
    - `BaseMonitor::mark_unhealthy`

- `monitor.rs`:
    - `InstatusL1Monitor`: Tests for `handle`, `initialize`, `check_initial_health`, and `Monitor` trait methods. Covers scenarios like batch/L2 outages and recoveries.
    - `InstatusMonitor`: Tests for `handle`, `initialize`, `check_initial_health`, and `Monitor` trait methods. Covers L2 outage and recovery scenarios.
    - `BatchProofTimeoutMonitor`: Tests for `check_unproven_batches`, `initialize`, and `Monitor` trait methods. Covers creation of incidents for overdue batch proofs and resolution when batches are proven, including catch-all incident logic.
    - `BatchVerifyTimeoutMonitor`: Tests for `check_unverified_batches`, `initialize`, and `Monitor` trait methods. Covers creation of incidents for overdue batch verifications and resolution when batches are verified, including catch-all incident logic.

Mocks for `IncidentClient` and `ClickhouseClient` were created using the `mockall` crate to facilitate testing.

Note: Running `cargo test` was blocked during development by an unrelated Cargo feature issue (`edition2024`) in the `taikoscope` workspace member. The tests were written assuming this external issue will be resolved separately.