### PR TITLE
Fix l2 block time query

### DIFF
--- a/crates/clickhouse/src/reader.rs
+++ b/crates/clickhouse/src/reader.rs
@@ -950,7 +950,7 @@ impl ClickhouseReader {
         let query = format!(
             "SELECT l2_block_number, \
                     block_ts AS block_time, \
-                    toUInt64OrNull(block_ts - lagInFrame(block_ts) OVER (ORDER BY l2_block_number)) \
+                    toUInt64OrNull(toString(block_ts - lagInFrame(block_ts) OVER (ORDER BY l2_block_number))) \
                         AS seconds_since_prev_block \
              FROM {db}.l2_head_events \
              WHERE block_ts >= toUnixTimestamp(now64() - INTERVAL 1 HOUR) \
@@ -984,7 +984,7 @@ impl ClickhouseReader {
         let query = format!(
             "SELECT l2_block_number, \
                     block_ts AS block_time, \
-                    toUInt64OrNull(block_ts - lagInFrame(block_ts) OVER (ORDER BY l2_block_number)) \
+                    toUInt64OrNull(toString(block_ts - lagInFrame(block_ts) OVER (ORDER BY l2_block_number))) \
                         AS seconds_since_prev_block \
              FROM {db}.l2_head_events \
              WHERE block_ts >= toUnixTimestamp(now64() - INTERVAL 24 HOUR) \
@@ -1018,7 +1018,7 @@ impl ClickhouseReader {
         let query = format!(
             "SELECT l2_block_number, \
                     block_ts AS block_time, \
-                    toUInt64OrNull(block_ts - lagInFrame(block_ts) OVER (ORDER BY l2_block_number)) \
+                    toUInt64OrNull(toString(block_ts - lagInFrame(block_ts) OVER (ORDER BY l2_block_number))) \
                         AS seconds_since_prev_block \
              FROM {db}.l2_head_events \
              WHERE block_ts >= toUnixTimestamp(now64() - INTERVAL 7 DAY) \


### PR DESCRIPTION
## Summary
- cast L2 block timestamp difference to string before using `toUInt64OrNull`

## Testing
- `just lint`
- `just test`