### PR TITLE
Add operator metrics to dashboard

### DIFF
--- a/dashboard/App.tsx
+++ b/dashboard/App.tsx
@@ -1,18 +1,18 @@
-import React, { useState, useEffect, useCallback } from "react";
-import { findMetricValue } from "./utils";
-import { createMetrics, hasBadRequest } from "./helpers";
-import { DashboardHeader } from "./components/DashboardHeader";
-import { MetricCard } from "./components/MetricCard";
-import { ChartCard } from "./components/ChartCard";
-import { SequencerPieChart } from "./components/SequencerPieChart";
-import { BlockTimeChart } from "./components/BlockTimeChart";
-import { BatchProcessChart } from "./components/BatchProcessChart";
+import React, { useState, useEffect, useCallback } from 'react';
+import { findMetricValue } from './utils';
+import { createMetrics, hasBadRequest } from './helpers';
+import { DashboardHeader } from './components/DashboardHeader';
+import { MetricCard } from './components/MetricCard';
+import { ChartCard } from './components/ChartCard';
+import { SequencerPieChart } from './components/SequencerPieChart';
+import { BlockTimeChart } from './components/BlockTimeChart';
+import { BatchProcessChart } from './components/BatchProcessChart';
 import {
   TimeRange,
   TimeSeriesData,
   PieChartDataItem,
   MetricData,
-} from "./types";
+} from './types';
 import {
   API_BASE,
   fetchAvgProveTime,
@@ -23,6 +23,8 @@ import {
   fetchL2Reorgs,
   fetchSlashingEvents,
   fetchForcedInclusions,
+  fetchCurrentOperator,
+  fetchNextOperator,
   fetchL2HeadBlock,
   fetchL1HeadBlock,
   fetchL2HeadNumber,
@@ -32,13 +34,13 @@ import {
   fetchL1BlockTimes,
   fetchL2BlockTimes,
   fetchSequencerDistribution,
-} from "./services/apiService";
+} from './services/apiService';
 
 // Updated Taiko Pink
-const TAIKO_PINK = "#e81899";
+const TAIKO_PINK = '#e81899';
 
 const App: React.FC = () => {
-  const [timeRange, setTimeRange] = useState<TimeRange>("1h");
+  const [timeRange, setTimeRange] = useState<TimeRange>('1h');
   const [metrics, setMetrics] = useState<MetricData[]>([]);
   const [secondsToProveData, setSecondsToProveData] = useState<
     TimeSeriesData[]
@@ -51,10 +53,10 @@ const App: React.FC = () => {
   const [sequencerDistribution, setSequencerDistribution] = useState<
     PieChartDataItem[]
   >([]);
-  const [l2HeadBlock, setL2HeadBlock] = useState<string>("0");
-  const [l1HeadBlock, setL1HeadBlock] = useState<string>("0");
+  const [l2HeadBlock, setL2HeadBlock] = useState<string>('0');
+  const [l1HeadBlock, setL1HeadBlock] = useState<string>('0');
   const [refreshRate, setRefreshRate] = useState<number>(60000);
-  const [errorMessage, setErrorMessage] = useState<string>("");
+  const [errorMessage, setErrorMessage] = useState<string>('');
 
   useEffect(() => {
     let pollId: NodeJS.Timeout | null = null;
@@ -69,7 +71,7 @@ const App: React.FC = () => {
         setL1HeadBlock(value);
         setMetrics((m) =>
           m.map((metric) =>
-            metric.title === "L1 Head Block" ? { ...metric, value } : metric,
+            metric.title === 'L1 Head Block' ? { ...metric, value } : metric,
           ),
         );
       }
@@ -78,7 +80,7 @@ const App: React.FC = () => {
         setL2HeadBlock(value);
         setMetrics((m) =>
           m.map((metric) =>
-            metric.title === "L2 Head Block" ? { ...metric, value } : metric,
+            metric.title === 'L2 Head Block' ? { ...metric, value } : metric,
           ),
         );
       }
@@ -87,7 +89,7 @@ const App: React.FC = () => {
     const startPolling = () => {
       if (!pollId) {
         setErrorMessage(
-          "Realtime updates unavailable, falling back to polling.",
+          'Realtime updates unavailable, falling back to polling.',
         );
         updateHeads();
         pollId = setInterval(updateHeads, 10000);
@@ -102,7 +104,7 @@ const App: React.FC = () => {
       setL1HeadBlock(value);
       setMetrics((m) =>
         m.map((metric) =>
-          metric.title === "L1 Head Block" ? { ...metric, value } : metric,
+          metric.title === 'L1 Head Block' ? { ...metric, value } : metric,
         ),
       );
     };
@@ -111,7 +113,7 @@ const App: React.FC = () => {
       setL2HeadBlock(value);
       setMetrics((m) =>
         m.map((metric) =>
-          metric.title === "L2 Head Block" ? { ...metric, value } : metric,
+          metric.title === 'L2 Head Block' ? { ...metric, value } : metric,
         ),
       );
     };
@@ -140,6 +142,8 @@ const App: React.FC = () => {
       avgProveRes,
       avgVerifyRes,
       activeGatewaysRes,
+      currentOperatorRes,
+      nextOperatorRes,
       l2ReorgsRes,
       slashingsRes,
       forcedInclusionsRes,
@@ -156,6 +160,8 @@ const App: React.FC = () => {
       fetchAvgProveTime(range),
       fetchAvgVerifyTime(range),
       fetchActiveGateways(range),
+      fetchCurrentOperator(),
+      fetchNextOperator(),
       fetchL2Reorgs(range),
       fetchSlashingEvents(range),
       fetchForcedInclusions(range),
@@ -173,6 +179,8 @@ const App: React.FC = () => {
     const avgProve = avgProveRes.data;
     const avgVerify = avgVerifyRes.data;
     const activeGateways = activeGatewaysRes.data;
+    const currentOperator = currentOperatorRes.data;
+    const nextOperator = nextOperatorRes.data;
     const l2Reorgs = l2ReorgsRes.data;
     const slashings = slashingsRes.data;
     const forcedInclusions = forcedInclusionsRes.data;
@@ -190,6 +198,8 @@ const App: React.FC = () => {
       avgProveRes,
       avgVerifyRes,
       activeGatewaysRes,
+      currentOperatorRes,
+      nextOperatorRes,
       l2ReorgsRes,
       slashingsRes,
       forcedInclusionsRes,
@@ -208,6 +218,8 @@ const App: React.FC = () => {
       avgProve,
       avgVerify,
       activeGateways,
+      currentOperator,
+      nextOperator,
       l2Reorgs,
       slashings,
       forcedInclusions,
@@ -222,17 +234,17 @@ const App: React.FC = () => {
     setL1BlockTimeData(l1Times);
     setSequencerDistribution(sequencerDist);
     setL2HeadBlock(
-      currentMetrics.find((m) => m.title === "L2 Head Block")?.value || "N/A",
+      currentMetrics.find((m) => m.title === 'L2 Head Block')?.value || 'N/A',
     );
     setL1HeadBlock(
-      currentMetrics.find((m) => m.title === "L1 Head Block")?.value || "N/A",
+      currentMetrics.find((m) => m.title === 'L1 Head Block')?.value || 'N/A',
     );
     if (anyBadRequest) {
       setErrorMessage(
-        "Invalid parameters provided. Some data may not be available.",
+        'Invalid parameters provided. Some data may not be available.',
       );
     } else {
-      setErrorMessage("");
+      setErrorMessage('');
     }
   }, [timeRange]);
 
@@ -266,37 +278,45 @@ const App: React.FC = () => {
           {/* Grouped Metrics */}
           <MetricCard
             title="L2 Block Cadence"
-            value={findMetricValue(metrics, "L2 Block Cadence")}
+            value={findMetricValue(metrics, 'L2 Block Cadence')}
           />
           <MetricCard
             title="Batch Posting Cadence"
-            value={findMetricValue(metrics, "Batch Posting Cadence")}
+            value={findMetricValue(metrics, 'Batch Posting Cadence')}
           />
           <MetricCard
             title="Avg. Prove Time"
-            value={findMetricValue(metrics, "Avg. Prove Time")}
+            value={findMetricValue(metrics, 'Avg. Prove Time')}
           />
           <MetricCard
             title="Avg. Verify Time"
-            value={findMetricValue(metrics, "Avg. Verify Time")}
+            value={findMetricValue(metrics, 'Avg. Verify Time')}
           />
 
           {/* Other Metrics */}
           <MetricCard
             title="Active Gateways"
-            value={findMetricValue(metrics, "Active Gateways")}
+            value={findMetricValue(metrics, 'Active Gateways')}
+          />
+          <MetricCard
+            title="Current Operator"
+            value={findMetricValue(metrics, 'Current Operator')}
+          />
+          <MetricCard
+            title="Next Operator"
+            value={findMetricValue(metrics, 'Next Operator')}
           />
           <MetricCard
             title="L2 Reorgs"
-            value={findMetricValue(metrics, "L2 Reorgs")}
+            value={findMetricValue(metrics, 'L2 Reorgs')}
           />
           <MetricCard
             title="Slashing Events"
-            value={findMetricValue(metrics, "Slashing Events")}
+            value={findMetricValue(metrics, 'Slashing Events')}
           />
           <MetricCard
             title="Forced Inclusions"
-            value={findMetricValue(metrics, "Forced Inclusions")}
+            value={findMetricValue(metrics, 'Forced Inclusions')}
           />
         </div>
 

--- a/dashboard/helpers.ts
+++ b/dashboard/helpers.ts
@@ -1,7 +1,7 @@
-import React from "react";
-import { type MetricData } from "./types";
-import { formatSeconds } from "./utils.js";
-import type { RequestResult } from "./services/apiService";
+import React from 'react';
+import { type MetricData } from './types';
+import { formatSeconds } from './utils.js';
+import type { RequestResult } from './services/apiService';
 
 export interface MetricInputData {
   l2Cadence: number | null;
@@ -9,6 +9,8 @@ export interface MetricInputData {
   avgProve: number | null;
   avgVerify: number | null;
   activeGateways: number | null;
+  currentOperator: string | null;
+  nextOperator: string | null;
   l2Reorgs: number | null;
   slashings: number | null;
   forcedInclusions: number | null;
@@ -18,64 +20,72 @@ export interface MetricInputData {
 
 export const createMetrics = (data: MetricInputData): MetricData[] => [
   {
-    title: "L2 Block Cadence",
+    title: 'L2 Block Cadence',
     value:
-      data.l2Cadence != null ? formatSeconds(data.l2Cadence / 1000) : "N/A",
+      data.l2Cadence != null ? formatSeconds(data.l2Cadence / 1000) : 'N/A',
   },
   {
-    title: "Batch Posting Cadence",
+    title: 'Batch Posting Cadence',
     value:
       data.batchCadence != null
         ? formatSeconds(data.batchCadence / 1000)
-        : "N/A",
+        : 'N/A',
   },
   {
-    title: "Avg. Prove Time",
+    title: 'Avg. Prove Time',
     value:
       data.avgProve != null && data.avgProve > 0
         ? formatSeconds(data.avgProve / 1000)
-        : "N/A",
+        : 'N/A',
   },
   {
     title: React.createElement(
-      "a",
+      'a',
       {
-        href: "https://docs.taiko.xyz/taiko-alethia-protocol/protocol-architecture/block-states",
-        target: "_blank",
-        rel: "noopener noreferrer",
-        className: "hover:underline",
+        href: 'https://docs.taiko.xyz/taiko-alethia-protocol/protocol-architecture/block-states',
+        target: '_blank',
+        rel: 'noopener noreferrer',
+        className: 'hover:underline',
       },
-      "Avg. Verify Time",
+      'Avg. Verify Time',
     ),
     value:
       data.avgVerify != null && data.avgVerify > 0
         ? formatSeconds(data.avgVerify / 1000)
-        : "N/A",
+        : 'N/A',
   },
   {
-    title: "Active Gateways",
-    value: data.activeGateways != null ? data.activeGateways.toString() : "N/A",
+    title: 'Active Gateways',
+    value: data.activeGateways != null ? data.activeGateways.toString() : 'N/A',
   },
   {
-    title: "L2 Reorgs",
-    value: data.l2Reorgs != null ? data.l2Reorgs.toString() : "N/A",
+    title: 'Current Operator',
+    value: data.currentOperator ?? 'N/A',
   },
   {
-    title: "Slashing Events",
-    value: data.slashings != null ? data.slashings.toString() : "N/A",
+    title: 'Next Operator',
+    value: data.nextOperator ?? 'N/A',
   },
   {
-    title: "Forced Inclusions",
+    title: 'L2 Reorgs',
+    value: data.l2Reorgs != null ? data.l2Reorgs.toString() : 'N/A',
+  },
+  {
+    title: 'Slashing Events',
+    value: data.slashings != null ? data.slashings.toString() : 'N/A',
+  },
+  {
+    title: 'Forced Inclusions',
     value:
-      data.forcedInclusions != null ? data.forcedInclusions.toString() : "N/A",
+      data.forcedInclusions != null ? data.forcedInclusions.toString() : 'N/A',
   },
   {
-    title: "L2 Head Block",
-    value: data.l2Block != null ? data.l2Block.toLocaleString() : "N/A",
+    title: 'L2 Head Block',
+    value: data.l2Block != null ? data.l2Block.toLocaleString() : 'N/A',
   },
   {
-    title: "L1 Head Block",
-    value: data.l1Block != null ? data.l1Block.toLocaleString() : "N/A",
+    title: 'L1 Head Block',
+    value: data.l1Block != null ? data.l1Block.toLocaleString() : 'N/A',
   },
 ];
 

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -139,6 +139,20 @@ export const fetchL1HeadBlock = async (
   return { data: value, badRequest: res.badRequest };
 };
 
+export const fetchCurrentOperator = async (): Promise<
+  RequestResult<string>
+> => {
+  const url = `${API_BASE}/current-operator`;
+  const res = await fetchJson<{ operator?: string }>(url);
+  return { data: res.data?.operator ?? null, badRequest: res.badRequest };
+};
+
+export const fetchNextOperator = async (): Promise<RequestResult<string>> => {
+  const url = `${API_BASE}/next-operator`;
+  const res = await fetchJson<{ operator?: string }>(url);
+  return { data: res.data?.operator ?? null, badRequest: res.badRequest };
+};
+
 export const fetchL2HeadNumber = async (): Promise<RequestResult<number>> => {
   const url = `${API_BASE}/l2-head-block`;
   const res = await fetchJson<{ l2_head_block?: number }>(url);

--- a/dashboard/tests/helpers.test.ts
+++ b/dashboard/tests/helpers.test.ts
@@ -7,6 +7,8 @@ const metrics = createMetrics({
   avgProve: 1200,
   avgVerify: 0,
   activeGateways: 2,
+  currentOperator: '0xabc',
+  nextOperator: null,
   l2Reorgs: 1,
   slashings: null,
   forcedInclusions: 0,
@@ -19,11 +21,13 @@ assert.strictEqual(metrics[1].value, 'N/A');
 assert.strictEqual(metrics[2].value, '1.20s');
 assert.strictEqual(metrics[3].value, 'N/A');
 assert.strictEqual(metrics[4].value, '2');
-assert.strictEqual(metrics[5].value, '1');
+assert.strictEqual(metrics[5].value, '0xabc');
 assert.strictEqual(metrics[6].value, 'N/A');
-assert.strictEqual(metrics[7].value, '0');
-assert.strictEqual(metrics[8].value, '100');
-assert.strictEqual(metrics[9].value, '50');
+assert.strictEqual(metrics[7].value, '1');
+assert.strictEqual(metrics[8].value, 'N/A');
+assert.strictEqual(metrics[9].value, '0');
+assert.strictEqual(metrics[10].value, '100');
+assert.strictEqual(metrics[11].value, '50');
 
 const results = [
   { badRequest: false, data: null },
@@ -43,6 +47,8 @@ const metricsAllNull = createMetrics({
   forcedInclusions: null,
   l2Block: null,
   l1Block: null,
+  currentOperator: null,
+  nextOperator: null,
 });
 for (const metric of metricsAllNull) {
   assert.strictEqual(metric.value, 'N/A');


### PR DESCRIPTION
## Summary
- expose current and next operator endpoints
- query last operators from clickhouse
- show current/next operator metrics in dashboard
- update helper tests for new fields

## Testing
- `just ci`
- `just dashboard-check`
