### PR TITLE
Add extra frontend unit tests

### DIFF
--- a/dashboard/tests/helpers.test.ts
+++ b/dashboard/tests/helpers.test.ts
@@ -1,5 +1,5 @@
-import assert from "assert";
-import { createMetrics, hasBadRequest } from "../helpers.js";
+import assert from 'assert';
+import { createMetrics, hasBadRequest } from '../helpers.js';
 
 const metrics = createMetrics({
   l2Cadence: 60000,
@@ -14,16 +14,16 @@ const metrics = createMetrics({
   l1Block: 50,
 });
 
-assert.strictEqual(metrics[0].value, "60.0s");
-assert.strictEqual(metrics[1].value, "N/A");
-assert.strictEqual(metrics[2].value, "1.20s");
-assert.strictEqual(metrics[3].value, "N/A");
-assert.strictEqual(metrics[4].value, "2");
-assert.strictEqual(metrics[5].value, "1");
-assert.strictEqual(metrics[6].value, "N/A");
-assert.strictEqual(metrics[7].value, "0");
-assert.strictEqual(metrics[8].value, "100");
-assert.strictEqual(metrics[9].value, "50");
+assert.strictEqual(metrics[0].value, '60.0s');
+assert.strictEqual(metrics[1].value, 'N/A');
+assert.strictEqual(metrics[2].value, '1.20s');
+assert.strictEqual(metrics[3].value, 'N/A');
+assert.strictEqual(metrics[4].value, '2');
+assert.strictEqual(metrics[5].value, '1');
+assert.strictEqual(metrics[6].value, 'N/A');
+assert.strictEqual(metrics[7].value, '0');
+assert.strictEqual(metrics[8].value, '100');
+assert.strictEqual(metrics[9].value, '50');
 
 const results = [
   { badRequest: false, data: null },
@@ -32,4 +32,28 @@ const results = [
 assert.strictEqual(hasBadRequest(results), true);
 assert.strictEqual(hasBadRequest([{ badRequest: false, data: null }]), false);
 
-console.log("Helper tests passed.");
+const metricsAllNull = createMetrics({
+  l2Cadence: null,
+  batchCadence: null,
+  avgProve: null,
+  avgVerify: null,
+  activeGateways: null,
+  l2Reorgs: null,
+  slashings: null,
+  forcedInclusions: null,
+  l2Block: null,
+  l1Block: null,
+});
+for (const metric of metricsAllNull) {
+  assert.strictEqual(metric.value, 'N/A');
+}
+
+assert.strictEqual(
+  hasBadRequest([
+    { badRequest: false, data: null },
+    { badRequest: false, data: null },
+  ]),
+  false,
+);
+
+console.log('Helper tests passed.');

--- a/dashboard/tests/utils.test.ts
+++ b/dashboard/tests/utils.test.ts
@@ -1,4 +1,4 @@
-import assert from "assert";
+import assert from 'assert';
 import {
   formatDecimal,
   formatSeconds,
@@ -8,39 +8,59 @@ import {
   shouldShowMinutes,
   findMetricValue,
   formatSequencerTooltip,
-} from "../utils.js";
+} from '../utils.js';
 
-assert.strictEqual(formatDecimal(1), "1.00");
-assert.strictEqual(formatDecimal(12.345), "12.3");
+assert.strictEqual(formatDecimal(1), '1.00');
+assert.strictEqual(formatDecimal(12.345), '12.3');
 
-assert.strictEqual(formatSeconds(30), "30.0s");
-assert.strictEqual(formatSeconds(150), "2.5m");
-assert.strictEqual(formatSeconds(7200), "2h");
+assert.strictEqual(formatSeconds(30), '30.0s');
+assert.strictEqual(formatSeconds(150), '2.5m');
+assert.strictEqual(formatSeconds(7200), '2h');
 
-assert.strictEqual(formatInterval(30000, false), "30 seconds");
-assert.strictEqual(formatInterval(180000, true), "3.00 minutes");
+assert.strictEqual(formatInterval(30000, false), '30 seconds');
+assert.strictEqual(formatInterval(180000, true), '3.00 minutes');
 
-assert.strictEqual(formatBatchDuration(45, false, false), "45 seconds");
-assert.strictEqual(formatBatchDuration(150, false, true), "2.50 minutes");
-assert.strictEqual(formatBatchDuration(7200, true, false), "2.00 hours");
+assert.strictEqual(formatBatchDuration(45, false, false), '45 seconds');
+assert.strictEqual(formatBatchDuration(150, false, true), '2.50 minutes');
+assert.strictEqual(formatBatchDuration(7200, true, false), '2.00 hours');
 
 const flags = computeBatchDurationFlags([{ value: 30 }, { value: 7200 }]);
 assert.strictEqual(flags.showHours, true);
 assert.strictEqual(flags.showMinutes, false);
+
+const flagsMinutes = computeBatchDurationFlags([
+  { value: 150 },
+  { value: 100 },
+]);
+assert.strictEqual(flagsMinutes.showHours, false);
+assert.strictEqual(flagsMinutes.showMinutes, true);
+
+const flagsNone = computeBatchDurationFlags([{ value: 60 }, { value: 80 }]);
+assert.strictEqual(flagsNone.showHours, false);
+assert.strictEqual(flagsNone.showMinutes, false);
 
 assert.strictEqual(
   shouldShowMinutes([{ timestamp: 1000 }, { timestamp: 200000 }]),
   true,
 );
 
+assert.strictEqual(
+  shouldShowMinutes([{ timestamp: 1000 }, { timestamp: 110000 }]),
+  false,
+);
+
 const metrics = [
-  { title: "Test", value: "42" },
-  { title: "Another", value: "0" },
+  { title: 'Test', value: '42' },
+  { title: 'Another', value: '0' },
 ];
-assert.strictEqual(findMetricValue(metrics, "test"), "42");
-assert.strictEqual(findMetricValue(metrics, "missing"), "N/A");
+assert.strictEqual(findMetricValue(metrics, 'test'), '42');
+assert.strictEqual(findMetricValue(metrics, 'TEST'), '42');
+assert.strictEqual(findMetricValue(metrics, 'missing'), 'N/A');
 
 const tooltip = formatSequencerTooltip([{ value: 1 }, { value: 3 }], 1);
-assert.strictEqual(tooltip, "1 blocks (25.00%)");
+assert.strictEqual(tooltip, '1 blocks (25.00%)');
 
-console.log("All tests passed.");
+const zeroTooltip = formatSequencerTooltip([{ value: 0 }], 0);
+assert.strictEqual(zeroTooltip, '0 blocks (0%)');
+
+console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- expand frontend unit tests to cover more helper and utility cases

## Testing
- `npm run check`
- `npm run test`
