### PR TITLE
Fix block time y-axis label

### DIFF
--- a/dashboard/components/BlockTimeChart.tsx
+++ b/dashboard/components/BlockTimeChart.tsx
@@ -18,7 +18,9 @@ interface BlockTimeChartProps {
 
 const formatTimestampToTime = (timestamp: number): string => {
   const date = new Date(timestamp);
-  return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  return date
+    .toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })
+    .replace(/\s/g, "");
 };
 
 export const BlockTimeChart: React.FC<BlockTimeChartProps> = ({


### PR DESCRIPTION
## Summary
- keep AM/PM text on one line in block time charts

## Testing
- `prettier --write components/BlockTimeChart.tsx`