### PR TITLE
Add dev-api docs

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -2,6 +2,7 @@
 
 ## Build & Test Commands
 - Build & run: `just dev` (with dev.env file) or `cargo run`
+- API server: `just dev-api` or `cargo run --bin api-server`
 - Run tests: `just test` or `cargo nextest run --workspace --all-targets`
 - Run single test: `cargo nextest run <test_name>` or `cargo test <test_name>`
 - Linting: `just lint` or `cargo clippy --examples --tests --benches --all-features`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,7 @@
 
 ## Build & Test Commands
 - Build & run: `just dev` (with dev.env file) or `cargo run`
+- API server: `just dev-api` or `cargo run --bin api-server`
 - Run tests: `just test` or `cargo nextest run --workspace --all-targets`
 - Run single test: `cargo nextest run <test_name>` or `cargo test <test_name>`
 - Linting: `just lint` or `cargo clippy --examples --tests --benches --all-features`

--- a/README.md
+++ b/README.md
@@ -14,9 +14,14 @@ Taikoscope is a unified dashboard developed by Chainbound to provide real-time, 
 
 ## Deploy
 
-Run locally
+Run engine locally
 ```
 just dev
+just dev-api
+```
+
+Run API server locally
+```
 just dev-api
 ```
 


### PR DESCRIPTION
## Summary
- document how to run API server locally in READMEs
- add `dev-api` recipe to run API server via just

## Testing
- `just lint`
- `just test`
- `just ci`
