### PR TITLE
Add HTTP API tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -732,13 +732,16 @@ dependencies = [
  "axum",
  "chrono",
  "clickhouse 0.1.0",
+ "clickhouse 0.13.2",
  "eyre",
  "primitives",
  "serde",
  "serde_json",
  "tokio",
+ "tower",
  "tower-http",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ tracing-subscriber = { version = "0.3.19", features = ["env-filter", "fmt"] }
 url = { version = "2.5.4", features = ["serde"] }
 axum = { version = "0.7.5", features = ["json"] }
 tower-http = { version = "0.5.2", features = ["cors"] }
+tower = "0.5.2"
 
 [workspace.lints]
 rust.missing_debug_implementations = "warn"

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-clickhouse = { path = "../clickhouse" }
+clickhouse_lib = { path = "../clickhouse", package = "clickhouse" }
 primitives = { path = "../primitives" }
 
 axum.workspace = true
@@ -17,6 +17,11 @@ tracing.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tower-http.workspace = true
+
+[dev-dependencies]
+tower = "0.5"
+url.workspace = true
+clickhouse = { package = "clickhouse", version = "0.13.2", features = ["native-tls", "test-util"] }
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary
- add tower and external clickhouse dev deps
- alias internal clickhouse crate
- add API integration tests for all HTTP endpoints

## Testing
- `just lint`
- `just test`