### PR TITLE
Add dashboard CI workflow

### DIFF
--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -1,0 +1,30 @@
+name: Dashboard CI
+
+on:
+  push:
+    branches:
+      - unstable
+      - main
+    paths:
+      - 'dashboard/**'
+  pull_request:
+    paths:
+      - 'dashboard/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: dashboard/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+        working-directory: dashboard
+      - name: Build dashboard
+        run: npm run build
+        working-directory: dashboard


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build the dashboard only when files in the `dashboard` directory change

## Testing
- `just ci`