### PR TITLE
Enable 7 day view in dashboard

### DIFF
--- a/dashboard/components/DashboardHeader.tsx
+++ b/dashboard/components/DashboardHeader.tsx
@@ -45,7 +45,7 @@ const TimeRangeSelector: React.FC<TimeRangeSelectorProps> = ({
   currentTimeRange,
   onTimeRangeChange,
 }) => {
-  const ranges: TimeRange[] = ["1h", "24h"];
+  const ranges: TimeRange[] = ["1h", "24h", "7d"];
 
   return (
     <div className="flex space-x-1 bg-gray-200 p-0.5 rounded-md">

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -19,7 +19,7 @@ export interface AvgTimeResponse {
 }
 
 export const fetchAvgProveTime = async (
-  range: "1h" | "24h",
+  range: "1h" | "24h" | "7d",
 ): Promise<number | null> => {
   const url =
     range === "1h"
@@ -30,7 +30,7 @@ export const fetchAvgProveTime = async (
 };
 
 export const fetchAvgVerifyTime = async (
-  range: "1h" | "24h",
+  range: "1h" | "24h" | "7d",
 ): Promise<number | null> => {
   const url =
     range === "1h"
@@ -41,7 +41,7 @@ export const fetchAvgVerifyTime = async (
 };
 
 export const fetchL2BlockCadence = async (
-  range: "1h" | "24h",
+  range: "1h" | "24h" | "7d",
 ): Promise<number | null> => {
   const url =
     range === "1h"
@@ -52,7 +52,7 @@ export const fetchL2BlockCadence = async (
 };
 
 export const fetchBatchPostingCadence = async (
-  range: "1h" | "24h",
+  range: "1h" | "24h" | "7d",
 ): Promise<number | null> => {
   const url =
     range === "1h"
@@ -63,7 +63,7 @@ export const fetchBatchPostingCadence = async (
 };
 
 export const fetchActiveGateways = async (
-  range: "1h" | "24h",
+  range: "1h" | "24h" | "7d",
 ): Promise<number | null> => {
   const url = `${API_BASE}/active-gateways?range=${range}`;
   const data = await fetchJson<{ gateways: string[] }>(url);
@@ -71,7 +71,7 @@ export const fetchActiveGateways = async (
 };
 
 export const fetchL2Reorgs = async (
-  range: "1h" | "24h",
+  range: "1h" | "24h" | "7d",
 ): Promise<number | null> => {
   const url = `${API_BASE}/reorgs?range=${range}`;
   const data = await fetchJson<{ events: unknown[] }>(url);
@@ -79,7 +79,7 @@ export const fetchL2Reorgs = async (
 };
 
 export const fetchSlashingEvents = async (
-  range: "1h" | "24h",
+  range: "1h" | "24h" | "7d",
 ): Promise<number | null> => {
   const url = `${API_BASE}/slashings?range=${range}`;
   const data = await fetchJson<{ events: unknown[] }>(url);
@@ -87,7 +87,7 @@ export const fetchSlashingEvents = async (
 };
 
 export const fetchForcedInclusions = async (
-  range: "1h" | "24h",
+  range: "1h" | "24h" | "7d",
 ): Promise<number | null> => {
   const url = `${API_BASE}/forced-inclusions?range=${range}`;
   const data = await fetchJson<{ events: unknown[] }>(url);
@@ -95,7 +95,7 @@ export const fetchForcedInclusions = async (
 };
 
 export const fetchL2HeadBlock = async (
-  range: "1h" | "24h",
+  range: "1h" | "24h" | "7d",
 ): Promise<number | null> => {
   const url = `${API_BASE}/l2-block-times?range=${range}`;
   const data = await fetchJson<{ blocks: { block_number: number }[] }>(url);
@@ -105,7 +105,7 @@ export const fetchL2HeadBlock = async (
 };
 
 export const fetchL1HeadBlock = async (
-  range: "1h" | "24h",
+  range: "1h" | "24h" | "7d",
 ): Promise<number | null> => {
   const url = `${API_BASE}/l1-block-times?range=${range}`;
   const data = await fetchJson<{ blocks: { block_number: number }[] }>(url);

--- a/dashboard/services/mockDataService.ts
+++ b/dashboard/services/mockDataService.ts
@@ -1,10 +1,13 @@
-
-import { TimeRange, TimeSeriesData, PieChartDataItem, MetricData } from '../types';
+import {
+  TimeRange,
+  TimeSeriesData,
+  PieChartDataItem,
+  MetricData,
+} from "../types";
 
 // Example color palette if needed by future charts
 // const TAIKO_PINK = '#BF007C';
 // const COLORS = [TAIKO_PINK, '#E573B5', '#5DA5DA', '#FAA43A', '#60BD68', '#F17CB0', '#B2912F', '#B276B2', '#DECF3F', '#F15854'];
-
 
 const getRandom = (min: number, max: number, float = false): number => {
   const val = Math.random() * (max - min) + min;
@@ -12,48 +15,86 @@ const getRandom = (min: number, max: number, float = false): number => {
 };
 
 export const generateMockMetrics = (timeRange: TimeRange): MetricData[] => {
-  const factor = timeRange === '1h' ? 1 : 24;
+  const factor = timeRange === "1h" ? 1 : timeRange === "24h" ? 24 : 24 * 7;
   return [
-    { title: "L2 Block Cadence", value: `${getRandom(1.91, 2.11, true).toFixed(2)}s` },
+    {
+      title: "L2 Block Cadence",
+      value: `${getRandom(1.91, 2.11, true).toFixed(2)}s`,
+    },
     { title: "Active Gateways", value: "3" }, // Hardcoded as per request
     { title: "L2 Reorgs", value: getRandom(0, 1 * factor).toString() },
-    { title: "Batch Posting Cadence", value: `${getRandom(40, 60, true).toFixed(2)}s` },
+    {
+      title: "Batch Posting Cadence",
+      value: `${getRandom(40, 60, true).toFixed(2)}s`,
+    },
     { title: "Slashing Events", value: getRandom(0, 1 * factor).toString() },
     { title: "Forced Inclusions", value: getRandom(0, 2 * factor).toString() },
-    { title: "Avg. Prove Time", value: `${getRandom(600, 700, true).toFixed(2)}s` },
-    { title: "Avg. Verify Time", value: `${getRandom(10, 15, true).toFixed(2)}s` },
-    { title: "L2 Head Block", value: (266226 + getRandom(0, 100 * factor)).toLocaleString() },
-    { title: "L1 Head Block", value: (22487468 + getRandom(0, 50 * factor)).toLocaleString() },
+    {
+      title: "Avg. Prove Time",
+      value: `${getRandom(600, 700, true).toFixed(2)}s`,
+    },
+    {
+      title: "Avg. Verify Time",
+      value: `${getRandom(10, 15, true).toFixed(2)}s`,
+    },
+    {
+      title: "L2 Head Block",
+      value: (266226 + getRandom(0, 100 * factor)).toLocaleString(),
+    },
+    {
+      title: "L1 Head Block",
+      value: (22487468 + getRandom(0, 50 * factor)).toLocaleString(),
+    },
   ];
 };
 
-export const generateMockBlockTimeData = (timeRange: TimeRange, type: 'L1' | 'L2'): TimeSeriesData[] => {
+export const generateMockBlockTimeData = (
+  timeRange: TimeRange,
+  type: "L1" | "L2",
+): TimeSeriesData[] => {
   const now = Date.now();
-  const points = timeRange === '1h' ? 12 : 24; // 12 points for 1h (every 5 mins), 24 for 24h (every hour)
-  const interval = timeRange === '1h' ? 5 * 60 * 1000 : 60 * 60 * 1000;
-  
-  let startBlock = type === 'L2' ? 165000 : 3877350;
-  const increment = type === 'L2' ? 100 : 50;
+  const points = timeRange === "1h" ? 12 : timeRange === "24h" ? 24 : 7; // hourly for 24h, daily for 7d
+  const interval =
+    timeRange === "1h"
+      ? 5 * 60 * 1000
+      : timeRange === "24h"
+        ? 60 * 60 * 1000
+        : 24 * 60 * 60 * 1000;
 
-  return Array.from({ length: points }).map((_, i) => {
-    startBlock += getRandom(increment * 0.8, increment * 1.2);
-    return {
-      timestamp: now - (points - 1 - i) * interval,
-      value: startBlock,
-    };
-  }).sort((a,b) => a.timestamp - b.timestamp);
+  let startBlock = type === "L2" ? 165000 : 3877350;
+  const increment = type === "L2" ? 100 : 50;
+
+  return Array.from({ length: points })
+    .map((_, i) => {
+      startBlock += getRandom(increment * 0.8, increment * 1.2);
+      return {
+        timestamp: now - (points - 1 - i) * interval,
+        value: startBlock,
+      };
+    })
+    .sort((a, b) => a.timestamp - b.timestamp);
 };
 
-export const generateMockBatchProcessData = (timeRange: TimeRange, type: 'prove' | 'verify'): TimeSeriesData[] => {
-  const points = timeRange === '1h' ? 10 : 20;
+export const generateMockBatchProcessData = (
+  timeRange: TimeRange,
+  type: "prove" | "verify",
+): TimeSeriesData[] => {
+  const points = timeRange === "1h" ? 10 : timeRange === "24h" ? 20 : 30;
   let startBatchId = 5800;
 
+  const rangeMillis =
+    timeRange === "1h"
+      ? 60 * 60 * 1000
+      : timeRange === "24h"
+        ? 24 * 60 * 60 * 1000
+        : 7 * 24 * 60 * 60 * 1000;
+
   return Array.from({ length: points }).map((_, i) => {
-    startBatchId += getRandom(1,3);
+    startBatchId += getRandom(1, 3);
     return {
       name: (startBatchId + i).toString(),
-      value: type === 'prove' ? getRandom(500, 2500) : getRandom(30, 150),
-      timestamp: Date.now() - (points - 1 - i) * ( (timeRange === '1h' ? 6 : 72) * 60 * 1000 / points) // spread over the time range
+      value: type === "prove" ? getRandom(500, 2500) : getRandom(30, 150),
+      timestamp: Date.now() - (points - 1 - i) * (rangeMillis / points), // spread over the range
     };
   });
 };
@@ -66,9 +107,11 @@ export const generateMockSequencerData = (): PieChartDataItem[] => {
     { name: "Chainbound", value: getRandom(200, 600) },
   ];
 
-  return sequencers.map(s => ({
-    name: s.name,
-    value: s.value,
-    // fill property is now optional and will be assigned by the PieChart component
-  })).sort((a,b) => b.value - a.value);
+  return sequencers
+    .map((s) => ({
+      name: s.name,
+      value: s.value,
+      // fill property is now optional and will be assigned by the PieChart component
+    }))
+    .sort((a, b) => b.value - a.value);
 };

--- a/dashboard/types.ts
+++ b/dashboard/types.ts
@@ -1,4 +1,4 @@
-export type TimeRange = '1h' | '24h';
+export type TimeRange = "1h" | "24h" | "7d";
 
 export interface TimeSeriesData {
   timestamp: number; // Unix timestamp (ms)


### PR DESCRIPTION
## Summary
- add `7d` to `TimeRange`
- show 7 day option in header
- mock service supports 7 day ranges
- allow API calls with `7d` range

## Testing
- `npx prettier -w components/DashboardHeader.tsx services/mockDataService.ts services/apiService.ts types.ts`