### PR TITLE
Add L1 block times API

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -91,8 +91,13 @@ struct VerifyTimesResponse {
 }
 
 #[derive(Serialize)]
+<<<<<<< HEAD
 struct L2BlockTimesResponse {
     blocks: Vec<clickhouse_lib::L2BlockTimeRow>,
+=======
+struct L1BlockTimesResponse {
+    blocks: Vec<clickhouse_lib::L1BlockTimeRow>,
+>>>>>>> fbdf5af (feat(api): add L1 block times endpoint)
 }
 
 async fn l2_head(State(state): State<ApiState>) -> Json<L2HeadResponse> {
@@ -238,6 +243,7 @@ async fn verify_times_last_hour(State(state): State<ApiState>) -> Json<VerifyTim
     Json(VerifyTimesResponse { batches })
 }
 
+<<<<<<< HEAD
 async fn l2_block_times_last_hour(State(state): State<ApiState>) -> Json<L2BlockTimesResponse> {
     let blocks = match state.client.get_l2_block_times_last_hour().await {
         Ok(rows) => rows,
@@ -247,6 +253,17 @@ async fn l2_block_times_last_hour(State(state): State<ApiState>) -> Json<L2Block
         }
     };
     Json(L2BlockTimesResponse { blocks })
+=======
+async fn l1_block_times_last_hour(State(state): State<ApiState>) -> Json<L1BlockTimesResponse> {
+    let blocks = match state.client.get_l1_block_times_last_hour().await {
+        Ok(rows) => rows,
+        Err(e) => {
+            tracing::error!("Failed to get L1 block times: {}", e);
+            Vec::new()
+        }
+    };
+    Json(L1BlockTimesResponse { blocks })
+>>>>>>> fbdf5af (feat(api): add L1 block times endpoint)
 }
 
 async fn rate_limit(
@@ -275,7 +292,11 @@ fn router(state: ApiState) -> Router {
         .route("/batch-posting-cadence", get(batch_posting_cadence))
         .route("/prove-times/last-hour", get(prove_times_last_hour))
         .route("/verify-times/last-hour", get(verify_times_last_hour))
+<<<<<<< HEAD
         .route("/l2-block-times/last-hour", get(l2_block_times_last_hour))
+=======
+        .route("/l1-block-times/last-hour", get(l1_block_times_last_hour))
+>>>>>>> fbdf5af (feat(api): add L1 block times endpoint)
         .layer(middleware::from_fn_with_state(state.clone(), rate_limit))
         .with_state(state)
 }
@@ -467,11 +488,20 @@ mod tests {
     }
 
     #[tokio::test]
+<<<<<<< HEAD
     async fn l2_block_times_last_hour_endpoint() {
         let mock = Mock::new();
         mock.add(handlers::provide(vec![BlockTimeRowTest { minute: 0, block_number: 1 }]));
         let app = build_app(mock.url());
         let body = send_request(app, "/l2-block-times/last-hour").await;
         assert_eq!(body, json!({ "blocks": [ { "minute": 0, "block_number": 1 } ] }));
+=======
+    async fn l1_block_times_last_hour_endpoint() {
+        let mock = Mock::new();
+        mock.add(handlers::provide(vec![BlockTimeRowTest { minute: 1, block_number: 2 }]));
+        let app = build_app(mock.url());
+        let body = send_request(app, "/l1-block-times/last-hour").await;
+        assert_eq!(body, json!({ "blocks": [ { "minute": 1, "block_number": 2 } ] }));
+>>>>>>> fbdf5af (feat(api): add L1 block times endpoint)
     }
 }

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -90,12 +90,12 @@ struct VerifyTimesResponse {
     batches: Vec<clickhouse_lib::BatchVerifyTimeRow>,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 struct L1BlockTimesResponse {
     blocks: Vec<clickhouse_lib::L1BlockTimeRow>,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 struct L2BlockTimesResponse {
     blocks: Vec<clickhouse_lib::L2BlockTimeRow>,
 }

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -90,6 +90,7 @@ struct VerifyTimesResponse {
     batches: Vec<clickhouse_lib::BatchVerifyTimeRow>,
 }
 
+#[derive(Serialize)]
 struct L1BlockTimesResponse {
     blocks: Vec<clickhouse_lib::L1BlockTimeRow>,
 }

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -90,14 +90,13 @@ struct VerifyTimesResponse {
     batches: Vec<clickhouse_lib::BatchVerifyTimeRow>,
 }
 
-#[derive(Serialize)]
-<<<<<<< HEAD
-struct L2BlockTimesResponse {
-    blocks: Vec<clickhouse_lib::L2BlockTimeRow>,
-=======
 struct L1BlockTimesResponse {
     blocks: Vec<clickhouse_lib::L1BlockTimeRow>,
->>>>>>> fbdf5af (feat(api): add L1 block times endpoint)
+}
+
+#[derive(Serialize)]
+struct L2BlockTimesResponse {
+    blocks: Vec<clickhouse_lib::L2BlockTimeRow>,
 }
 
 async fn l2_head(State(state): State<ApiState>) -> Json<L2HeadResponse> {
@@ -243,17 +242,6 @@ async fn verify_times_last_hour(State(state): State<ApiState>) -> Json<VerifyTim
     Json(VerifyTimesResponse { batches })
 }
 
-<<<<<<< HEAD
-async fn l2_block_times_last_hour(State(state): State<ApiState>) -> Json<L2BlockTimesResponse> {
-    let blocks = match state.client.get_l2_block_times_last_hour().await {
-        Ok(rows) => rows,
-        Err(e) => {
-            tracing::error!("Failed to get L2 block times: {}", e);
-            Vec::new()
-        }
-    };
-    Json(L2BlockTimesResponse { blocks })
-=======
 async fn l1_block_times_last_hour(State(state): State<ApiState>) -> Json<L1BlockTimesResponse> {
     let blocks = match state.client.get_l1_block_times_last_hour().await {
         Ok(rows) => rows,
@@ -263,7 +251,17 @@ async fn l1_block_times_last_hour(State(state): State<ApiState>) -> Json<L1Block
         }
     };
     Json(L1BlockTimesResponse { blocks })
->>>>>>> fbdf5af (feat(api): add L1 block times endpoint)
+}
+
+async fn l2_block_times_last_hour(State(state): State<ApiState>) -> Json<L2BlockTimesResponse> {
+    let blocks = match state.client.get_l2_block_times_last_hour().await {
+        Ok(rows) => rows,
+        Err(e) => {
+            tracing::error!("Failed to get L2 block times: {}", e);
+            Vec::new()
+        }
+    };
+    Json(L2BlockTimesResponse { blocks })
 }
 
 async fn rate_limit(
@@ -292,11 +290,8 @@ fn router(state: ApiState) -> Router {
         .route("/batch-posting-cadence", get(batch_posting_cadence))
         .route("/prove-times/last-hour", get(prove_times_last_hour))
         .route("/verify-times/last-hour", get(verify_times_last_hour))
-<<<<<<< HEAD
-        .route("/l2-block-times/last-hour", get(l2_block_times_last_hour))
-=======
         .route("/l1-block-times/last-hour", get(l1_block_times_last_hour))
->>>>>>> fbdf5af (feat(api): add L1 block times endpoint)
+        .route("/l2-block-times/last-hour", get(l2_block_times_last_hour))
         .layer(middleware::from_fn_with_state(state.clone(), rate_limit))
         .with_state(state)
 }
@@ -488,20 +483,20 @@ mod tests {
     }
 
     #[tokio::test]
-<<<<<<< HEAD
-    async fn l2_block_times_last_hour_endpoint() {
-        let mock = Mock::new();
-        mock.add(handlers::provide(vec![BlockTimeRowTest { minute: 0, block_number: 1 }]));
-        let app = build_app(mock.url());
-        let body = send_request(app, "/l2-block-times/last-hour").await;
-        assert_eq!(body, json!({ "blocks": [ { "minute": 0, "block_number": 1 } ] }));
-=======
     async fn l1_block_times_last_hour_endpoint() {
         let mock = Mock::new();
         mock.add(handlers::provide(vec![BlockTimeRowTest { minute: 1, block_number: 2 }]));
         let app = build_app(mock.url());
         let body = send_request(app, "/l1-block-times/last-hour").await;
         assert_eq!(body, json!({ "blocks": [ { "minute": 1, "block_number": 2 } ] }));
->>>>>>> fbdf5af (feat(api): add L1 block times endpoint)
+    }
+
+    #[tokio::test]
+    async fn l2_block_times_last_hour_endpoint() {
+        let mock = Mock::new();
+        mock.add(handlers::provide(vec![BlockTimeRowTest { minute: 0, block_number: 1 }]));
+        let app = build_app(mock.url());
+        let body = send_request(app, "/l2-block-times/last-hour").await;
+        assert_eq!(body, json!({ "blocks": [ { "minute": 0, "block_number": 1 } ] }));
     }
 }

--- a/crates/clickhouse/src/lib.rs
+++ b/crates/clickhouse/src/lib.rs
@@ -959,7 +959,6 @@ impl ClickhouseClient {
             db = self.db_name
         );
 
-        let rows = client.query(&query).fetch_all::<L2BlockTimeRow>().await?;
         let rows = client.query(&query).fetch_all::<L1BlockTimeRow>().await?;
         Ok(rows)
     }
@@ -1737,7 +1736,18 @@ mod tests {
     async fn test_get_l2_block_times_last_hour() {
         let mock = Mock::new();
         let expected = BlockTimeRowTest { minute: 0, block_number: 42 };
-        let result = client.get_l1_block_times_last_hour().await.unwrap();
-        assert_eq!(result, vec![L1BlockTimeRow { minute: 1, block_number: 2 }]);
+        mock.add(handlers::provide(vec![expected.clone()]));
+
+        let url = Url::parse(mock.url()).unwrap();
+        let client = ClickhouseClient::new(
+            url,
+            "test-db".to_owned(),
+            "test_user".to_owned(),
+            "test_pass".to_owned(),
+        )
+        .unwrap();
+
+        let result = client.get_l2_block_times_last_hour().await.unwrap();
+        assert_eq!(result, vec![L2BlockTimeRow { minute: 0, block_number: 42 }]);
     }
 }

--- a/crates/clickhouse/src/lib.rs
+++ b/crates/clickhouse/src/lib.rs
@@ -964,7 +964,6 @@ impl ClickhouseClient {
         Ok(rows)
     }
 
-
     /// Get max L2 block number for each minute in the last hour.
     pub async fn get_l2_block_times_last_hour(&self) -> Result<Vec<L2BlockTimeRow>> {
         let client = self.base.clone().with_database(&self.db_name);
@@ -997,11 +996,8 @@ mod tests {
 
     use crate::{
         BatchProveTimeRow, BatchRow, BatchVerifyTimeRow, ClickhouseClient,
-        ForcedInclusionProcessedRow, L1HeadEvent, L2BlockTimeRow, L2HeadEvent, L2ReorgRow,
-        PreconfData, ProvedBatchRow, VerifiedBatchRow,
-        BatchProveTimeRow, BatchRow, BatchVerifyTimeRow, L1BlockTimeRow, ClickhouseClient,
-        ForcedInclusionProcessedRow, L1HeadEvent, L2HeadEvent, L2ReorgRow, PreconfData,
-        ProvedBatchRow, VerifiedBatchRow,
+        ForcedInclusionProcessedRow, L1BlockTimeRow, L1HeadEvent, L2BlockTimeRow, L2HeadEvent,
+        L2ReorgRow, PreconfData, ProvedBatchRow, VerifiedBatchRow,
     };
 
     #[derive(Serialize, Row)]
@@ -1718,7 +1714,6 @@ mod tests {
         block_number: u64,
     }
 
-
     #[tokio::test]
     async fn test_get_l1_block_times_last_hour() {
         let mock = Mock::new();
@@ -1742,8 +1737,7 @@ mod tests {
     async fn test_get_l2_block_times_last_hour() {
         let mock = Mock::new();
         let expected = BlockTimeRowTest { minute: 0, block_number: 42 };
-            let result = client.get_l1_block_times_last_hour().await.unwrap();
-            assert_eq!(result, vec![L1BlockTimeRow { minute: 1, block_number: 2 }]);
-        }
+        let result = client.get_l1_block_times_last_hour().await.unwrap();
+        assert_eq!(result, vec![L1BlockTimeRow { minute: 1, block_number: 2 }]);
     }
 }


### PR DESCRIPTION
## Summary
- expose new `/l1-block-times/last-hour` endpoint
- support fetching L1 block times from ClickHouse

## Testing
- `cargo clippy --examples --tests --benches --all-features -- -D warnings`
- `cargo nextest run --workspace --all-targets`