### PR TITLE
Implement missed slot tracking

### DIFF
--- a/crates/clickhouse/migrations/001_create_tables.sql
+++ b/crates/clickhouse/migrations/001_create_tables.sql
@@ -77,3 +77,11 @@ CREATE TABLE IF NOT EXISTS ${DB}.slashing_events (
     inserted_at DateTime64(3) DEFAULT now64()
 ) ENGINE = MergeTree()
 ORDER BY (l1_block_number, validator_addr);
+
+CREATE TABLE IF NOT EXISTS ${DB}.missed_slots (
+    sequencer_addr FixedString(20),
+    slot UInt64,
+    l1_block_number UInt64,
+    inserted_at DateTime64(3) DEFAULT now64()
+) ENGINE = MergeTree()
+ORDER BY (slot, sequencer_addr);

--- a/crates/clickhouse/src/models.rs
+++ b/crates/clickhouse/src/models.rs
@@ -116,3 +116,14 @@ pub struct SlashingEventRow {
     /// Address of the validator that was slashed
     pub validator_addr: [u8; 20],
 }
+
+/// Missed slot event row
+#[derive(Debug, Row, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MissedSlotRow {
+    /// Address of the sequencer expected for the slot
+    pub sequencer_addr: [u8; 20],
+    /// Slot number that was missed
+    pub slot: u64,
+    /// L1 block number corresponding to the slot
+    pub l1_block_number: u64,
+}

--- a/crates/clickhouse/src/schema.rs
+++ b/crates/clickhouse/src/schema.rs
@@ -18,6 +18,7 @@ pub const TABLES: &[&str] = &[
     "forced_inclusion_processed",
     "verified_batches",
     "slashing_events",
+    "missed_slots",
 ];
 
 /// Schema definitions for tables
@@ -101,5 +102,13 @@ pub const TABLE_SCHEMAS: &[TableSchema] = &[
                  validator_addr FixedString(20),
                  inserted_at DateTime64(3) DEFAULT now64()",
         order_by: "l1_block_number, validator_addr",
+    },
+    TableSchema {
+        name: "missed_slots",
+        columns: "sequencer_addr FixedString(20),
+                 slot UInt64,
+                 l1_block_number UInt64,
+                 inserted_at DateTime64(3) DEFAULT now64()",
+        order_by: "slot, sequencer_addr",
     },
 ];


### PR DESCRIPTION
## Summary
- add `missed_slots` table schema and migration
- record missed slot proposals when gaps are detected
- expose `insert_missed_slot` in ClickHouse client
- track last batch slot in the driver
- adjust tests for new table

## Testing
- `just ci`