### PR TITLE
Add hardware cost estimates

### DIFF
--- a/crates/primitives/src/hardware.rs
+++ b/crates/primitives/src/hardware.rs
@@ -1,13 +1,13 @@
 //! Estimated hardware cost constants for running a redundant sequencer setup.
 
 /// Rough estimate for the cost of a single sequencer server in USD.
-pub const SEQUENCER_SERVER_COST_USD: f64 = 3500.0;
+pub const SEQUENCER_SERVER_COST_USD: f64 = 30.0;
 
 /// Number of servers required for a redundant setup.
 pub const SEQUENCER_SERVER_COUNT: usize = 2;
 
 /// Estimated cost for networking and other supporting equipment in USD.
-pub const NETWORKING_COST_USD: f64 = 500.0;
+pub const NETWORKING_COST_USD: f64 = 30.0;
 
 /// Estimated total hardware cost for a redundant sequencer setup in USD.
 pub const TOTAL_HARDWARE_COST_USD: f64 =

--- a/crates/primitives/src/hardware.rs
+++ b/crates/primitives/src/hardware.rs
@@ -1,0 +1,14 @@
+//! Estimated hardware cost constants for running a redundant sequencer setup.
+
+/// Rough estimate for the cost of a single sequencer server in USD.
+pub const SEQUENCER_SERVER_COST_USD: f64 = 3500.0;
+
+/// Number of servers required for a redundant setup.
+pub const SEQUENCER_SERVER_COUNT: usize = 2;
+
+/// Estimated cost for networking and other supporting equipment in USD.
+pub const NETWORKING_COST_USD: f64 = 500.0;
+
+/// Estimated total hardware cost for a redundant sequencer setup in USD.
+pub const TOTAL_HARDWARE_COST_USD: f64 =
+    SEQUENCER_SERVER_COST_USD * SEQUENCER_SERVER_COUNT as f64 + NETWORKING_COST_USD;

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -1,4 +1,6 @@
 //! Primitives for the taikoscope.
+/// Hardware cost estimates
+pub mod hardware;
 /// Retry layer
 pub mod retries;
 /// Shutdown handling


### PR DESCRIPTION
## Summary
- add constants for sequencer hardware costs
- expose new hardware module from primitives crate

## Testing
- `just lint`
- `just test`
- `just ci`
