### PR TITLE
Fix L2 block time queries

### DIFF
--- a/crates/clickhouse/src/lib.rs
+++ b/crates/clickhouse/src/lib.rs
@@ -1149,7 +1149,7 @@ impl ClickhouseClient {
     pub async fn get_l2_block_times_last_hour(&self) -> Result<Vec<L2BlockTimeRow>> {
         let client = self.base.clone().with_database(&self.db_name);
         let query = format!(
-            "SELECT toUInt64(toUnixTimestamp64Milli(toStartOfMinute(fromUnixTimestamp64Milli(block_ts * 1000)))) AS minute, \
+            "SELECT intDiv(block_ts, 60) * 60000 AS minute, \
                     max(l2_block_number) AS block_number \
              FROM {db}.l2_head_events \
              WHERE block_ts >= toUnixTimestamp(now64() - INTERVAL 1 HOUR) \
@@ -1166,7 +1166,7 @@ impl ClickhouseClient {
     pub async fn get_l2_block_times_last_24_hours(&self) -> Result<Vec<L2BlockTimeRow>> {
         let client = self.base.clone().with_database(&self.db_name);
         let query = format!(
-            "SELECT toUInt64(toUnixTimestamp64Milli(toStartOfMinute(fromUnixTimestamp64Milli(block_ts * 1000)))) AS minute, \
+            "SELECT intDiv(block_ts, 60) * 60000 AS minute, \
                     max(l2_block_number) AS block_number \
              FROM {db}.l2_head_events \
              WHERE block_ts >= toUnixTimestamp(now64() - INTERVAL 24 HOUR) \


### PR DESCRIPTION
## Summary
- correct `get_l2_block_times_last_hour` query to avoid DateTime64 cast error
- correct `get_l2_block_times_last_24_hours` query the same way

## Testing
- `just lint`
- `just test`
