### PR TITLE
Fix: Remove shadows from dashboard metric cards

### DIFF
--- a/dashboard/components/ChartCard.tsx
+++ b/dashboard/components/ChartCard.tsx
@@ -8,7 +8,7 @@ interface ChartCardProps {
 
 export const ChartCard: React.FC<ChartCardProps> = ({ title, children }) => {
   return (
-    <div className="bg-white p-4 md:p-6 rounded-lg shadow-md border border-gray-200">
+    <div className="bg-white p-4 md:p-6 rounded-lg border border-gray-200">
       <h3 className="text-lg font-semibold text-gray-700 mb-4">{title}</h3>
       <div className="h-64 md:h-80 w-full"> {/* Ensure chart has height */}
         {children}

--- a/dashboard/components/MetricCard.tsx
+++ b/dashboard/components/MetricCard.tsx
@@ -9,7 +9,7 @@ interface MetricCardProps {
 
 export const MetricCard: React.FC<MetricCardProps> = ({ title, value, description }) => {
   return (
-    <div className="bg-white p-4 rounded-lg shadow-md border border-gray-200 hover:shadow-lg transition-shadow duration-200">
+    <div className="bg-white p-4 rounded-lg border border-gray-200 transition-shadow duration-200">
       {/* Removed {unit && `(${unit})`} from here */}
       <h3 className="text-sm font-medium text-gray-500 truncate">{title}</h3>
       <p className="mt-1 text-3xl font-semibold text-gray-900">{value}</p>


### PR DESCRIPTION
Removes the `shadow-md` and `hover:shadow-lg` Tailwind CSS classes from the `MetricCard` and `ChartCard` components in the dashboard.

This change makes the design of these components flatter, as per the issue request.