### PR TITLE
Add basic API rate limiter

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -44,20 +44,23 @@ impl RateLimiter {
         }
     }
 
-    fn try_acquire(&self) -> bool {
-        let mut state = self.state.lock().expect("lock poisoned");
-        let now = Instant::now();
-        if now >= state.reset_at {
-            state.reset_at = now + self.period;
-            state.count = 0;
-        }
-        if state.count < self.capacity {
-            state.count += 1;
-            true
-        } else {
-            false
-        }
+
+fn try_acquire(&self) -> bool {
+    let mut state = self.state.lock().expect("lock poisoned");
+    let now = Instant::now();
+    if now >= state.reset_at {
+        state.reset_at = now + self.period;
+        state.count = 1;  // Start at 1 for this request
+        return true;
     }
+    if state.count < self.capacity {
+        state.count += 1;
+        true
+    } else {
+        false
+    }
+}
+
 }
 
 #[derive(Clone, Debug)]

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -2,22 +2,73 @@
 
 use std::net::SocketAddr;
 
-use axum::{Json, Router, extract::State, routing::get};
-use chrono::{Duration, Utc};
+use axum::{Json, Router, extract::State, middleware, response::IntoResponse, routing::get};
+use chrono::{Duration as ChronoDuration, Utc};
 use clickhouse::ClickhouseClient;
 use eyre::Result;
 use serde::Serialize;
+use std::{
+    sync::{Arc, Mutex},
+    time::{Duration as StdDuration, Instant},
+};
 use tower_http::cors::CorsLayer;
 use tracing::info;
+
+/// Maximum number of requests allowed during the [`RATE_PERIOD`].
+const MAX_REQUESTS: u64 = 60;
+/// Duration for the rate limiting window.
+const RATE_PERIOD: StdDuration = StdDuration::from_secs(60);
+
+#[derive(Clone, Debug)]
+struct RateLimiter {
+    state: Arc<Mutex<LimiterState>>,
+    capacity: u64,
+    period: StdDuration,
+}
+
+#[derive(Debug)]
+struct LimiterState {
+    count: u64,
+    reset_at: Instant,
+}
+
+impl RateLimiter {
+    fn new(capacity: u64, period: StdDuration) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(LimiterState {
+                count: 0,
+                reset_at: Instant::now() + period,
+            })),
+            capacity,
+            period,
+        }
+    }
+
+    fn try_acquire(&self) -> bool {
+        let mut state = self.state.lock().expect("lock poisoned");
+        let now = Instant::now();
+        if now >= state.reset_at {
+            state.reset_at = now + self.period;
+            state.count = 0;
+        }
+        if state.count < self.capacity {
+            state.count += 1;
+            true
+        } else {
+            false
+        }
+    }
+}
 
 #[derive(Clone, Debug)]
 struct ApiState {
     client: ClickhouseClient,
+    limiter: RateLimiter,
 }
 
 impl ApiState {
-    const fn new(client: ClickhouseClient) -> Self {
-        Self { client }
+    fn new(client: ClickhouseClient) -> Self {
+        Self { client, limiter: RateLimiter::new(MAX_REQUESTS, RATE_PERIOD) }
     }
 }
 
@@ -68,7 +119,7 @@ async fn l1_head(State(state): State<ApiState>) -> Json<L1HeadResponse> {
 }
 
 async fn slashing_last_hour(State(state): State<ApiState>) -> Json<SlashingEventsResponse> {
-    let since = Utc::now() - Duration::hours(1);
+    let since = Utc::now() - ChronoDuration::hours(1);
     let events = match state.client.get_slashing_events_since(since).await {
         Ok(evts) => evts,
         Err(e) => {
@@ -90,6 +141,18 @@ async fn avg_prove_time(State(state): State<ApiState>) -> Json<AvgProveTimeRespo
     Json(AvgProveTimeResponse { avg_prove_time_ms: avg })
 }
 
+async fn rate_limit(
+    State(state): State<ApiState>,
+    req: axum::http::Request<axum::body::Body>,
+    next: middleware::Next,
+) -> axum::response::Response {
+    if state.limiter.try_acquire() {
+        next.run(req).await
+    } else {
+        axum::http::StatusCode::TOO_MANY_REQUESTS.into_response()
+    }
+}
+
 /// Run the API server on the given address
 pub async fn run(addr: SocketAddr, client: ClickhouseClient) -> Result<()> {
     let state = ApiState::new(client);
@@ -98,6 +161,7 @@ pub async fn run(addr: SocketAddr, client: ClickhouseClient) -> Result<()> {
         .route("/l1-head", get(l1_head))
         .route("/slashings/last-hour", get(slashing_last_hour))
         .route("/avg-prove-time", get(avg_prove_time))
+        .layer(middleware::from_fn_with_state(state.clone(), rate_limit))
         .with_state(state)
         .layer(CorsLayer::permissive());
 

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -44,23 +44,21 @@ impl RateLimiter {
         }
     }
 
-
-fn try_acquire(&self) -> bool {
-    let mut state = self.state.lock().expect("lock poisoned");
-    let now = Instant::now();
-    if now >= state.reset_at {
-        state.reset_at = now + self.period;
-        state.count = 1;  // Start at 1 for this request
-        return true;
+    fn try_acquire(&self) -> bool {
+        let mut state = self.state.lock().expect("lock poisoned");
+        let now = Instant::now();
+        if now >= state.reset_at {
+            state.reset_at = now + self.period;
+            state.count = 1; // Start at 1 for this request
+            return true;
+        }
+        if state.count < self.capacity {
+            state.count += 1;
+            true
+        } else {
+            false
+        }
     }
-    if state.count < self.capacity {
-        state.count += 1;
-        true
-    } else {
-        false
-    }
-}
-
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
## Summary
- implement a naive in-memory rate limiter to throttle API requests

## Testing
- `just lint`
- `just test`
