### PR TITLE
Fix migration test handler count

### DIFF
--- a/crates/driver/src/lib.rs
+++ b/crates/driver/src/lib.rs
@@ -506,7 +506,7 @@ mod tests {
     async fn new_respects_batch_proof_timeout_from_opts() {
         // Mock ClickHouse server with enough handlers for `init_db`
         let mock = Mock::new();
-        for _ in 0..10 {
+        for _ in 0..16 {
             mock.add(handlers::failure(StatusCode::OK));
         }
 


### PR DESCRIPTION
## Summary
- ensure driver test has enough mock handlers for database migrations

## Testing
- `just ci`