### PR TITLE
Implement SSE updates for head blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -727,11 +727,13 @@ dependencies = [
 name = "api"
 version = "0.1.0"
 dependencies = [
+ "async-stream",
  "axum",
  "chrono",
  "clickhouse 0.1.0",
  "clickhouse 0.13.2",
  "eyre",
+ "futures",
  "hex",
  "primitives",
  "serde",

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -18,6 +18,8 @@ tracing.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tower-http.workspace = true
+async-stream = "0.3"
+futures.workspace = true
 
 [dev-dependencies]
 tower = "0.5"

--- a/dashboard/App.tsx
+++ b/dashboard/App.tsx
@@ -13,6 +13,7 @@ import {
   MetricData,
 } from "./types";
 import {
+  API_BASE,
   fetchAvgProveTime,
   fetchAvgVerifyTime,
   fetchL2BlockCadence,
@@ -50,6 +51,19 @@ const App: React.FC = () => {
   const [l1HeadBlock, setL1HeadBlock] = useState<string>("0");
   const [refreshRate, setRefreshRate] = useState<number>(60000);
   const [errorMessage, setErrorMessage] = useState<string>("");
+
+  useEffect(() => {
+    const l1Source = new EventSource(`${API_BASE}/sse/l1-head`);
+    const l2Source = new EventSource(`${API_BASE}/sse/l2-head`);
+
+    l1Source.onmessage = (e) => setL1HeadBlock(Number(e.data).toLocaleString());
+    l2Source.onmessage = (e) => setL2HeadBlock(Number(e.data).toLocaleString());
+
+    return () => {
+      l1Source.close();
+      l2Source.close();
+    };
+  }, []);
 
   const fetchData = useCallback(async () => {
     const range = timeRange;


### PR DESCRIPTION
## Summary
- add SSE endpoints in API for live head block updates
- expose last head block number queries in ClickHouse client
- connect dashboard to SSE for real-time L1/L2 head blocks

## Testing
- `npm run build`
- `just ci` *(fails: driver tests require unavailable services)*