### PR TITLE
Add fallback for multiple RPC nodes

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -23,12 +23,22 @@ pub struct ClickhouseOpts {
 /// RPC endpoint configuration options
 #[derive(Debug, Clone, Parser)]
 pub struct RpcOpts {
-    /// L1 RPC URL
-    #[clap(long, env = "L1_RPC_URL")]
-    pub l1_url: Url,
-    /// L2 RPC URL
-    #[clap(long, env = "L2_RPC_URL")]
-    pub l2_url: Url,
+    /// L1 RPC URLs (comma separated or repeated)
+    #[clap(
+        long = "l1-url",
+        env = "L1_RPC_URL",
+        value_delimiter = ',',
+        num_args = 1..
+    )]
+    pub l1_urls: Vec<Url>,
+    /// L2 RPC URLs (comma separated or repeated)
+    #[clap(
+        long = "l2-url",
+        env = "L2_RPC_URL",
+        value_delimiter = ',',
+        num_args = 1..
+    )]
+    pub l2_urls: Vec<Url>,
 }
 
 /// Taiko contract address configuration options
@@ -179,6 +189,8 @@ mod tests {
         assert_eq!(opts.api.host, "127.0.0.1");
         assert_eq!(opts.api.port, 3000);
         assert!(!opts.reset_db);
+        assert_eq!(opts.rpc.l1_urls.len(), 1);
+        assert_eq!(opts.rpc.l2_urls.len(), 1);
     }
 
     #[test]
@@ -202,6 +214,8 @@ mod tests {
         assert_eq!(opts.api.host, "127.0.0.1");
         assert_eq!(opts.api.port, 3000);
         assert!(opts.reset_db);
+        assert_eq!(opts.rpc.l1_urls.len(), 1);
+        assert_eq!(opts.rpc.l2_urls.len(), 1);
 
         unsafe {
             env::remove_var("INSTATUS_MONITOR_POLL_INTERVAL_SECS");

--- a/crates/driver/src/lib.rs
+++ b/crates/driver/src/lib.rs
@@ -55,8 +55,8 @@ impl Driver {
 
         // init extractor
         let extractor = Extractor::new(
-            opts.rpc.l1_url,
-            opts.rpc.l2_url,
+            opts.rpc.l1_urls,
+            opts.rpc.l2_urls,
             opts.taiko_addresses.inbox_address,
             opts.taiko_addresses.preconf_whitelist_address,
             opts.taiko_addresses.taiko_wrapper_address,
@@ -517,7 +517,7 @@ mod tests {
                 username: "user".into(),
                 password: "pass".into(),
             },
-            rpc: RpcOpts { l1_url, l2_url },
+            rpc: RpcOpts { l1_urls: vec![l1_url], l2_urls: vec![l2_url] },
             api: ApiOpts { host: "127.0.0.1".into(), port: 3000 },
             taiko_addresses: TaikoAddressOpts {
                 inbox_address: Address::ZERO,

--- a/crates/extractor/tests/integration.rs
+++ b/crates/extractor/tests/integration.rs
@@ -41,8 +41,8 @@ async fn test_get_block_stream() -> Result<()> {
 
     // Create Extractor
     let ext = Extractor::new(
-        ws.clone(),
-        ws,
+        vec![ws.clone()],
+        vec![ws],
         address!("0xa7B208DE7F35E924D59C2b5f7dE3bb346E8A138C"),
         address!("0x3ea351Db28A9d4833Bf6c519F52766788DE14eC1"),
         address!("0x962C95233f04Ef08E7FaA84DBd1c5171f06f5616"),


### PR DESCRIPTION
## Summary
- accept multiple RPC URLs in config
- connect to any available node when subscribing
- update driver and tests for new Extractor API

## Testing
- `just ci`