### PR TITLE
Fix rounding of L2 block intervals

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -958,7 +958,7 @@ mod tests {
     struct L2BlockTimeRowTest {
         l2_block_number: u64,
         block_time: u64,
-        seconds_since_prev_block: Option<u64>,
+        ms_since_prev_block: Option<u64>,
     }
 
     #[tokio::test]
@@ -983,22 +983,18 @@ mod tests {
     async fn l2_block_times_last_hour_endpoint() {
         let mock = Mock::new();
         mock.add(handlers::provide(vec![
-            L2BlockTimeRowTest {
-                l2_block_number: 0,
-                block_time: 0,
-                seconds_since_prev_block: None,
-            },
+            L2BlockTimeRowTest { l2_block_number: 0, block_time: 0, ms_since_prev_block: None },
             L2BlockTimeRowTest {
                 l2_block_number: 1,
                 block_time: 2,
-                seconds_since_prev_block: Some(2),
+                ms_since_prev_block: Some(2000),
             },
         ]));
         let app = build_app(mock.url());
         let body = send_request(app, "/l2-block-times?range=1h").await;
         assert_eq!(
             body,
-            json!({ "blocks": [ { "l2_block_number": 1, "block_time": "1970-01-01T00:00:02Z", "seconds_since_prev_block": 2 } ] })
+            json!({ "blocks": [ { "l2_block_number": 1, "block_time": "1970-01-01T00:00:02Z", "seconds_since_prev_block": 2.0 } ] })
         );
     }
 
@@ -1006,22 +1002,18 @@ mod tests {
     async fn l2_block_times_last_day_endpoint() {
         let mock = Mock::new();
         mock.add(handlers::provide(vec![
-            L2BlockTimeRowTest {
-                l2_block_number: 0,
-                block_time: 0,
-                seconds_since_prev_block: None,
-            },
+            L2BlockTimeRowTest { l2_block_number: 0, block_time: 0, ms_since_prev_block: None },
             L2BlockTimeRowTest {
                 l2_block_number: 1,
                 block_time: 2,
-                seconds_since_prev_block: Some(2),
+                ms_since_prev_block: Some(2000),
             },
         ]));
         let app = build_app(mock.url());
         let body = send_request(app, "/l2-block-times?range=24h").await;
         assert_eq!(
             body,
-            json!({ "blocks": [ { "l2_block_number": 1, "block_time": "1970-01-01T00:00:02Z", "seconds_since_prev_block": 2 } ] })
+            json!({ "blocks": [ { "l2_block_number": 1, "block_time": "1970-01-01T00:00:02Z", "seconds_since_prev_block": 2.0 } ] })
         );
     }
 
@@ -1029,22 +1021,18 @@ mod tests {
     async fn l2_block_times_last_week_endpoint() {
         let mock = Mock::new();
         mock.add(handlers::provide(vec![
-            L2BlockTimeRowTest {
-                l2_block_number: 0,
-                block_time: 0,
-                seconds_since_prev_block: None,
-            },
+            L2BlockTimeRowTest { l2_block_number: 0, block_time: 0, ms_since_prev_block: None },
             L2BlockTimeRowTest {
                 l2_block_number: 1,
                 block_time: 2,
-                seconds_since_prev_block: Some(2),
+                ms_since_prev_block: Some(2000),
             },
         ]));
         let app = build_app(mock.url());
         let body = send_request(app, "/l2-block-times?range=7d").await;
         assert_eq!(
             body,
-            json!({ "blocks": [ { "l2_block_number": 1, "block_time": "1970-01-01T00:00:02Z", "seconds_since_prev_block": 2 } ] })
+            json!({ "blocks": [ { "l2_block_number": 1, "block_time": "1970-01-01T00:00:02Z", "seconds_since_prev_block": 2.0 } ] })
         );
     }
 

--- a/crates/clickhouse/src/models.rs
+++ b/crates/clickhouse/src/models.rs
@@ -155,12 +155,12 @@ pub struct L1BlockTimeRow {
 }
 
 /// Row representing the time between consecutive L2 blocks
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct L2BlockTimeRow {
     /// L2 block number
     pub l2_block_number: u64,
     /// Timestamp of the L2 block
     pub block_time: DateTime<Utc>,
     /// Seconds since the previous block
-    pub seconds_since_prev_block: Option<u64>,
+    pub seconds_since_prev_block: Option<f64>,
 }

--- a/crates/clickhouse/src/reader.rs
+++ b/crates/clickhouse/src/reader.rs
@@ -975,15 +975,15 @@ impl ClickhouseReader {
         struct RawRow {
             l2_block_number: u64,
             block_time: u64,
-            seconds_since_prev_block: Option<u64>,
+            ms_since_prev_block: Option<u64>,
         }
 
         let client = self.base.clone().with_database(&self.db_name);
         let query = format!(
             "SELECT l2_block_number, \
                     block_ts AS block_time, \
-                    toUInt64OrNull(toString(block_ts - lagInFrame(block_ts) OVER (ORDER BY l2_block_number))) \
-                        AS seconds_since_prev_block \
+                    toUInt64OrNull(toUnixTimestamp64Milli(inserted_at) - lagInFrame(toUnixTimestamp64Milli(inserted_at)) OVER (ORDER BY l2_block_number)) \
+                        AS ms_since_prev_block \
              FROM {db}.l2_head_events \
              WHERE block_ts >= toUnixTimestamp(now64() - INTERVAL 1 HOUR) \
              ORDER BY l2_block_number",
@@ -994,10 +994,10 @@ impl ClickhouseReader {
             .into_iter()
             .filter_map(|r| {
                 let dt = Utc.timestamp_opt(r.block_time as i64, 0).single()?;
-                r.seconds_since_prev_block.map(|secs| L2BlockTimeRow {
+                r.ms_since_prev_block.map(|ms| L2BlockTimeRow {
                     l2_block_number: r.l2_block_number,
                     block_time: dt,
-                    seconds_since_prev_block: Some(secs),
+                    seconds_since_prev_block: Some(ms as f64 / 1000.0),
                 })
             })
             .collect())
@@ -1009,15 +1009,15 @@ impl ClickhouseReader {
         struct RawRow {
             l2_block_number: u64,
             block_time: u64,
-            seconds_since_prev_block: Option<u64>,
+            ms_since_prev_block: Option<u64>,
         }
 
         let client = self.base.clone().with_database(&self.db_name);
         let query = format!(
             "SELECT l2_block_number, \
                     block_ts AS block_time, \
-                    toUInt64OrNull(toString(block_ts - lagInFrame(block_ts) OVER (ORDER BY l2_block_number))) \
-                        AS seconds_since_prev_block \
+                    toUInt64OrNull(toUnixTimestamp64Milli(inserted_at) - lagInFrame(toUnixTimestamp64Milli(inserted_at)) OVER (ORDER BY l2_block_number)) \
+                        AS ms_since_prev_block \
              FROM {db}.l2_head_events \
              WHERE block_ts >= toUnixTimestamp(now64() - INTERVAL 24 HOUR) \
              ORDER BY l2_block_number",
@@ -1028,10 +1028,10 @@ impl ClickhouseReader {
             .into_iter()
             .filter_map(|r| {
                 let dt = Utc.timestamp_opt(r.block_time as i64, 0).single()?;
-                r.seconds_since_prev_block.map(|secs| L2BlockTimeRow {
+                r.ms_since_prev_block.map(|ms| L2BlockTimeRow {
                     l2_block_number: r.l2_block_number,
                     block_time: dt,
-                    seconds_since_prev_block: Some(secs),
+                    seconds_since_prev_block: Some(ms as f64 / 1000.0),
                 })
             })
             .collect())
@@ -1043,15 +1043,15 @@ impl ClickhouseReader {
         struct RawRow {
             l2_block_number: u64,
             block_time: u64,
-            seconds_since_prev_block: Option<u64>,
+            ms_since_prev_block: Option<u64>,
         }
 
         let client = self.base.clone().with_database(&self.db_name);
         let query = format!(
             "SELECT l2_block_number, \
                     block_ts AS block_time, \
-                    toUInt64OrNull(toString(block_ts - lagInFrame(block_ts) OVER (ORDER BY l2_block_number))) \
-                        AS seconds_since_prev_block \
+                    toUInt64OrNull(toUnixTimestamp64Milli(inserted_at) - lagInFrame(toUnixTimestamp64Milli(inserted_at)) OVER (ORDER BY l2_block_number)) \
+                        AS ms_since_prev_block \
              FROM {db}.l2_head_events \
              WHERE block_ts >= toUnixTimestamp(now64() - INTERVAL 7 DAY) \
              ORDER BY l2_block_number",
@@ -1062,10 +1062,10 @@ impl ClickhouseReader {
             .into_iter()
             .filter_map(|r| {
                 let dt = Utc.timestamp_opt(r.block_time as i64, 0).single()?;
-                r.seconds_since_prev_block.map(|secs| L2BlockTimeRow {
+                r.ms_since_prev_block.map(|ms| L2BlockTimeRow {
                     l2_block_number: r.l2_block_number,
                     block_time: dt,
-                    seconds_since_prev_block: Some(secs),
+                    seconds_since_prev_block: Some(ms as f64 / 1000.0),
                 })
             })
             .collect())


### PR DESCRIPTION
## Summary
- avoid rounding L2 block intervals by computing millisecond deltas
- expose seconds_since_prev_block as a float
- update API tests

## Testing
- `just ci`