### PR TITLE
Improve is_retryable tests

### DIFF
--- a/crates/incident/src/retry.rs
+++ b/crates/incident/src/retry.rs
@@ -28,8 +28,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use eyre::Report;
     use mockito::Server;
     use reqwest::Client;
+    use std::time::Duration;
 
     #[tokio::test]
     async fn retries_when_error_is_retryable() {
@@ -65,5 +67,47 @@ mod tests {
 
         assert!(result.is_err());
         mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn is_retryable_returns_true_for_server_error() {
+        let mut server = Server::new_async().await;
+        let _mock = server.mock("GET", "/").with_status(500).create_async().await;
+
+        let client = Client::new();
+        let url = server.url();
+        let err = client.get(url).send().await.unwrap().error_for_status().unwrap_err();
+        assert!(super::is_retryable(&Report::from(err)));
+    }
+
+    #[tokio::test]
+    async fn is_retryable_returns_true_for_http_429() {
+        let mut server = Server::new_async().await;
+        let _mock = server.mock("GET", "/").with_status(429).create_async().await;
+
+        let client = Client::new();
+        let url = server.url();
+        let err = client.get(url).send().await.unwrap().error_for_status().unwrap_err();
+        assert!(super::is_retryable(&Report::from(err)));
+    }
+
+    #[tokio::test]
+    async fn is_retryable_returns_true_for_connect_error() {
+        let client = Client::builder().timeout(Duration::from_millis(100)).build().unwrap();
+
+        let err = client.get("http://127.0.0.1:9").send().await.unwrap_err();
+        assert!(err.is_connect());
+        assert!(super::is_retryable(&Report::from(err)));
+    }
+
+    #[tokio::test]
+    async fn is_retryable_returns_false_for_client_error() {
+        let mut server = Server::new_async().await;
+        let _mock = server.mock("GET", "/").with_status(404).create_async().await;
+
+        let client = Client::new();
+        let url = server.url();
+        let err = client.get(url).send().await.unwrap().error_for_status().unwrap_err();
+        assert!(!super::is_retryable(&Report::from(err)));
     }
 }

--- a/crates/primitives/src/retries.rs
+++ b/crates/primitives/src/retries.rs
@@ -220,4 +220,9 @@ mod tests {
         assert!(is_connection_refused("connection refused"));
         assert!(!is_connection_refused("other error"));
     }
+
+    #[test]
+    fn is_retryable_on_null_response() {
+        assert!(RpcError::<TransportErrorKind>::NullResp.is_retryable());
+    }
 }


### PR DESCRIPTION
## Summary
- add tests covering more reqwest error cases for `incident` retry helper
- test `NullResp` branch of `RpcErrorExt::is_retryable`

## Testing
- `just fmt`
- `just lint`
- `just test`