### PR TITLE
Extract rate limiter to primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -733,6 +733,7 @@ dependencies = [
  "chrono",
  "clickhouse 0.1.0",
  "eyre",
+ "primitives",
  "serde",
  "serde_json",
  "tokio",

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -16,6 +16,7 @@ serde.workspace = true
 serde_json.workspace = true
 chrono.workspace = true
 tower-http.workspace = true
+primitives = { path = "../primitives" }
 
 [lints]
 workspace = true

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -6,11 +6,9 @@ use axum::{Json, Router, extract::State, middleware, response::IntoResponse, rou
 use chrono::{Duration as ChronoDuration, Utc};
 use clickhouse::ClickhouseClient;
 use eyre::Result;
+use primitives::rate_limiter::RateLimiter;
 use serde::Serialize;
-use std::{
-    sync::{Arc, Mutex},
-    time::{Duration as StdDuration, Instant},
-};
+use std::time::Duration as StdDuration;
 use tower_http::cors::CorsLayer;
 use tracing::info;
 
@@ -18,48 +16,6 @@ use tracing::info;
 const MAX_REQUESTS: u64 = 60;
 /// Duration for the rate limiting window.
 const RATE_PERIOD: StdDuration = StdDuration::from_secs(60);
-
-#[derive(Clone, Debug)]
-struct RateLimiter {
-    state: Arc<Mutex<LimiterState>>,
-    capacity: u64,
-    period: StdDuration,
-}
-
-#[derive(Debug)]
-struct LimiterState {
-    count: u64,
-    reset_at: Instant,
-}
-
-impl RateLimiter {
-    fn new(capacity: u64, period: StdDuration) -> Self {
-        Self {
-            state: Arc::new(Mutex::new(LimiterState {
-                count: 0,
-                reset_at: Instant::now() + period,
-            })),
-            capacity,
-            period,
-        }
-    }
-
-    fn try_acquire(&self) -> bool {
-        let mut state = self.state.lock().expect("lock poisoned");
-        let now = Instant::now();
-        if now >= state.reset_at {
-            state.reset_at = now + self.period;
-            state.count = 1; // Start at 1 for this request
-            return true;
-        }
-        if state.count < self.capacity {
-            state.count += 1;
-            true
-        } else {
-            false
-        }
-    }
-}
 
 #[derive(Clone, Debug)]
 struct ApiState {
@@ -139,7 +95,7 @@ async fn slashing_last_hour(State(state): State<ApiState>) -> Json<SlashingEvent
 async fn forced_inclusions_last_hour(
     State(state): State<ApiState>,
 ) -> Json<ForcedInclusionEventsResponse> {
-    let since = Utc::now() - Duration::hours(1);
+    let since = Utc::now() - ChronoDuration::hours(1);
     let events = match state.client.get_forced_inclusions_since(since).await {
         Ok(evts) => evts,
         Err(e) => {

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -1,6 +1,8 @@
 //! Primitives for the taikoscope.
 /// Hardware cost estimates
 pub mod hardware;
+/// Simple rate limiter
+pub mod rate_limiter;
 /// Retry layer
 pub mod retries;
 /// Shutdown handling

--- a/crates/primitives/src/rate_limiter.rs
+++ b/crates/primitives/src/rate_limiter.rs
@@ -1,0 +1,98 @@
+use std::{
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
+};
+
+/// A simple fixed window rate limiter.
+#[derive(Clone, Debug)]
+pub struct RateLimiter {
+    state: Arc<Mutex<LimiterState>>,
+    capacity: u64,
+    period: Duration,
+}
+
+#[derive(Debug)]
+struct LimiterState {
+    count: u64,
+    reset_at: Instant,
+}
+
+impl RateLimiter {
+    /// Create a new [`RateLimiter`] with the given `capacity` and `period`.
+    pub fn new(capacity: u64, period: Duration) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(LimiterState {
+                count: 0,
+                reset_at: Instant::now() + period,
+            })),
+            capacity,
+            period,
+        }
+    }
+
+    /// Attempt to acquire a permit.
+    pub fn try_acquire(&self) -> bool {
+        let mut state = self.state.lock().expect("lock poisoned");
+        let now = Instant::now();
+        if now >= state.reset_at {
+            state.reset_at = now + self.period;
+            state.count = 1;
+            true
+        } else if state.count < self.capacity {
+            state.count += 1;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RateLimiter;
+    use std::{
+        sync::{
+            Arc,
+            atomic::{AtomicU64, Ordering},
+        },
+        time::Duration,
+    };
+    use tokio::time::sleep;
+
+    #[tokio::test]
+    async fn denies_when_over_capacity() {
+        let limiter = RateLimiter::new(2, Duration::from_millis(50));
+        assert!(limiter.try_acquire());
+        assert!(limiter.try_acquire());
+        assert!(!limiter.try_acquire());
+    }
+
+    #[tokio::test]
+    async fn resets_after_period() {
+        let limiter = RateLimiter::new(1, Duration::from_millis(10));
+        assert!(limiter.try_acquire());
+        assert!(!limiter.try_acquire());
+        sleep(Duration::from_millis(15)).await;
+        assert!(limiter.try_acquire());
+    }
+
+    #[tokio::test]
+    async fn concurrency_respects_capacity() {
+        let limiter = Arc::new(RateLimiter::new(5, Duration::from_secs(1)));
+        let success = Arc::new(AtomicU64::new(0));
+        let mut handles = Vec::new();
+        for _ in 0..10 {
+            let l = Arc::clone(&limiter);
+            let s = Arc::clone(&success);
+            handles.push(tokio::spawn(async move {
+                if l.try_acquire() {
+                    s.fetch_add(1, Ordering::SeqCst);
+                }
+            }));
+        }
+        for handle in handles {
+            handle.await.unwrap();
+        }
+        assert_eq!(success.load(Ordering::SeqCst), 5);
+    }
+}


### PR DESCRIPTION
## Notes
- moved API rate limiter into `primitives` crate
- added tests for limiter behaviour and concurrency
- updated API to use the shared limiter

## Testing
- `just fmt`
- `just lint`
- `just test`
