### PR TITLE
Fix operator address overflow

### DIFF
--- a/dashboard/components/MetricCard.tsx
+++ b/dashboard/components/MetricCard.tsx
@@ -16,7 +16,9 @@ export const MetricCard: React.FC<MetricCardProps> = ({
     <div className="bg-white p-4 rounded-lg border border-gray-200 transition-shadow duration-200">
       {/* Removed {unit && `(${unit})`} from here */}
       <h3 className="text-sm font-medium text-gray-500 truncate">{title}</h3>
-      <p className="mt-1 text-3xl font-semibold text-gray-900">{value}</p>
+      <p className="mt-1 text-3xl font-semibold text-gray-900 break-all">
+        {value}
+      </p>
       {description && (
         <p className="text-xs text-gray-400 mt-1">{description}</p>
       )}


### PR DESCRIPTION
## Summary
- prevent long operator addresses from overflowing the MetricCard

## Testing
- `npm run check`