### PR TITLE
Allow custom CORS origins for API

### DIFF
--- a/bin/api-server/src/main.rs
+++ b/bin/api-server/src/main.rs
@@ -44,7 +44,7 @@ async fn main() -> eyre::Result<()> {
         info!("👋 API server shutting down...");
     };
 
-    let run_server = async { run(addr, client).await };
+    let run_server = async { run(addr, client, opts.api.allowed_origins).await };
 
     run_until_shutdown(run_server, shutdown_signal, on_shutdown).await
 }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -100,6 +100,9 @@ pub struct ApiOpts {
     /// API server port
     #[clap(long = "api-port", env = "API_PORT", default_value = "3000")]
     pub port: u16,
+    /// Additional allowed CORS origins (comma separated)
+    #[clap(long = "allowed-origin", env = "ALLOWED_ORIGINS", value_delimiter = ',')]
+    pub allowed_origins: Vec<String>,
 }
 
 /// CLI options for taikoscope
@@ -191,6 +194,7 @@ mod tests {
         assert_eq!(opts.instatus.batch_proof_timeout_secs, 10800);
         assert_eq!(opts.api.host, "127.0.0.1");
         assert_eq!(opts.api.port, 3000);
+        assert!(opts.api.allowed_origins.is_empty());
         assert!(!opts.reset_db);
     }
 
@@ -202,6 +206,7 @@ mod tests {
             env::set_var("INSTATUS_MONITOR_POLL_INTERVAL_SECS", "42");
             env::set_var("INSTATUS_MONITOR_THRESHOLD_SECS", "33");
             env::set_var("BATCH_PROOF_TIMEOUT_SECS", "99");
+            env::set_var("ALLOWED_ORIGINS", "http://localhost:3000,http://localhost:5173");
         }
 
         let mut args = base_args();
@@ -214,12 +219,17 @@ mod tests {
         assert_eq!(opts.instatus.batch_proof_timeout_secs, 99);
         assert_eq!(opts.api.host, "127.0.0.1");
         assert_eq!(opts.api.port, 3000);
+        assert_eq!(
+            opts.api.allowed_origins,
+            vec!["http://localhost:3000", "http://localhost:5173",]
+        );
         assert!(opts.reset_db);
 
         unsafe {
             env::remove_var("INSTATUS_MONITOR_POLL_INTERVAL_SECS");
             env::remove_var("INSTATUS_MONITOR_THRESHOLD_SECS");
             env::remove_var("BATCH_PROOF_TIMEOUT_SECS");
+            env::remove_var("ALLOWED_ORIGINS");
         }
     }
 }

--- a/crates/driver/src/lib.rs
+++ b/crates/driver/src/lib.rs
@@ -539,7 +539,7 @@ mod tests {
                 password: "pass".into(),
             },
             rpc: RpcOpts { l1_url, l2_url },
-            api: ApiOpts { host: "127.0.0.1".into(), port: 3000 },
+            api: ApiOpts { host: "127.0.0.1".into(), port: 3000, allowed_origins: Vec::new() },
             taiko_addresses: TaikoAddressOpts {
                 inbox_address: Address::ZERO,
                 preconf_whitelist_address: Address::ZERO,


### PR DESCRIPTION
## Summary
- allow passing extra CORS origins via command line or env var
- use these origins in API server
- update driver tests
- extend config tests

## Testing
- `just ci`