### PR TITLE
Skip Rust CI for dashboard changes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,11 @@ on:
     branches:
       - unstable
       - main
+    paths-ignore:
+      - 'dashboard/**'
   pull_request:
+    paths-ignore:
+      - 'dashboard/**'
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -5,7 +5,11 @@ on:
     branches:
       - unstable
       - main
+    paths-ignore:
+      - 'dashboard/**'
   pull_request:
+    paths-ignore:
+      - 'dashboard/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
## Summary
- skip Rust lint and unit workflows when changing only the `dashboard` folder

## Testing
- `just ci`