### PR TITLE
Reduce metric card width

### DIFF
--- a/dashboard/App.tsx
+++ b/dashboard/App.tsx
@@ -225,7 +225,7 @@ const App: React.FC = () => {
 
       <main className="mt-6">
         {/* Metrics Grid */}
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 md:gap-6">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-6 2xl:grid-cols-8 gap-4 md:gap-6">
           {/* Grouped Metrics */}
           <MetricCard
             title="L2 Block Cadence"


### PR DESCRIPTION
## Summary
- adjust layout so metric cards take less width on large screens

## Testing
- `npx prettier -w App.tsx`