### PR TITLE
Add dashboard just commands to guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,10 @@
 - Format code: `just fmt` or `cargo +nightly fmt --all`
 - Run CI checks: `just ci` (runs fmt, lint, test)
 - Always run all CI checks after any changes (except for changes in the dashboard dir)
+- Dashboard install dependencies: `just dashboard-install`
+- Dashboard dev server: `just dashboard-dev`
+- Dashboard build: `just dashboard-build`
+- Dashboard type checks: `just dashboard-check`
 
 ## Code Style Guidelines
 - Use Rust 2024 edition


### PR DESCRIPTION
## Summary
- document dashboard just commands in `AGENTS.md`

## Testing
- `just ci`