### PR TITLE
Display long durations in minutes

### DIFF
--- a/dashboard/App.tsx
+++ b/dashboard/App.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback } from "react";
+import { formatSeconds } from "./utils";
 import { DashboardHeader } from "./components/DashboardHeader";
 import { MetricCard } from "./components/MetricCard";
 import { ChartCard } from "./components/ChartCard";
@@ -122,27 +123,25 @@ const App: React.FC = () => {
     const currentMetrics: MetricData[] = [
       {
         title: "L2 Block Cadence",
-        value: l2Cadence !== null ? `${(l2Cadence / 1000).toFixed(2)}s` : "N/A",
+        value: l2Cadence !== null ? formatSeconds(l2Cadence / 1000) : "N/A",
       },
       {
         title: "Batch Posting Cadence",
         value:
-          batchCadence !== null
-            ? `${(batchCadence / 1000).toFixed(2)}s`
-            : "N/A",
+          batchCadence !== null ? formatSeconds(batchCadence / 1000) : "N/A",
       },
       {
         title: "Avg. Prove Time",
         value:
           avgProve !== null && avgProve > 0
-            ? `${(avgProve / 1000).toFixed(2)}s`
+            ? formatSeconds(avgProve / 1000)
             : "N/A",
       },
       {
         title: "Avg. Verify Time",
         value:
           avgVerify !== null && avgVerify > 0
-            ? `${(avgVerify / 1000).toFixed(2)}s`
+            ? formatSeconds(avgVerify / 1000)
             : "N/A",
       },
       {

--- a/dashboard/components/BatchProcessChart.tsx
+++ b/dashboard/components/BatchProcessChart.tsx
@@ -1,21 +1,43 @@
-import React from 'react';
-import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
-import { TimeSeriesData } from '../types';
+import React from "react";
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
+import { TimeSeriesData } from "../types";
 
 interface BatchProcessChartProps {
   data: TimeSeriesData[];
   lineColor: string;
 }
 
-export const BatchProcessChart: React.FC<BatchProcessChartProps> = ({ data, lineColor }) => {
+export const BatchProcessChart: React.FC<BatchProcessChartProps> = ({
+  data,
+  lineColor,
+}) => {
   if (!data || data.length === 0) {
-    return <div className="flex items-center justify-center h-full text-gray-500">No data available</div>;
+    return (
+      <div className="flex items-center justify-center h-full text-gray-500">
+        No data available
+      </div>
+    );
   }
+
+  const showMinutes = data.some((d) => d.value >= 120);
+  const formatValue = (value: number) =>
+    showMinutes
+      ? `${(value / 60).toFixed(1)} minutes`
+      : `${Math.round(value)} seconds`;
 
   return (
     <ResponsiveContainer width="100%" height="100%">
-      <LineChart 
-        data={data} 
+      <LineChart
+        data={data}
         margin={{ top: 5, right: 30, left: 20, bottom: 20 }}
       >
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
@@ -23,50 +45,51 @@ export const BatchProcessChart: React.FC<BatchProcessChartProps> = ({ data, line
           dataKey="name"
           stroke="#666666"
           fontSize={12}
-          label={{ 
-            value: 'Batch ID', 
-            position: 'insideBottom', 
-            offset: -10, 
-            fontSize: 10, 
-            fill: '#666666' 
+          label={{
+            value: "Batch ID",
+            position: "insideBottom",
+            offset: -10,
+            fontSize: 10,
+            fill: "#666666",
           }}
           padding={{ left: 10, right: 10 }}
         />
         <YAxis
           stroke="#666666"
           fontSize={12}
-          label={{ 
-            value: 'Seconds', 
-            angle: -90, 
-            position: 'insideLeft', 
-            offset: -5, 
-            fontSize: 10, 
-            fill: '#666666' 
+          tickFormatter={(v) => (showMinutes ? (v / 60).toFixed(0) : v)}
+          label={{
+            value: showMinutes ? "Minutes" : "Seconds",
+            angle: -90,
+            position: "insideLeft",
+            offset: -5,
+            fontSize: 10,
+            fill: "#666666",
           }}
         />
         <Tooltip
-          formatter={(value: number) => [`${Math.round(value)} seconds`]}
+          formatter={(value: number) => [formatValue(value)]}
           labelFormatter={(label) => `Batch ${label}`}
-          contentStyle={{ 
-            backgroundColor: 'rgba(255, 255, 255, 0.9)', 
+          contentStyle={{
+            backgroundColor: "rgba(255, 255, 255, 0.9)",
             borderColor: lineColor,
-            borderRadius: '4px'
+            borderRadius: "4px",
           }}
-          labelStyle={{ color: '#333', fontWeight: 'bold' }}
+          labelStyle={{ color: "#333", fontWeight: "bold" }}
         />
-        <Legend 
-          verticalAlign="bottom" 
-          align="right" 
-          wrapperStyle={{ right: 20, bottom: 0 }} 
+        <Legend
+          verticalAlign="bottom"
+          align="right"
+          wrapperStyle={{ right: 20, bottom: 0 }}
         />
-        <Line 
-          type="monotone" 
-          dataKey="value" 
-          stroke={lineColor} 
-          strokeWidth={2} 
-          dot={{ r: 3 }} 
-          activeDot={{ r: 6 }} 
-          name="Time (seconds)" 
+        <Line
+          type="monotone"
+          dataKey="value"
+          stroke={lineColor}
+          strokeWidth={2}
+          dot={{ r: 3 }}
+          activeDot={{ r: 6 }}
+          name={showMinutes ? "Time (minutes)" : "Time (seconds)"}
         />
       </LineChart>
     </ResponsiveContainer>

--- a/dashboard/utils.ts
+++ b/dashboard/utils.ts
@@ -1,0 +1,5 @@
+export const formatSeconds = (seconds: number): string => {
+  return seconds >= 120
+    ? `${(seconds / 60).toFixed(2)}m`
+    : `${seconds.toFixed(2)}s`;
+};


### PR DESCRIPTION
## Summary
- show durations in minutes when they exceed 120 seconds
- update charts to switch axis labels and tooltips to minutes
- add a small helper util

## Testing
- `npx prettier -w dashboard/App.tsx dashboard/components/BatchProcessChart.tsx dashboard/utils.ts`