### PR TITLE
Aggregate L2 block metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1642,8 +1642,11 @@ name = "extractor"
 version = "0.1.0"
 dependencies = [
  "alloy",
+ "alloy-consensus",
  "alloy-json-rpc",
+ "alloy-network-primitives",
  "alloy-rpc-client",
+ "alloy-rpc-types-eth",
  "chainio",
  "derive_more 1.0.0",
  "eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,10 @@ alloy = { version = "1.0.3", features = ["provider-ws"] }
 alloy-contract = { version = "1.0.3" }
 alloy-json-rpc = { version = "1.0.3" }
 alloy-rpc-client = "1.0.3"
+alloy-rpc-types-eth = "1.0.1"
 alloy-primitives = "1.1.0"
+alloy-consensus = "1.0.1"
+alloy-network-primitives = "1.0.1"
 alloy-sol-types = "1.1.0"
 alloy-sol-macro = "1.1.0"
 chrono = "0.4.41"

--- a/crates/extractor/Cargo.toml
+++ b/crates/extractor/Cargo.toml
@@ -13,6 +13,9 @@ primitives = { path = "../primitives" }
 alloy.workspace = true
 alloy-json-rpc.workspace = true
 alloy-rpc-client.workspace = true
+alloy-rpc-types-eth.workspace = true
+alloy-consensus.workspace = true
+alloy-network-primitives.workspace = true
 derive_more.workspace = true
 eyre.workspace = true
 tokio.workspace = true


### PR DESCRIPTION
## Summary
- compute per-block tx count, gas used and priority fee
- store aggregated data in `l2_head_events`
- expose helper in extractor to fetch block receipts
- update driver to use new helper

## Testing
- `RUSTFLAGS="-D warnings" cargo clippy --examples --tests --benches --all-features --offline`
- `cargo nextest run --workspace --all-targets --offline`
