### PR TITLE
Add L2 block timing query

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ alloy-network-primitives = "1.0.6"
 alloy-sol-types = "1.1.2"
 alloy-sol-macro = "1.1.2"
 async-trait = "0.1"
-chrono = "0.4.41"
+chrono = { version = "0.4.41", features = ["serde"] }
 clap = { version = "4.5.38", features = ["derive", "env"] }
 clickhouse = { version = "0.13.2", features = ["native-tls", "test-util"] }
 derive_more = { version = "1.0.0", features = ["debug", "deref"] }

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -10,7 +10,7 @@ clickhouse_lib = { path = "../clickhouse", package = "clickhouse" }
 primitives = { path = "../primitives" }
 
 axum.workspace = true
-chrono.workspace = true
+chrono = { workspace = true, features = ["serde"] }
 eyre.workspace = true
 hex.workspace = true
 tokio.workspace = true

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -863,6 +863,13 @@ mod tests {
         block_number: u64,
     }
 
+    #[derive(Serialize, Row)]
+    struct L2BlockTimeRowTest {
+        l2_block_number: u64,
+        block_time: u64,
+        seconds_since_prev_block: Option<u64>,
+    }
+
     #[tokio::test]
     async fn l1_block_times_last_hour_endpoint() {
         let mock = Mock::new();
@@ -884,28 +891,70 @@ mod tests {
     #[tokio::test]
     async fn l2_block_times_last_hour_endpoint() {
         let mock = Mock::new();
-        mock.add(handlers::provide(vec![BlockTimeRowTest { minute: 0, block_number: 1 }]));
+        mock.add(handlers::provide(vec![
+            L2BlockTimeRowTest {
+                l2_block_number: 0,
+                block_time: 0,
+                seconds_since_prev_block: None,
+            },
+            L2BlockTimeRowTest {
+                l2_block_number: 1,
+                block_time: 2,
+                seconds_since_prev_block: Some(2),
+            },
+        ]));
         let app = build_app(mock.url());
         let body = send_request(app, "/l2-block-times?range=1h").await;
-        assert_eq!(body, json!({ "blocks": [ { "minute": 0, "block_number": 1 } ] }));
+        assert_eq!(
+            body,
+            json!({ "blocks": [ { "l2_block_number": 1, "block_time": "1970-01-01T00:00:02Z", "seconds_since_prev_block": 2 } ] })
+        );
     }
 
     #[tokio::test]
     async fn l2_block_times_last_day_endpoint() {
         let mock = Mock::new();
-        mock.add(handlers::provide(vec![BlockTimeRowTest { minute: 0, block_number: 1 }]));
+        mock.add(handlers::provide(vec![
+            L2BlockTimeRowTest {
+                l2_block_number: 0,
+                block_time: 0,
+                seconds_since_prev_block: None,
+            },
+            L2BlockTimeRowTest {
+                l2_block_number: 1,
+                block_time: 2,
+                seconds_since_prev_block: Some(2),
+            },
+        ]));
         let app = build_app(mock.url());
         let body = send_request(app, "/l2-block-times?range=24h").await;
-        assert_eq!(body, json!({ "blocks": [ { "minute": 0, "block_number": 1 } ] }));
+        assert_eq!(
+            body,
+            json!({ "blocks": [ { "l2_block_number": 1, "block_time": "1970-01-01T00:00:02Z", "seconds_since_prev_block": 2 } ] })
+        );
     }
 
     #[tokio::test]
     async fn l2_block_times_last_week_endpoint() {
         let mock = Mock::new();
-        mock.add(handlers::provide(vec![BlockTimeRowTest { minute: 0, block_number: 1 }]));
+        mock.add(handlers::provide(vec![
+            L2BlockTimeRowTest {
+                l2_block_number: 0,
+                block_time: 0,
+                seconds_since_prev_block: None,
+            },
+            L2BlockTimeRowTest {
+                l2_block_number: 1,
+                block_time: 2,
+                seconds_since_prev_block: Some(2),
+            },
+        ]));
         let app = build_app(mock.url());
         let body = send_request(app, "/l2-block-times?range=7d").await;
-        assert_eq!(body, json!({ "blocks": [ { "minute": 0, "block_number": 1 } ] }));
+        assert_eq!(
+            body,
+            json!({ "blocks": [ { "l2_block_number": 1, "block_time": "1970-01-01T00:00:02Z", "seconds_since_prev_block": 2 } ] })
+        );
     }
 
     #[derive(Serialize, Row)]

--- a/crates/clickhouse/Cargo.toml
+++ b/crates/clickhouse/Cargo.toml
@@ -11,7 +11,7 @@ chainio = { path = "../chainio" }
 extractor = { version = "0.1.0", path = "../extractor" }
 
 alloy.workspace = true
-chrono.workspace = true
+chrono = { workspace = true, features = ["serde"] }
 clickhouse.workspace = true
 derive_more.workspace = true
 eyre.workspace = true

--- a/crates/clickhouse/src/models.rs
+++ b/crates/clickhouse/src/models.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Utc};
 use clickhouse::Row;
 use derive_more::Debug;
 use serde::{Deserialize, Serialize};
@@ -153,11 +154,13 @@ pub struct L1BlockTimeRow {
     pub block_number: u64,
 }
 
-/// Row representing L2 block numbers per minute
-#[derive(Debug, Row, Serialize, Deserialize, PartialEq, Eq)]
+/// Row representing the time between consecutive L2 blocks
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct L2BlockTimeRow {
-    /// Minute timestamp
-    pub minute: u64,
-    /// Highest block number observed in that minute
-    pub block_number: u64,
+    /// L2 block number
+    pub l2_block_number: u64,
+    /// Timestamp of the L2 block
+    pub block_time: DateTime<Utc>,
+    /// Seconds since the previous block
+    pub seconds_since_prev_block: Option<u64>,
 }

--- a/crates/driver/Cargo.toml
+++ b/crates/driver/Cargo.toml
@@ -13,7 +13,7 @@ clickhouse = { path = "../clickhouse" }
 extractor = { path = "../extractor" }
 incident = { path = "../incident" }
 
-chrono.workspace = true
+chrono = { workspace = true, features = ["serde"] }
 alloy-primitives.workspace = true
 clap.workspace = true
 dotenvy.workspace = true

--- a/crates/incident/Cargo.toml
+++ b/crates/incident/Cargo.toml
@@ -10,7 +10,7 @@ repository.workspace = true
 clickhouse = { path = "../clickhouse" }
 
 async-trait.workspace = true
-chrono.workspace = true
+chrono = { workspace = true, features = ["serde"] }
 eyre.workspace = true
 reqwest.workspace = true
 serde.workspace = true


### PR DESCRIPTION
## Summary
- track time between consecutive L2 blocks
- expose new query via API
- adjust tests for new schema

## Testing
- `just ci`