### PR TITLE
Refactor extractor stats

### DIFF
--- a/crates/extractor/src/lib.rs
+++ b/crates/extractor/src/lib.rs
@@ -442,20 +442,28 @@ impl Extractor {
         let receipts_opt = self.l2_provider.get_block_receipts(block).await?;
         let receipts = receipts_opt.ok_or_else(|| eyre::eyre!("missing receipts"))?;
 
-        let mut sum_gas_used: u128 = 0;
-        let mut sum_priority_fee: u128 = 0;
-        let base = base_fee.unwrap_or(0) as u128;
-        let tx_count = receipts.len() as u32;
-
-        for receipt in receipts {
-            let gas = receipt.gas_used() as u128;
-            sum_gas_used += gas;
-            let effective = receipt.effective_gas_price();
-            let priority_per_gas = effective.saturating_sub(base);
-            sum_priority_fee += priority_per_gas.saturating_mul(gas);
-        }
-        Ok((sum_gas_used, tx_count, sum_priority_fee))
+        Ok(compute_block_stats(&receipts, base_fee))
     }
+}
+
+/// Compute aggregated gas and priority fee statistics for a set of receipts.
+pub fn compute_block_stats<R: ReceiptResponse>(
+    receipts: &[R],
+    base_fee: Option<u64>,
+) -> (u128, u32, u128) {
+    let base = base_fee.unwrap_or(0) as u128;
+    let mut sum_gas_used: u128 = 0;
+    let mut sum_priority_fee: u128 = 0;
+
+    for receipt in receipts {
+        let gas = receipt.gas_used() as u128;
+        sum_gas_used += gas;
+        let priority_per_gas = receipt.effective_gas_price().saturating_sub(base);
+        sum_priority_fee += priority_per_gas.saturating_mul(gas);
+    }
+
+    let tx_count = receipts.len() as u32;
+    (sum_gas_used, tx_count, sum_priority_fee)
 }
 
 /// Detects reorgs based on block numbers.
@@ -501,6 +509,7 @@ impl ReorgDetector {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy::primitives::{B256, TxHash};
 
     #[test]
     fn initial_block() {
@@ -573,5 +582,75 @@ mod tests {
         // New block 0. 0 < 5. Reorg. Depth = 5 - 0 = 5.
         assert_eq!(det.on_new_block(0), Some(5));
         assert_eq!(det.head_number, 0);
+    }
+
+    #[derive(Clone, Copy)]
+    struct TestReceipt {
+        gas: u64,
+        price: u128,
+    }
+
+    impl ReceiptResponse for TestReceipt {
+        fn contract_address(&self) -> Option<Address> {
+            None
+        }
+        fn status(&self) -> bool {
+            true
+        }
+        fn block_hash(&self) -> Option<BlockHash> {
+            None
+        }
+        fn block_number(&self) -> Option<u64> {
+            None
+        }
+        fn transaction_hash(&self) -> TxHash {
+            TxHash::ZERO
+        }
+        fn transaction_index(&self) -> Option<u64> {
+            None
+        }
+        fn gas_used(&self) -> u64 {
+            self.gas
+        }
+        fn effective_gas_price(&self) -> u128 {
+            self.price
+        }
+        fn blob_gas_used(&self) -> Option<u64> {
+            None
+        }
+        fn blob_gas_price(&self) -> Option<u128> {
+            None
+        }
+        fn from(&self) -> Address {
+            Address::ZERO
+        }
+        fn to(&self) -> Option<Address> {
+            None
+        }
+        fn cumulative_gas_used(&self) -> u64 {
+            self.gas
+        }
+        fn state_root(&self) -> Option<B256> {
+            None
+        }
+    }
+
+    #[test]
+    fn compute_block_stats_basic() {
+        let receipts =
+            vec![TestReceipt { gas: 100, price: 10 }, TestReceipt { gas: 200, price: 20 }];
+        let (gas, count, priority) = compute_block_stats(&receipts, Some(5));
+        assert_eq!(gas, 300);
+        assert_eq!(count, 2);
+        assert_eq!(priority, 3500);
+    }
+
+    #[test]
+    fn compute_block_stats_zero_base_fee() {
+        let receipts = vec![TestReceipt { gas: 150, price: 40 }];
+        let (gas, count, priority) = compute_block_stats(&receipts, None);
+        assert_eq!(gas, 150);
+        assert_eq!(count, 1);
+        assert_eq!(priority, 6000);
     }
 }


### PR DESCRIPTION
## Summary
- split L2 block stats logic into helper to reduce complexity
- add tests for new computation helper

## Testing
- `cargo clippy --examples --tests --benches --all-features`
- `cargo nextest run --workspace --all-targets`
