### PR TITLE
Remove time units from prove/verify legend

### DIFF
--- a/dashboard/components/BatchProcessChart.tsx
+++ b/dashboard/components/BatchProcessChart.tsx
@@ -99,13 +99,7 @@ export const BatchProcessChart: React.FC<BatchProcessChartProps> = ({
           strokeWidth={2}
           dot={{ r: 3 }}
           activeDot={{ r: 6 }}
-          name={
-            showHours
-              ? "Time (hours)"
-              : showMinutes
-                ? "Time (minutes)"
-                : "Time (seconds)"
-          }
+          name="Time"
         />
       </LineChart>
     </ResponsiveContainer>


### PR DESCRIPTION
## Summary
- simplify the legend for Prove Time and Verify Time charts

## Testing
- `npx prettier -w dashboard/components/BatchProcessChart.tsx`