### PR TITLE
Add L2 gas usage metrics

### DIFF
--- a/crates/clickhouse/src/models.rs
+++ b/crates/clickhouse/src/models.rs
@@ -164,3 +164,12 @@ pub struct L2BlockTimeRow {
     /// Milliseconds since the previous block
     pub ms_since_prev_block: Option<u64>,
 }
+
+/// Row representing the gas used in each L2 block
+#[derive(Debug, Row, Serialize, Deserialize, PartialEq, Eq)]
+pub struct L2GasUsedRow {
+    /// L2 block number
+    pub l2_block_number: u64,
+    /// Total gas used in the block
+    pub gas_used: u64,
+}

--- a/dashboard/components/GasUsedChart.tsx
+++ b/dashboard/components/GasUsedChart.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts';
+import { TimeSeriesData } from '../types';
+import { formatDecimal } from '../utils';
+
+interface GasUsedChartProps {
+  data: TimeSeriesData[];
+  lineColor: string;
+}
+
+export const GasUsedChart: React.FC<GasUsedChartProps> = ({ data, lineColor }) => {
+  if (!data || data.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-full text-gray-500">
+        No data available
+      </div>
+    );
+  }
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <LineChart data={data} margin={{ top: 5, right: 30, left: 20, bottom: 50 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
+        <XAxis
+          dataKey="value"
+          tickFormatter={(v: number) => v.toLocaleString()}
+          stroke="#666666"
+          fontSize={12}
+          label={{
+            value: 'Block Number',
+            position: 'insideBottom',
+            offset: -10,
+            fontSize: 10,
+            fill: '#666666',
+          }}
+          padding={{ left: 10, right: 10 }}
+        />
+        <YAxis
+          stroke="#666666"
+          fontSize={12}
+          domain={['auto', 'auto']}
+          tickFormatter={(v) => formatDecimal(v)}
+          label={{
+            value: 'Gas Used',
+            angle: -90,
+            position: 'insideLeft',
+            offset: -16,
+            fontSize: 10,
+            fill: '#666666',
+          }}
+        />
+        <Tooltip
+          labelFormatter={(label: number) => `Block ${label.toLocaleString()}`}
+          formatter={(value: number) => [formatDecimal(value), 'gas']}
+          contentStyle={{ backgroundColor: 'rgba(255, 255, 255, 0.8)', borderColor: lineColor }}
+          labelStyle={{ color: '#333' }}
+        />
+        <Legend verticalAlign="bottom" align="right" wrapperStyle={{ right: 20, bottom: 0 }} />
+        <Line
+          type="monotone"
+          dataKey="timestamp"
+          stroke={lineColor}
+          strokeWidth={2}
+          dot={false}
+          activeDot={data.length <= 100 ? { r: 6 } : false}
+          name="Gas Used"
+        />
+      </LineChart>
+    </ResponsiveContainer>
+  );
+};

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -296,6 +296,27 @@ export const fetchL2BlockTimes = async (
   return { data, badRequest: res.badRequest };
 };
 
+export const fetchL2GasUsed = async (
+  range: '1h' | '24h' | '7d',
+): Promise<RequestResult<TimeSeriesData[]>> => {
+  const url = `${API_BASE}/l2-gas-used?range=${range}`;
+  const res = await fetchJson<{
+    blocks: { l2_block_number: number; gas_used: number }[];
+  }>(url);
+  if (!res.data) {
+    return { data: null, badRequest: res.badRequest };
+  }
+
+  const data = res.data.blocks.slice(1).map(
+    (b): TimeSeriesData => ({
+      value: b.l2_block_number,
+      timestamp: b.gas_used,
+    }),
+  );
+
+  return { data, badRequest: res.badRequest };
+};
+
 export const fetchSequencerDistribution = async (
   range: '1h' | '24h' | '7d',
 ): Promise<RequestResult<PieChartDataItem[]>> => {


### PR DESCRIPTION
## Summary
- expose gas used per L2 block via API
- support querying gas usage from ClickHouse reader
- visualize gas used in dashboard with new chart
- add dashboard API helper for gas usage
- test new API endpoint

## Testing
- `npm --prefix dashboard run check`
- `just ci`