### PR TITLE
Refactor driver event loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1557,6 +1557,7 @@ dependencies = [
  "extractor",
  "eyre",
  "incident",
+ "primitives",
  "tokio",
  "tokio-stream",
  "tracing",

--- a/crates/driver/Cargo.toml
+++ b/crates/driver/Cargo.toml
@@ -12,6 +12,7 @@ chainio = { path = "../chainio" }
 clickhouse = { path = "../clickhouse" }
 extractor = { path = "../extractor" }
 incident = { path = "../incident" }
+primitives = { path = "../primitives" }
 
 chrono.workspace = true
 alloy-primitives.workspace = true

--- a/crates/driver/src/event.rs
+++ b/crates/driver/src/event.rs
@@ -1,0 +1,22 @@
+use chainio::{
+    ITaikoInbox::{BatchProposed, BatchesProved},
+    taiko::wrapper::ITaikoWrapper::ForcedInclusionProcessed,
+};
+use extractor::{L1Header, L2Header};
+
+/// Events handled by the [`Driver`] event loop.
+#[derive(Debug)]
+pub enum DriverEvent {
+    /// A new L1 header was received.
+    L1Header(L1Header),
+    /// A new L2 header was received.
+    L2Header(L2Header),
+    /// A new batch was proposed on L1.
+    BatchProposed(BatchProposed),
+    /// A forced inclusion was processed.
+    ForcedInclusion(ForcedInclusionProcessed),
+    /// Batches were proved on L1 together with the block number.
+    BatchesProved((BatchesProved, u64)),
+    /// Batches were verified on L1 together with the block number.
+    BatchesVerified((chainio::BatchesVerified, u64)),
+}

--- a/crates/extractor/src/lib.rs
+++ b/crates/extractor/src/lib.rs
@@ -26,7 +26,7 @@ use tracing::{error, info, warn};
 use url::Url;
 
 /// Extractor client
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Extractor {
     #[debug(skip)]
     l1_provider: DefaultProvider,


### PR DESCRIPTION
## Summary
- make `Extractor` clonable
- refactor `Driver` loop to use tasks and mpsc channel
- add `DriverEvent` enum for events
- integrate shutdown handling

## Testing
- `cargo clippy --examples --tests --benches --all-features`
- `cargo nextest run --workspace --all-targets`