### PR TITLE
Add metric groups to dashboard

### DIFF
--- a/dashboard/App.tsx
+++ b/dashboard/App.tsx
@@ -253,8 +253,21 @@ const App: React.FC = () => {
     return () => clearInterval(interval);
   }, [timeRange, fetchData, refreshRate]);
 
-  const operatorMetrics = metrics.filter((m) => m.group === 'Operators');
-  const otherMetrics = metrics.filter((m) => m.group !== 'Operators');
+  const groupedMetrics = metrics.reduce<Record<string, MetricData[]>>(
+    (acc, m) => {
+      const group = m.group ?? 'Other';
+      if (!acc[group]) acc[group] = [];
+      acc[group].push(m);
+      return acc;
+    },
+    {},
+  );
+  const groupOrder = [
+    'Network Performance',
+    'Network Health & Security',
+    'Operators',
+    'Other',
+  ];
 
   return (
     <div
@@ -276,20 +289,23 @@ const App: React.FC = () => {
 
       <main className="mt-6">
         {/* Metrics Grid */}
-        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 gap-4 md:gap-6">
-          {otherMetrics.map((m, idx) => (
-            <MetricCard key={`other-${idx}`} title={m.title} value={m.value} />
-          ))}
-        </div>
-        {operatorMetrics.length > 0 && (
-          <>
-            <h2 className="mt-6 mb-2 text-lg font-semibold">Operators</h2>
-            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 gap-4 md:gap-6">
-              {operatorMetrics.map((m, idx) => (
-                <MetricCard key={`op-${idx}`} title={m.title} value={m.value} />
-              ))}
-            </div>
-          </>
+        {groupOrder.map((group) =>
+          groupedMetrics[group] && groupedMetrics[group].length > 0 ? (
+            <React.Fragment key={group}>
+              {group !== 'Other' && (
+                <h2 className="mt-6 mb-2 text-lg font-semibold">{group}</h2>
+              )}
+              <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 gap-4 md:gap-6">
+                {groupedMetrics[group].map((m, idx) => (
+                  <MetricCard
+                    key={`${group}-${idx}`}
+                    title={m.title}
+                    value={m.value}
+                  />
+                ))}
+              </div>
+            </React.Fragment>
+          ) : null,
         )}
 
         {/* Charts Grid - Reordered: Sequencer Pie Chart first */}

--- a/dashboard/helpers.ts
+++ b/dashboard/helpers.ts
@@ -23,6 +23,7 @@ export const createMetrics = (data: MetricInputData): MetricData[] => [
     title: 'L2 Block Cadence',
     value:
       data.l2Cadence != null ? formatSeconds(data.l2Cadence / 1000) : 'N/A',
+    group: 'Network Performance',
   },
   {
     title: 'Batch Posting Cadence',
@@ -30,6 +31,7 @@ export const createMetrics = (data: MetricInputData): MetricData[] => [
       data.batchCadence != null
         ? formatSeconds(data.batchCadence / 1000)
         : 'N/A',
+    group: 'Network Performance',
   },
   {
     title: 'Avg. Prove Time',
@@ -37,6 +39,7 @@ export const createMetrics = (data: MetricInputData): MetricData[] => [
       data.avgProve != null && data.avgProve > 0
         ? formatSeconds(data.avgProve / 1000)
         : 'N/A',
+    group: 'Network Performance',
   },
   {
     title: React.createElement(
@@ -53,6 +56,7 @@ export const createMetrics = (data: MetricInputData): MetricData[] => [
       data.avgVerify != null && data.avgVerify > 0
         ? formatSeconds(data.avgVerify / 1000)
         : 'N/A',
+    group: 'Network Performance',
   },
   {
     title: 'Active Gateways',
@@ -72,15 +76,18 @@ export const createMetrics = (data: MetricInputData): MetricData[] => [
   {
     title: 'L2 Reorgs',
     value: data.l2Reorgs != null ? data.l2Reorgs.toString() : 'N/A',
+    group: 'Network Health & Security',
   },
   {
     title: 'Slashing Events',
     value: data.slashings != null ? data.slashings.toString() : 'N/A',
+    group: 'Network Health & Security',
   },
   {
     title: 'Forced Inclusions',
     value:
       data.forcedInclusions != null ? data.forcedInclusions.toString() : 'N/A',
+    group: 'Network Health & Security',
   },
   {
     title: 'L2 Head Block',

--- a/dashboard/tests/helpers.test.ts
+++ b/dashboard/tests/helpers.test.ts
@@ -17,9 +17,13 @@ const metrics = createMetrics({
 });
 
 assert.strictEqual(metrics[0].value, '60.0s');
+assert.strictEqual(metrics[0].group, 'Network Performance');
 assert.strictEqual(metrics[1].value, 'N/A');
+assert.strictEqual(metrics[1].group, 'Network Performance');
 assert.strictEqual(metrics[2].value, '1.20s');
+assert.strictEqual(metrics[2].group, 'Network Performance');
 assert.strictEqual(metrics[3].value, 'N/A');
+assert.strictEqual(metrics[3].group, 'Network Performance');
 assert.strictEqual(metrics[4].value, '2');
 assert.strictEqual(metrics[4].group, 'Operators');
 assert.strictEqual(metrics[5].value, '0xabc');
@@ -27,8 +31,11 @@ assert.strictEqual(metrics[5].group, 'Operators');
 assert.strictEqual(metrics[6].value, 'N/A');
 assert.strictEqual(metrics[6].group, 'Operators');
 assert.strictEqual(metrics[7].value, '1');
+assert.strictEqual(metrics[7].group, 'Network Health & Security');
 assert.strictEqual(metrics[8].value, 'N/A');
+assert.strictEqual(metrics[8].group, 'Network Health & Security');
 assert.strictEqual(metrics[9].value, '0');
+assert.strictEqual(metrics[9].group, 'Network Health & Security');
 assert.strictEqual(metrics[10].value, '100');
 assert.strictEqual(metrics[11].value, '50');
 
@@ -56,9 +63,16 @@ const metricsAllNull = createMetrics({
 for (const metric of metricsAllNull) {
   assert.strictEqual(metric.value, 'N/A');
 }
+assert.strictEqual(metricsAllNull[0].group, 'Network Performance');
+assert.strictEqual(metricsAllNull[1].group, 'Network Performance');
+assert.strictEqual(metricsAllNull[2].group, 'Network Performance');
+assert.strictEqual(metricsAllNull[3].group, 'Network Performance');
 assert.strictEqual(metricsAllNull[4].group, 'Operators');
 assert.strictEqual(metricsAllNull[5].group, 'Operators');
 assert.strictEqual(metricsAllNull[6].group, 'Operators');
+assert.strictEqual(metricsAllNull[7].group, 'Network Health & Security');
+assert.strictEqual(metricsAllNull[8].group, 'Network Health & Security');
+assert.strictEqual(metricsAllNull[9].group, 'Network Health & Security');
 
 assert.strictEqual(
   hasBadRequest([


### PR DESCRIPTION
## Summary
- group metrics by category in dashboard
- add Network Performance and Network Health & Security groups
- update tests for new metric grouping

## Testing
- `npm run check`
- `npm run test`
