### PR TITLE
feat: refine dashboard time rounding

### DIFF
--- a/dashboard/components/BatchProcessChart.tsx
+++ b/dashboard/components/BatchProcessChart.tsx
@@ -10,6 +10,7 @@ import {
   ResponsiveContainer,
 } from "recharts";
 import { TimeSeriesData } from "../types";
+import { formatDecimal } from "../utils";
 
 interface BatchProcessChartProps {
   data: TimeSeriesData[];
@@ -31,7 +32,7 @@ export const BatchProcessChart: React.FC<BatchProcessChartProps> = ({
   const showMinutes = data.some((d) => d.value >= 120);
   const formatValue = (value: number) =>
     showMinutes
-      ? `${Number((value / 60).toFixed(2))} minutes`
+      ? `${formatDecimal(value / 60)} minutes`
       : `${Math.round(value)} seconds`;
 
   return (
@@ -58,7 +59,7 @@ export const BatchProcessChart: React.FC<BatchProcessChartProps> = ({
           stroke="#666666"
           fontSize={12}
           tickFormatter={(v) =>
-            showMinutes ? Number((v / 60).toFixed(2)) : v.toString()
+            showMinutes ? Number(formatDecimal(v / 60)) : v.toString()
           }
           label={{
             value: showMinutes ? "Minutes" : "Seconds",

--- a/dashboard/utils.ts
+++ b/dashboard/utils.ts
@@ -1,5 +1,10 @@
+export const formatDecimal = (value: number): string => {
+  const decimals = Math.abs(value) >= 10 ? 1 : 2;
+  return value.toFixed(decimals);
+};
+
 export const formatSeconds = (seconds: number): string => {
   return seconds >= 120
-    ? `${Number((seconds / 60).toFixed(2))}m`
-    : `${seconds.toFixed(2)}s`;
+    ? `${Number(formatDecimal(seconds / 60))}m`
+    : `${formatDecimal(seconds)}s`;
 };


### PR DESCRIPTION
## Summary
- follow new rounding rules for seconds in dashboard
- share decimal formatting in utils

## Testing
- `npx prettier --write dashboard/utils.ts dashboard/components/BatchProcessChart.tsx`