### PR TITLE
Fix minute rounding display

### DIFF
--- a/dashboard/components/BatchProcessChart.tsx
+++ b/dashboard/components/BatchProcessChart.tsx
@@ -31,7 +31,7 @@ export const BatchProcessChart: React.FC<BatchProcessChartProps> = ({
   const showMinutes = data.some((d) => d.value >= 120);
   const formatValue = (value: number) =>
     showMinutes
-      ? `${(value / 60).toFixed(2)} minutes`
+      ? `${Number((value / 60).toFixed(2))} minutes`
       : `${Math.round(value)} seconds`;
 
   return (
@@ -58,7 +58,7 @@ export const BatchProcessChart: React.FC<BatchProcessChartProps> = ({
           stroke="#666666"
           fontSize={12}
           tickFormatter={(v) =>
-            showMinutes ? (v / 60).toFixed(2) : v.toString()
+            showMinutes ? Number((v / 60).toFixed(2)) : v.toString()
           }
           label={{
             value: showMinutes ? "Minutes" : "Seconds",

--- a/dashboard/utils.ts
+++ b/dashboard/utils.ts
@@ -1,5 +1,5 @@
 export const formatSeconds = (seconds: number): string => {
   return seconds >= 120
-    ? `${(seconds / 60).toFixed(2)}m`
+    ? `${Number((seconds / 60).toFixed(2))}m`
     : `${seconds.toFixed(2)}s`;
 };


### PR DESCRIPTION
## Summary
- avoid displaying trailing zeros in minute formatting for dashboards

## Testing
- `npx prettier -w dashboard/utils.ts dashboard/components/BatchProcessChart.tsx`