### PR TITLE
Add head block API and SSE fallback

### DIFF
--- a/dashboard/App.tsx
+++ b/dashboard/App.tsx
@@ -24,6 +24,8 @@ import {
   fetchForcedInclusions,
   fetchL2HeadBlock,
   fetchL1HeadBlock,
+  fetchL2HeadNumber,
+  fetchL1HeadNumber,
   fetchProveTimes,
   fetchVerifyTimes,
   fetchL1BlockTimes,
@@ -53,6 +55,43 @@ const App: React.FC = () => {
   const [errorMessage, setErrorMessage] = useState<string>("");
 
   useEffect(() => {
+    let pollId: NodeJS.Timeout | null = null;
+
+    const updateHeads = async () => {
+      const [l1, l2] = await Promise.all([
+        fetchL1HeadNumber(),
+        fetchL2HeadNumber(),
+      ]);
+      if (l1.data !== null) {
+        const value = l1.data.toLocaleString();
+        setL1HeadBlock(value);
+        setMetrics((m) =>
+          m.map((metric) =>
+            metric.title === "L1 Head Block" ? { ...metric, value } : metric,
+          ),
+        );
+      }
+      if (l2.data !== null) {
+        const value = l2.data.toLocaleString();
+        setL2HeadBlock(value);
+        setMetrics((m) =>
+          m.map((metric) =>
+            metric.title === "L2 Head Block" ? { ...metric, value } : metric,
+          ),
+        );
+      }
+    };
+
+    const startPolling = () => {
+      if (!pollId) {
+        setErrorMessage(
+          "Realtime updates unavailable, falling back to polling.",
+        );
+        updateHeads();
+        pollId = setInterval(updateHeads, 10000);
+      }
+    };
+
     const l1Source = new EventSource(`${API_BASE}/sse/l1-head`);
     const l2Source = new EventSource(`${API_BASE}/sse/l2-head`);
 
@@ -75,9 +114,19 @@ const App: React.FC = () => {
       );
     };
 
+    const handleError = () => {
+      l1Source.close();
+      l2Source.close();
+      startPolling();
+    };
+
+    l1Source.onerror = handleError;
+    l2Source.onerror = handleError;
+
     return () => {
       l1Source.close();
       l2Source.close();
+      if (pollId) clearInterval(pollId);
     };
   }, []);
 

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -139,6 +139,18 @@ export const fetchL1HeadBlock = async (
   return { data: value, badRequest: res.badRequest };
 };
 
+export const fetchL2HeadNumber = async (): Promise<RequestResult<number>> => {
+  const url = `${API_BASE}/l2-head-block`;
+  const res = await fetchJson<{ l2_head_block?: number }>(url);
+  return { data: res.data?.l2_head_block ?? null, badRequest: res.badRequest };
+};
+
+export const fetchL1HeadNumber = async (): Promise<RequestResult<number>> => {
+  const url = `${API_BASE}/l1-head-block`;
+  const res = await fetchJson<{ l1_head_block?: number }>(url);
+  return { data: res.data?.l1_head_block ?? null, badRequest: res.badRequest };
+};
+
 export const fetchProveTimes = async (
   range: "1h" | "24h" | "7d",
 ): Promise<RequestResult<TimeSeriesData[]>> => {


### PR DESCRIPTION
## Summary
- add `/l1-head-block` and `/l2-head-block` API endpoints
- fall back to polling for head blocks when SSE connections fail
- provide API helpers for the new endpoints

## Testing
- `just fmt`
- `just lint`
- `just test`
- `npm run check`