### PR TITLE
Extract dashboard utils and add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 
 .vscode/
 .claude/
+dashboard/tests-build/

--- a/dashboard/components/BatchProcessChart.tsx
+++ b/dashboard/components/BatchProcessChart.tsx
@@ -10,7 +10,7 @@ import {
   ResponsiveContainer,
 } from "recharts";
 import { TimeSeriesData } from "../types";
-import { formatDecimal } from "../utils";
+import { formatDecimal, formatBatchDuration } from "../utils";
 
 interface BatchProcessChartProps {
   data: TimeSeriesData[];
@@ -32,11 +32,7 @@ export const BatchProcessChart: React.FC<BatchProcessChartProps> = ({
   const showHours = data.some((d) => d.value >= 120 * 60);
   const showMinutes = !showHours && data.some((d) => d.value >= 120);
   const formatValue = (value: number) =>
-    showHours
-      ? `${formatDecimal(value / 3600)} hours`
-      : showMinutes
-        ? `${formatDecimal(value / 60)} minutes`
-        : `${Math.round(value)} seconds`;
+    formatBatchDuration(value, showHours, showMinutes);
 
   return (
     <ResponsiveContainer width="100%" height="100%">

--- a/dashboard/components/BlockTimeChart.tsx
+++ b/dashboard/components/BlockTimeChart.tsx
@@ -10,18 +10,12 @@ import {
   ResponsiveContainer,
 } from "recharts";
 import { TimeSeriesData } from "../types";
-import { formatDecimal } from "../utils";
+import { formatDecimal, formatInterval } from "../utils";
 
 interface BlockTimeChartProps {
   data: TimeSeriesData[];
   lineColor: string;
 }
-
-const formatInterval = (ms: number, showMinutes: boolean): string => {
-  return showMinutes
-    ? `${formatDecimal(ms / 60000)} minutes`
-    : `${Number(formatDecimal(ms / 1000))} seconds`;
-};
 
 export const BlockTimeChart: React.FC<BlockTimeChartProps> = ({
   data,

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "check": "tsc --noEmit"
+    "check": "tsc --noEmit",
+    "test": "tsc -p tsconfig.tests.json && node tests-build/tests/utils.test.js"
   },
   "dependencies": {
     "react": "^19.1.0",

--- a/dashboard/tests/utils.test.ts
+++ b/dashboard/tests/utils.test.ts
@@ -1,0 +1,23 @@
+import assert from "assert";
+import {
+  formatDecimal,
+  formatSeconds,
+  formatInterval,
+  formatBatchDuration,
+} from "../utils.js";
+
+assert.strictEqual(formatDecimal(1), "1.00");
+assert.strictEqual(formatDecimal(12.345), "12.3");
+
+assert.strictEqual(formatSeconds(30), "30.0s");
+assert.strictEqual(formatSeconds(150), "2.5m");
+assert.strictEqual(formatSeconds(7200), "2h");
+
+assert.strictEqual(formatInterval(30000, false), "30 seconds");
+assert.strictEqual(formatInterval(180000, true), "3.00 minutes");
+
+assert.strictEqual(formatBatchDuration(45, false, false), "45 seconds");
+assert.strictEqual(formatBatchDuration(150, false, true), "2.50 minutes");
+assert.strictEqual(formatBatchDuration(7200, true, false), "2.00 hours");
+
+console.log("All tests passed.");

--- a/dashboard/tsconfig.tests.json
+++ b/dashboard/tsconfig.tests.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./tests-build",
+    "module": "ES2020",
+    "noEmit": false,
+    "allowImportingTsExtensions": false
+  },
+  "include": ["tests/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/dashboard/utils.ts
+++ b/dashboard/utils.ts
@@ -12,3 +12,21 @@ export const formatSeconds = (seconds: number): string => {
   }
   return `${formatDecimal(seconds)}s`;
 };
+
+export const formatInterval = (ms: number, showMinutes: boolean): string => {
+  return showMinutes
+    ? `${formatDecimal(ms / 60000)} minutes`
+    : `${Number(formatDecimal(ms / 1000))} seconds`;
+};
+
+export const formatBatchDuration = (
+  value: number,
+  showHours: boolean,
+  showMinutes: boolean,
+): string => {
+  return showHours
+    ? `${formatDecimal(value / 3600)} hours`
+    : showMinutes
+      ? `${formatDecimal(value / 60)} minutes`
+      : `${Math.round(value)} seconds`;
+};


### PR DESCRIPTION
## Summary
- refactor chart components to use new utils
- add testing configuration and simple unit tests for utilities
- ignore dashboard test build output

## Testing
- `npm run test`