### PR TITLE
Add reorgs and active gateways API endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -733,6 +733,7 @@ dependencies = [
  "chrono",
  "clickhouse 0.1.0",
  "eyre",
+ "hex",
  "primitives",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ tokio-stream = "0.1.17"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter", "fmt"] }
 url = { version = "2.5.4", features = ["serde"] }
+hex = "0.4"
 axum = { version = "0.7.5", features = ["json"] }
 tower-http = { version = "0.5.2", features = ["cors"] }
 

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -12,6 +12,7 @@ primitives = { path = "../primitives" }
 axum.workspace = true
 chrono.workspace = true
 eyre.workspace = true
+hex.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 serde.workspace = true

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -6,6 +6,7 @@ use axum::{Json, Router, extract::State, middleware, response::IntoResponse, rou
 use chrono::{Duration as ChronoDuration, Utc};
 use clickhouse::ClickhouseClient;
 use eyre::Result;
+use hex::encode;
 use primitives::rate_limiter::RateLimiter;
 use serde::Serialize;
 use std::time::Duration as StdDuration;
@@ -47,6 +48,16 @@ struct SlashingEventsResponse {
 #[derive(Serialize)]
 struct ForcedInclusionEventsResponse {
     events: Vec<clickhouse::ForcedInclusionProcessedRow>,
+}
+
+#[derive(Serialize)]
+struct ReorgEventsResponse {
+    events: Vec<clickhouse::L2ReorgRow>,
+}
+
+#[derive(Serialize)]
+struct ActiveGatewaysResponse {
+    gateways: Vec<String>,
 }
 
 #[derive(Serialize)]
@@ -111,6 +122,31 @@ async fn forced_inclusions_last_hour(
     Json(ForcedInclusionEventsResponse { events })
 }
 
+async fn reorgs_last_hour(State(state): State<ApiState>) -> Json<ReorgEventsResponse> {
+    let since = Utc::now() - ChronoDuration::hours(1);
+    let events = match state.client.get_l2_reorgs_since(since).await {
+        Ok(evts) => evts,
+        Err(e) => {
+            tracing::error!("Failed to get reorg events: {}", e);
+            Vec::new()
+        }
+    };
+    Json(ReorgEventsResponse { events })
+}
+
+async fn active_gateways_last_hour(State(state): State<ApiState>) -> Json<ActiveGatewaysResponse> {
+    let since = Utc::now() - ChronoDuration::hours(1);
+    let gateways = match state.client.get_active_gateways_since(since).await {
+        Ok(g) => g,
+        Err(e) => {
+            tracing::error!("Failed to get active gateways: {}", e);
+            Vec::new()
+        }
+    };
+    let gateways = gateways.into_iter().map(|a| format!("0x{}", encode(a))).collect();
+    Json(ActiveGatewaysResponse { gateways })
+}
+
 async fn avg_prove_time(State(state): State<ApiState>) -> Json<AvgProveTimeResponse> {
     let avg = match state.client.get_avg_prove_time_last_hour().await {
         Ok(val) => val,
@@ -153,6 +189,8 @@ pub async fn run(addr: SocketAddr, client: ClickhouseClient) -> Result<()> {
         .route("/l1-head", get(l1_head))
         .route("/slashings/last-hour", get(slashing_last_hour))
         .route("/forced-inclusions/last-hour", get(forced_inclusions_last_hour))
+        .route("/reorgs/last-hour", get(reorgs_last_hour))
+        .route("/active-gateways/last-hour", get(active_gateways_last_hour))
         .route("/avg-prove-time", get(avg_prove_time))
         .route("/avg-verify-time", get(avg_verify_time))
         .layer(middleware::from_fn_with_state(state.clone(), rate_limit))


### PR DESCRIPTION
## Summary
- expose new clickhouse queries for reorgs and active gateways
- add `/reorgs/last-hour` and `/active-gateways/last-hour` API routes
- pull in `hex` crate for address formatting

## Testing
- `just lint`
- `just test`
- `just ci`
