### PR TITLE
Fix Tailwind content pattern

### DIFF
--- a/dashboard/tailwind.config.js
+++ b/dashboard/tailwind.config.js
@@ -1,9 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
-  content: [
-    './index.html',
-    './**/*.{ts,tsx}',
-  ],
+  content: ["./index.html", "./**/*.{ts,tsx}", "!./node_modules/**/*"],
   theme: {
     extend: {},
   },


### PR DESCRIPTION
## Summary
- ignore `node_modules` in dashboard Tailwind config to avoid scanning it

## Testing
- `npm run check`