### PR TITLE
Refactor dashboard helpers and add tests

### DIFF
--- a/dashboard/App.tsx
+++ b/dashboard/App.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from "react";
-import { formatSeconds, findMetricValue } from "./utils";
+import { findMetricValue } from "./utils";
 import { createMetrics, hasBadRequest } from "./helpers";
 import { DashboardHeader } from "./components/DashboardHeader";
 import { MetricCard } from "./components/MetricCard";

--- a/dashboard/App.tsx
+++ b/dashboard/App.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback } from "react";
 import { formatSeconds, findMetricValue } from "./utils";
+import { createMetrics, hasBadRequest } from "./helpers";
 import { DashboardHeader } from "./components/DashboardHeader";
 import { MetricCard } from "./components/MetricCard";
 import { ChartCard } from "./components/ChartCard";
@@ -183,81 +184,36 @@ const App: React.FC = () => {
     const l2Times = l2TimesRes.data || [];
     const sequencerDist = sequencerDistRes.data || [];
 
-    const anyBadRequest =
-      l2CadenceRes.badRequest ||
-      batchCadenceRes.badRequest ||
-      avgProveRes.badRequest ||
-      avgVerifyRes.badRequest ||
-      activeGatewaysRes.badRequest ||
-      l2ReorgsRes.badRequest ||
-      slashingsRes.badRequest ||
-      forcedInclusionsRes.badRequest ||
-      l2BlockRes.badRequest ||
-      l1BlockRes.badRequest ||
-      proveTimesRes.badRequest ||
-      verifyTimesRes.badRequest ||
-      l1TimesRes.badRequest ||
-      l2TimesRes.badRequest ||
-      sequencerDistRes.badRequest;
+    const anyBadRequest = hasBadRequest([
+      l2CadenceRes,
+      batchCadenceRes,
+      avgProveRes,
+      avgVerifyRes,
+      activeGatewaysRes,
+      l2ReorgsRes,
+      slashingsRes,
+      forcedInclusionsRes,
+      l2BlockRes,
+      l1BlockRes,
+      proveTimesRes,
+      verifyTimesRes,
+      l1TimesRes,
+      l2TimesRes,
+      sequencerDistRes,
+    ]);
 
-    const currentMetrics: MetricData[] = [
-      {
-        title: "L2 Block Cadence",
-        value: l2Cadence != null ? formatSeconds(l2Cadence / 1000) : "N/A",
-      },
-      {
-        title: "Batch Posting Cadence",
-        value:
-          batchCadence != null ? formatSeconds(batchCadence / 1000) : "N/A",
-      },
-      {
-        title: "Avg. Prove Time",
-        value:
-          avgProve != null && avgProve > 0
-            ? formatSeconds(avgProve / 1000)
-            : "N/A",
-      },
-      {
-        title: (
-          <a
-            href="https://docs.taiko.xyz/taiko-alethia-protocol/protocol-architecture/block-states"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="hover:underline"
-          >
-            Avg. Verify Time
-          </a>
-        ),
-        value:
-          avgVerify != null && avgVerify > 0
-            ? formatSeconds(avgVerify / 1000)
-            : "N/A",
-      },
-      {
-        title: "Active Gateways",
-        value: activeGateways != null ? activeGateways.toString() : "N/A",
-      },
-      {
-        title: "L2 Reorgs",
-        value: l2Reorgs != null ? l2Reorgs.toString() : "N/A",
-      },
-      {
-        title: "Slashing Events",
-        value: slashings != null ? slashings.toString() : "N/A",
-      },
-      {
-        title: "Forced Inclusions",
-        value: forcedInclusions != null ? forcedInclusions.toString() : "N/A",
-      },
-      {
-        title: "L2 Head Block",
-        value: l2Block != null ? l2Block.toLocaleString() : "N/A",
-      },
-      {
-        title: "L1 Head Block",
-        value: l1Block != null ? l1Block.toLocaleString() : "N/A",
-      },
-    ];
+    const currentMetrics: MetricData[] = createMetrics({
+      l2Cadence,
+      batchCadence,
+      avgProve,
+      avgVerify,
+      activeGateways,
+      l2Reorgs,
+      slashings,
+      forcedInclusions,
+      l2Block,
+      l1Block,
+    });
 
     setMetrics(currentMetrics);
     setSecondsToProveData(proveTimes);

--- a/dashboard/helpers.ts
+++ b/dashboard/helpers.ts
@@ -1,0 +1,83 @@
+import React from "react";
+import { type MetricData } from "./types";
+import { formatSeconds } from "./utils.js";
+import type { RequestResult } from "./services/apiService";
+
+export interface MetricInputData {
+  l2Cadence: number | null;
+  batchCadence: number | null;
+  avgProve: number | null;
+  avgVerify: number | null;
+  activeGateways: number | null;
+  l2Reorgs: number | null;
+  slashings: number | null;
+  forcedInclusions: number | null;
+  l2Block: number | null;
+  l1Block: number | null;
+}
+
+export const createMetrics = (data: MetricInputData): MetricData[] => [
+  {
+    title: "L2 Block Cadence",
+    value:
+      data.l2Cadence != null ? formatSeconds(data.l2Cadence / 1000) : "N/A",
+  },
+  {
+    title: "Batch Posting Cadence",
+    value:
+      data.batchCadence != null
+        ? formatSeconds(data.batchCadence / 1000)
+        : "N/A",
+  },
+  {
+    title: "Avg. Prove Time",
+    value:
+      data.avgProve != null && data.avgProve > 0
+        ? formatSeconds(data.avgProve / 1000)
+        : "N/A",
+  },
+  {
+    title: React.createElement(
+      "a",
+      {
+        href: "https://docs.taiko.xyz/taiko-alethia-protocol/protocol-architecture/block-states",
+        target: "_blank",
+        rel: "noopener noreferrer",
+        className: "hover:underline",
+      },
+      "Avg. Verify Time",
+    ),
+    value:
+      data.avgVerify != null && data.avgVerify > 0
+        ? formatSeconds(data.avgVerify / 1000)
+        : "N/A",
+  },
+  {
+    title: "Active Gateways",
+    value: data.activeGateways != null ? data.activeGateways.toString() : "N/A",
+  },
+  {
+    title: "L2 Reorgs",
+    value: data.l2Reorgs != null ? data.l2Reorgs.toString() : "N/A",
+  },
+  {
+    title: "Slashing Events",
+    value: data.slashings != null ? data.slashings.toString() : "N/A",
+  },
+  {
+    title: "Forced Inclusions",
+    value:
+      data.forcedInclusions != null ? data.forcedInclusions.toString() : "N/A",
+  },
+  {
+    title: "L2 Head Block",
+    value: data.l2Block != null ? data.l2Block.toLocaleString() : "N/A",
+  },
+  {
+    title: "L1 Head Block",
+    value: data.l1Block != null ? data.l1Block.toLocaleString() : "N/A",
+  },
+];
+
+export const hasBadRequest = (results: RequestResult<unknown>[]): boolean =>
+  results.some((r) => r.badRequest);

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "check": "tsc --noEmit",
-    "test": "tsc -p tsconfig.tests.json && node tests-build/tests/utils.test.js"
+    "test": "tsc -p tsconfig.tests.json && node tests-build/tests/utils.test.js && node tests-build/tests/helpers.test.js"
   },
   "dependencies": {
     "react": "^19.1.0",

--- a/dashboard/tests/helpers.test.ts
+++ b/dashboard/tests/helpers.test.ts
@@ -1,0 +1,35 @@
+import assert from "assert";
+import { createMetrics, hasBadRequest } from "../helpers.js";
+
+const metrics = createMetrics({
+  l2Cadence: 60000,
+  batchCadence: null,
+  avgProve: 1200,
+  avgVerify: 0,
+  activeGateways: 2,
+  l2Reorgs: 1,
+  slashings: null,
+  forcedInclusions: 0,
+  l2Block: 100,
+  l1Block: 50,
+});
+
+assert.strictEqual(metrics[0].value, "60.0s");
+assert.strictEqual(metrics[1].value, "N/A");
+assert.strictEqual(metrics[2].value, "1.20s");
+assert.strictEqual(metrics[3].value, "N/A");
+assert.strictEqual(metrics[4].value, "2");
+assert.strictEqual(metrics[5].value, "1");
+assert.strictEqual(metrics[6].value, "N/A");
+assert.strictEqual(metrics[7].value, "0");
+assert.strictEqual(metrics[8].value, "100");
+assert.strictEqual(metrics[9].value, "50");
+
+const results = [
+  { badRequest: false, data: null },
+  { badRequest: true, data: null },
+];
+assert.strictEqual(hasBadRequest(results), true);
+assert.strictEqual(hasBadRequest([{ badRequest: false, data: null }]), false);
+
+console.log("Helper tests passed.");


### PR DESCRIPTION
## Summary
- extract helper functions for metrics and error checking
- update app to use new helpers
- add unit tests for helpers and include them in npm test

## Testing
- `npm test`