### PR TITLE
Fix dashboard chunk size warning

### DIFF
--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -1,16 +1,27 @@
-import path from 'path';
-import { defineConfig, loadEnv } from 'vite';
+import path from "path";
+import { defineConfig, loadEnv } from "vite";
 
 export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, '.', '');
+  const env = loadEnv(mode, ".", "");
   return {
     define: {
-      'process.env.API_KEY': JSON.stringify(env.API_KEY),
+      "process.env.API_KEY": JSON.stringify(env.API_KEY),
     },
     resolve: {
       alias: {
-        '@': path.resolve(__dirname, '.'),
-      }
-    }
+        "@": path.resolve(__dirname, "."),
+      },
+    },
+    build: {
+      chunkSizeWarningLimit: 1000,
+      rollupOptions: {
+        output: {
+          manualChunks: {
+            react: ["react", "react-dom"],
+            charts: ["recharts"],
+          },
+        },
+      },
+    },
   };
 });


### PR DESCRIPTION
## Summary
- enable manual chunks in Vite config for dashboard
- bump chunk size warning limit

## Testing
- `npm run build`