### PR TITLE
Add avg verify time API

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -98,6 +98,11 @@ struct AvgProveTimeResponse {
     avg_prove_time_ms: Option<u64>,
 }
 
+#[derive(Serialize)]
+struct AvgVerifyTimeResponse {
+    avg_verify_time_ms: Option<u64>,
+}
+
 async fn l2_head(State(state): State<ApiState>) -> Json<L2HeadResponse> {
     let ts = match state.client.get_last_l2_head_time().await {
         Ok(time) => time,
@@ -139,7 +144,7 @@ async fn slashing_last_hour(State(state): State<ApiState>) -> Json<SlashingEvent
 async fn forced_inclusions_last_hour(
     State(state): State<ApiState>,
 ) -> Json<ForcedInclusionEventsResponse> {
-    let since = Utc::now() - Duration::hours(1);
+    let since = Utc::now() - ChronoDuration::hours(1);
     let events = match state.client.get_forced_inclusions_since(since).await {
         Ok(evts) => evts,
         Err(e) => {
@@ -159,6 +164,17 @@ async fn avg_prove_time(State(state): State<ApiState>) -> Json<AvgProveTimeRespo
         }
     };
     Json(AvgProveTimeResponse { avg_prove_time_ms: avg })
+}
+
+async fn avg_verify_time(State(state): State<ApiState>) -> Json<AvgVerifyTimeResponse> {
+    let avg = match state.client.get_avg_verify_time_last_hour().await {
+        Ok(val) => val,
+        Err(e) => {
+            tracing::error!("Failed to get avg verify time: {}", e);
+            None
+        }
+    };
+    Json(AvgVerifyTimeResponse { avg_verify_time_ms: avg })
 }
 
 async fn rate_limit(
@@ -182,6 +198,7 @@ pub async fn run(addr: SocketAddr, client: ClickhouseClient) -> Result<()> {
         .route("/slashings/last-hour", get(slashing_last_hour))
         .route("/forced-inclusions/last-hour", get(forced_inclusions_last_hour))
         .route("/avg-prove-time", get(avg_prove_time))
+        .route("/avg-verify-time", get(avg_verify_time))
         .layer(middleware::from_fn_with_state(state.clone(), rate_limit))
         .with_state(state)
         .layer(CorsLayer::permissive());

--- a/crates/clickhouse/src/lib.rs
+++ b/crates/clickhouse/src/lib.rs
@@ -738,6 +738,34 @@ impl ClickhouseClient {
 
         Ok(row.avg_ms.map(|ms| ms.round() as u64))
     }
+
+    /// Get the average time in milliseconds it takes for a batch to be verified
+    /// for verifications submitted within the last hour.
+    pub async fn get_avg_verify_time_last_hour(&self) -> Result<Option<u64>> {
+        #[derive(Row, Deserialize)]
+        struct AvgRow {
+            avg_ms: Option<f64>,
+        }
+
+        let client = self.base.clone().with_database(&self.db_name);
+        let query = format!(
+            "SELECT avg(toUnixTimestamp64Milli(v.inserted_at) - \
+                    toUnixTimestamp64Milli(p.inserted_at)) AS avg_ms \
+             FROM {db}.verified_batches v \
+             INNER JOIN {db}.proved_batches p \
+             ON v.l1_block_number = p.l1_block_number AND v.batch_id = p.batch_id \
+             WHERE v.inserted_at >= now64() - INTERVAL 1 HOUR",
+            db = self.db_name
+        );
+
+        let rows = client.query(&query).fetch_all::<AvgRow>().await?;
+        let row = match rows.into_iter().next() {
+            Some(r) => r,
+            None => return Ok(None),
+        };
+
+        Ok(row.avg_ms.map(|ms| ms.round() as u64))
+    }
 }
 
 #[cfg(test)]
@@ -1324,6 +1352,43 @@ mod tests {
         .unwrap();
 
         let result = client.get_avg_prove_time_last_hour().await.unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[tokio::test]
+    async fn test_get_avg_verify_time_last_hour() {
+        let mock = Mock::new();
+        let expected = 2500.0f64;
+        mock.add(handlers::provide(vec![AvgRowTest { avg_ms: Some(expected) }]));
+
+        let url = Url::parse(mock.url()).unwrap();
+        let client = ClickhouseClient::new(
+            url,
+            "test-db".to_owned(),
+            "test_user".to_owned(),
+            "test_pass".to_owned(),
+        )
+        .unwrap();
+
+        let result = client.get_avg_verify_time_last_hour().await.unwrap();
+        assert_eq!(result, Some(expected.round() as u64));
+    }
+
+    #[tokio::test]
+    async fn test_get_avg_verify_time_last_hour_empty() {
+        let mock = Mock::new();
+        mock.add(handlers::provide(Vec::<AvgRowTest>::new()));
+
+        let url = Url::parse(mock.url()).unwrap();
+        let client = ClickhouseClient::new(
+            url,
+            "test-db".to_owned(),
+            "test_user".to_owned(),
+            "test_pass".to_owned(),
+        )
+        .unwrap();
+
+        let result = client.get_avg_verify_time_last_hour().await.unwrap();
         assert_eq!(result, None);
     }
 }


### PR DESCRIPTION
## Summary
- expose average batch verification time
- add API endpoint `GET /avg-verify-time`
- test clickhouse average verification time query

## Testing
- `just ci`
