### PR TITLE
Add thin HTTP API layer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ tokio-stream = "0.1.17"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter", "fmt"] }
 url = { version = "2.5.4", features = ["serde"] }
+axum = { version = "0.7.5", features = ["json"] }
 
 [workspace.lints]
 rust.missing_debug_implementations = "warn"

--- a/bin/api-server/Cargo.toml
+++ b/bin/api-server/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "api-server"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+api = { path = "../../crates/api" }
+clickhouse = { path = "../../crates/clickhouse" }
+config = { path = "../../crates/config" }
+dotenvy.workspace = true
+clap.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+eyre.workspace = true
+
+[[bin]]
+name = "api-server"
+path = "src/main.rs"

--- a/bin/api-server/src/main.rs
+++ b/bin/api-server/src/main.rs
@@ -1,0 +1,32 @@
+//! API server binary
+
+use std::net::SocketAddr;
+
+use api::run;
+use clap::Parser;
+use clickhouse::ClickhouseClient;
+use config::Opts;
+use dotenvy::dotenv;
+use tracing_subscriber::filter::EnvFilter;
+
+#[tokio::main]
+async fn main() -> eyre::Result<()> {
+    dotenv().ok();
+    let opts = Opts::parse();
+
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .init();
+
+    let client = ClickhouseClient::new(
+        opts.clickhouse.url,
+        opts.clickhouse.db,
+        opts.clickhouse.username,
+        opts.clickhouse.password,
+    )?;
+
+    let addr: SocketAddr = format!("{}:{}", opts.api.host, opts.api.port).parse()?;
+    run(addr, client).await
+}

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "api"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+axum.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+eyre.workspace = true
+clickhouse = { path = "../clickhouse" }
+
+[lints]
+workspace = true

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -1,0 +1,41 @@
+//! Thin HTTP API for accessing ClickHouse data
+
+use std::net::SocketAddr;
+
+use axum::{Json, Router, extract::State, routing::get};
+use clickhouse::ClickhouseClient;
+use eyre::Result;
+use serde::Serialize;
+use tracing::info;
+
+#[derive(Clone, Debug)]
+struct ApiState {
+    client: ClickhouseClient,
+}
+
+impl ApiState {
+    fn new(client: ClickhouseClient) -> Self {
+        Self { client }
+    }
+}
+
+#[derive(Serialize)]
+struct L2HeadResponse {
+    last_l2_head_time: Option<String>,
+}
+
+async fn l2_head(State(state): State<ApiState>) -> Result<Json<L2HeadResponse>> {
+    let ts = state.client.get_last_l2_head_time().await?;
+    let resp = L2HeadResponse { last_l2_head_time: ts.map(|t| t.to_rfc3339()) };
+    Ok(Json(resp))
+}
+
+/// Run the API server on the given address
+pub async fn run(addr: SocketAddr, client: ClickhouseClient) -> Result<()> {
+    let state = ApiState::new(client);
+    let app = Router::new().route("/l2-head", get(l2_head)).with_state(state);
+
+    info!("Starting API server", %addr);
+    axum::Server::bind(&addr).serve(app.into_make_service()).await?;
+    Ok(())
+}

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -78,6 +78,17 @@ pub struct InstatusOpts {
     pub batch_proof_timeout_secs: u64,
 }
 
+/// API server configuration options
+#[derive(Debug, Clone, Parser)]
+pub struct ApiOpts {
+    /// API server host
+    #[clap(long, env = "API_HOST", default_value = "127.0.0.1")]
+    pub host: String,
+    /// API server port
+    #[clap(long, env = "API_PORT", default_value = "3000")]
+    pub port: u16,
+}
+
 /// CLI options for taikoscope
 #[derive(Debug, Clone, Parser)]
 pub struct Opts {
@@ -96,6 +107,10 @@ pub struct Opts {
     /// Instatus monitoring configuration
     #[clap(flatten)]
     pub instatus: InstatusOpts,
+
+    /// API server configuration
+    #[clap(flatten)]
+    pub api: ApiOpts,
 
     /// If set, drop & re-create all tables (local/dev only)
     #[clap(long)]
@@ -146,6 +161,10 @@ mod tests {
             "verify",
             "--l2-component-id",
             "l2",
+            "--api-host",
+            "127.0.0.1",
+            "--api-port",
+            "3000",
         ]
     }
 
@@ -157,6 +176,8 @@ mod tests {
         assert_eq!(opts.instatus.monitor_poll_interval_secs, 30);
         assert_eq!(opts.instatus.monitor_threshold_secs, 96);
         assert_eq!(opts.instatus.batch_proof_timeout_secs, 10800);
+        assert_eq!(opts.api.host, "127.0.0.1");
+        assert_eq!(opts.api.port, 3000);
         assert!(!opts.reset_db);
     }
 
@@ -178,6 +199,8 @@ mod tests {
         assert_eq!(opts.instatus.monitor_poll_interval_secs, 42);
         assert_eq!(opts.instatus.monitor_threshold_secs, 33);
         assert_eq!(opts.instatus.batch_proof_timeout_secs, 99);
+        assert_eq!(opts.api.host, "127.0.0.1");
+        assert_eq!(opts.api.port, 3000);
         assert!(opts.reset_db);
 
         unsafe {


### PR DESCRIPTION
## Summary
- implement a small `api` crate that exposes an `axum` server
- add `api-server` binary to run the API
- introduce `ApiOpts` config options
- wire up new CLI options and tests
- add `axum` dependency

## Testing
- `just fmt`
- `just lint` *(fails: Could not connect to server)*
- `just test` *(fails: Could not connect to server)*
- `just ci` *(fails: Could not connect to server)*