### PR TITLE
Add test for 400 error in is_retryable

### DIFF
--- a/crates/incident/src/retry.rs
+++ b/crates/incident/src/retry.rs
@@ -110,4 +110,15 @@ mod tests {
         let err = client.get(url).send().await.unwrap().error_for_status().unwrap_err();
         assert!(!super::is_retryable(&Report::from(err)));
     }
+
+    #[tokio::test]
+    async fn is_retryable_returns_false_for_http_400() {
+        let mut server = Server::new_async().await;
+        let _mock = server.mock("GET", "/").with_status(400).create_async().await;
+
+        let client = Client::new();
+        let url = server.url();
+        let err = client.get(url).send().await.unwrap().error_for_status().unwrap_err();
+        assert!(!super::is_retryable(&Report::from(err)));
+    }
 }


### PR DESCRIPTION
## Summary
- add a regression test to ensure is_retryable returns false for HTTP 400

## Testing
- `cargo +nightly fmt --all`
- `cargo clippy --examples --tests --benches --all-features --locked`
- `cargo nextest run --workspace --all-targets`