### PR TITLE
Enable CORS for API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,6 +736,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tower-http",
  "tracing",
 ]
 
@@ -4183,6 +4184,22 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter", "fmt"] }
 url = { version = "2.5.4", features = ["serde"] }
 axum = { version = "0.7.5", features = ["json"] }
+tower-http = { version = "0.5.2", features = ["cors"] }
 
 [workspace.lints]
 rust.missing_debug_implementations = "warn"

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -15,6 +15,7 @@ tracing.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 chrono.workspace = true
+tower-http.workspace = true
 
 [lints]
 workspace = true

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -7,6 +7,7 @@ use chrono::{Duration, Utc};
 use clickhouse::ClickhouseClient;
 use eyre::Result;
 use serde::Serialize;
+use tower_http::cors::CorsLayer;
 use tracing::info;
 
 #[derive(Clone, Debug)]
@@ -95,9 +96,14 @@ pub async fn run(addr: SocketAddr, client: ClickhouseClient) -> Result<()> {
     let app = Router::new()
         .route("/l2-head", get(l2_head))
         .route("/l1-head", get(l1_head))
+<<<<<<< HEAD
         .route("/slashings/last-hour", get(slashing_last_hour))
         .route("/avg-prove-time", get(avg_prove_time))
         .with_state(state);
+=======
+        .with_state(state)
+        .layer(CorsLayer::permissive());
+>>>>>>> c1a7179 (feat(api): enable CORS)
 
     info!("Starting API server on {}", addr);
     let listener = tokio::net::TcpListener::bind(addr).await?;

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -96,14 +96,10 @@ pub async fn run(addr: SocketAddr, client: ClickhouseClient) -> Result<()> {
     let app = Router::new()
         .route("/l2-head", get(l2_head))
         .route("/l1-head", get(l1_head))
-<<<<<<< HEAD
         .route("/slashings/last-hour", get(slashing_last_hour))
         .route("/avg-prove-time", get(avg_prove_time))
-        .with_state(state);
-=======
         .with_state(state)
         .layer(CorsLayer::permissive());
->>>>>>> c1a7179 (feat(api): enable CORS)
 
     info!("Starting API server on {}", addr);
     let listener = tokio::net::TcpListener::bind(addr).await?;


### PR DESCRIPTION
## Summary
- configure CORS using `CorsLayer::permissive`
- add `tower-http` dependency

## Testing
- `just fmt`
- `just lint` *(fails: failed to download from crates.io)*
- `just test` *(fails: failed to download from crates.io)*