### PR TITLE
Add Network Health metric group to dashboard

### DIFF
--- a/dashboard/App.tsx
+++ b/dashboard/App.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback } from "react";
 import { formatSeconds } from "./utils";
 import { DashboardHeader } from "./components/DashboardHeader";
 import { MetricCard } from "./components/MetricCard";
+import { MetricGroup } from "./components/MetricGroup";
 import { ChartCard } from "./components/ChartCard";
 import { SequencerPieChart } from "./components/SequencerPieChart";
 import { BlockTimeChart } from "./components/BlockTimeChart";
@@ -234,9 +235,24 @@ const App: React.FC = () => {
       )}
 
       <main className="mt-6">
+        <MetricGroup title="Network Health">
+          <MetricCard
+            title="Active Gateways"
+            value={findMetricValue("Active Gateways")}
+          />
+          <MetricCard title="L2 Reorgs" value={findMetricValue("L2 Reorgs")} />
+          <MetricCard
+            title="Slashing Events"
+            value={findMetricValue("Slashing Events")}
+          />
+          <MetricCard
+            title="Forced Inclusions"
+            value={findMetricValue("Forced Inclusions")}
+          />
+        </MetricGroup>
+
         {/* Metrics Grid */}
         <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 gap-4 md:gap-6">
-          {/* Grouped Metrics */}
           <MetricCard
             title="L2 Block Cadence"
             value={findMetricValue("L2 Block Cadence")}
@@ -252,21 +268,6 @@ const App: React.FC = () => {
           <MetricCard
             title="Avg. Verify Time"
             value={findMetricValue("Avg. Verify Time")}
-          />
-
-          {/* Other Metrics */}
-          <MetricCard
-            title="Active Gateways"
-            value={findMetricValue("Active Gateways")}
-          />
-          <MetricCard title="L2 Reorgs" value={findMetricValue("L2 Reorgs")} />
-          <MetricCard
-            title="Slashing Events"
-            value={findMetricValue("Slashing Events")}
-          />
-          <MetricCard
-            title="Forced Inclusions"
-            value={findMetricValue("Forced Inclusions")}
           />
         </div>
 

--- a/dashboard/components/MetricGroup.tsx
+++ b/dashboard/components/MetricGroup.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+interface MetricGroupProps {
+  title: string;
+  children: React.ReactNode;
+}
+
+export const MetricGroup: React.FC<MetricGroupProps> = ({
+  title,
+  children,
+}) => (
+  <section className="mb-6">
+    <h2 className="text-lg font-semibold text-gray-700 mb-2">{title}</h2>
+    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 gap-4 md:gap-6">
+      {children}
+    </div>
+  </section>
+);


### PR DESCRIPTION
## Summary
- group Active Gateways, L2 Reorgs, Slashing Events and Forced Inclusions under a new **Network Health** section
- display this group at the top of the dashboard

## Testing
- `npx prettier -w dashboard/App.tsx dashboard/components/MetricGroup.tsx`