### PR TITLE
Refactor block time intervals to milliseconds

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -994,7 +994,7 @@ mod tests {
         let body = send_request(app, "/l2-block-times?range=1h").await;
         assert_eq!(
             body,
-            json!({ "blocks": [ { "l2_block_number": 1, "block_time": "1970-01-01T00:00:02Z", "seconds_since_prev_block": 2.0 } ] })
+            json!({ "blocks": [ { "l2_block_number": 1, "block_time": "1970-01-01T00:00:02Z", "ms_since_prev_block": 2000 } ] })
         );
     }
 
@@ -1013,7 +1013,7 @@ mod tests {
         let body = send_request(app, "/l2-block-times?range=24h").await;
         assert_eq!(
             body,
-            json!({ "blocks": [ { "l2_block_number": 1, "block_time": "1970-01-01T00:00:02Z", "seconds_since_prev_block": 2.0 } ] })
+            json!({ "blocks": [ { "l2_block_number": 1, "block_time": "1970-01-01T00:00:02Z", "ms_since_prev_block": 2000 } ] })
         );
     }
 
@@ -1032,7 +1032,7 @@ mod tests {
         let body = send_request(app, "/l2-block-times?range=7d").await;
         assert_eq!(
             body,
-            json!({ "blocks": [ { "l2_block_number": 1, "block_time": "1970-01-01T00:00:02Z", "seconds_since_prev_block": 2.0 } ] })
+            json!({ "blocks": [ { "l2_block_number": 1, "block_time": "1970-01-01T00:00:02Z", "ms_since_prev_block": 2000 } ] })
         );
     }
 

--- a/crates/clickhouse/src/models.rs
+++ b/crates/clickhouse/src/models.rs
@@ -155,12 +155,12 @@ pub struct L1BlockTimeRow {
 }
 
 /// Row representing the time between consecutive L2 blocks
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct L2BlockTimeRow {
     /// L2 block number
     pub l2_block_number: u64,
     /// Timestamp of the L2 block
     pub block_time: DateTime<Utc>,
-    /// Seconds since the previous block
-    pub seconds_since_prev_block: Option<f64>,
+    /// Milliseconds since the previous block
+    pub ms_since_prev_block: Option<u64>,
 }

--- a/crates/clickhouse/src/reader.rs
+++ b/crates/clickhouse/src/reader.rs
@@ -997,7 +997,7 @@ impl ClickhouseReader {
                 r.ms_since_prev_block.map(|ms| L2BlockTimeRow {
                     l2_block_number: r.l2_block_number,
                     block_time: dt,
-                    seconds_since_prev_block: Some(ms as f64 / 1000.0),
+                    ms_since_prev_block: Some(ms),
                 })
             })
             .collect())
@@ -1031,7 +1031,7 @@ impl ClickhouseReader {
                 r.ms_since_prev_block.map(|ms| L2BlockTimeRow {
                     l2_block_number: r.l2_block_number,
                     block_time: dt,
-                    seconds_since_prev_block: Some(ms as f64 / 1000.0),
+                    ms_since_prev_block: Some(ms),
                 })
             })
             .collect())
@@ -1065,7 +1065,7 @@ impl ClickhouseReader {
                 r.ms_since_prev_block.map(|ms| L2BlockTimeRow {
                     l2_block_number: r.l2_block_number,
                     block_time: dt,
-                    seconds_since_prev_block: Some(ms as f64 / 1000.0),
+                    ms_since_prev_block: Some(ms),
                 })
             })
             .collect())

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -241,7 +241,7 @@ export const fetchL2BlockTimes = async (
 ): Promise<RequestResult<TimeSeriesData[]>> => {
   const url = `${API_BASE}/l2-block-times?range=${range}`;
   const res = await fetchJson<{
-    blocks: { l2_block_number: number; seconds_since_prev_block: number }[];
+    blocks: { l2_block_number: number; ms_since_prev_block: number }[];
   }>(url);
   if (!res.data) {
     return { data: null, badRequest: res.badRequest };
@@ -250,7 +250,7 @@ export const fetchL2BlockTimes = async (
   const data = res.data.blocks.slice(1).map(
     (b): TimeSeriesData => ({
       value: b.l2_block_number,
-      timestamp: b.seconds_since_prev_block * 1000,
+      timestamp: b.ms_since_prev_block,
     }),
   );
 


### PR DESCRIPTION
## Notes
- Change `L2BlockTimeRow` to expose milliseconds instead of seconds
- Update ClickHouse reader to keep ms precision
- Adjust API tests and dashboard client for new field

## Testing
- `just lint`
- `just test`
