### PR TITLE
Add table view for dashboard charts

### DIFF
--- a/dashboard/App.tsx
+++ b/dashboard/App.tsx
@@ -3,6 +3,7 @@ import { createMetrics, hasBadRequest } from './helpers';
 import { DashboardHeader } from './components/DashboardHeader';
 import { MetricCard } from './components/MetricCard';
 import { ChartCard } from './components/ChartCard';
+import { DataTable } from './components/DataTable';
 import { SequencerPieChart } from './components/SequencerPieChart';
 import { BlockTimeChart } from './components/BlockTimeChart';
 import { BatchProcessChart } from './components/BatchProcessChart';
@@ -56,6 +57,11 @@ const App: React.FC = () => {
   const [l1HeadBlock, setL1HeadBlock] = useState<string>('0');
   const [refreshRate, setRefreshRate] = useState<number>(60000);
   const [errorMessage, setErrorMessage] = useState<string>('');
+  const [tableView, setTableView] = useState<null | {
+    title: string;
+    columns: { key: string; label: string }[];
+    rows: Record<string, string | number>[];
+  }>(null);
 
   useEffect(() => {
     let pollId: NodeJS.Timeout | null = null;
@@ -269,6 +275,25 @@ const App: React.FC = () => {
     'Other',
   ];
 
+  const openTable = (
+    title: string,
+    columns: { key: string; label: string }[],
+    rows: Record<string, string | number>[],
+  ) => {
+    setTableView({ title, columns, rows });
+  };
+
+  if (tableView) {
+    return (
+      <DataTable
+        title={tableView.title}
+        columns={tableView.columns}
+        rows={tableView.rows}
+        onBack={() => setTableView(null)}
+      />
+    );
+  }
+
   return (
     <div
       className="min-h-screen bg-white text-gray-800 p-4 md:p-6 lg:p-8"
@@ -310,22 +335,91 @@ const App: React.FC = () => {
 
         {/* Charts Grid - Reordered: Sequencer Pie Chart first */}
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 md:gap-6 mt-6">
-          <ChartCard title="Sequencer Distribution">
+          <ChartCard
+            title="Sequencer Distribution"
+            onMore={() =>
+              openTable(
+                'Sequencer Distribution',
+                [
+                  { key: 'name', label: 'Address' },
+                  { key: 'value', label: 'Blocks' },
+                ],
+                sequencerDistribution as unknown as Record<
+                  string,
+                  string | number
+                >[],
+              )
+            }
+          >
             <SequencerPieChart data={sequencerDistribution} />
           </ChartCard>
-          <ChartCard title="Prove Time">
+          <ChartCard
+            title="Prove Time"
+            onMore={() =>
+              openTable(
+                'Prove Time',
+                [
+                  { key: 'name', label: 'Batch' },
+                  { key: 'value', label: 'Seconds' },
+                ],
+                secondsToProveData as unknown as Record<
+                  string,
+                  string | number
+                >[],
+              )
+            }
+          >
             <BatchProcessChart
               data={secondsToProveData}
               lineColor={TAIKO_PINK}
             />
           </ChartCard>
-          <ChartCard title="Verify Time">
+          <ChartCard
+            title="Verify Time"
+            onMore={() =>
+              openTable(
+                'Verify Time',
+                [
+                  { key: 'name', label: 'Batch' },
+                  { key: 'value', label: 'Seconds' },
+                ],
+                secondsToVerifyData as unknown as Record<
+                  string,
+                  string | number
+                >[],
+              )
+            }
+          >
             <BatchProcessChart data={secondsToVerifyData} lineColor="#5DA5DA" />
           </ChartCard>
-          <ChartCard title="L2 Block Times">
+          <ChartCard
+            title="L2 Block Times"
+            onMore={() =>
+              openTable(
+                'L2 Block Times',
+                [
+                  { key: 'value', label: 'Block Number' },
+                  { key: 'timestamp', label: 'Interval (ms)' },
+                ],
+                l2BlockTimeData as unknown as Record<string, string | number>[],
+              )
+            }
+          >
             <BlockTimeChart data={l2BlockTimeData} lineColor="#FAA43A" />
           </ChartCard>
-          <ChartCard title="L1 Block Times">
+          <ChartCard
+            title="L1 Block Times"
+            onMore={() =>
+              openTable(
+                'L1 Block Times',
+                [
+                  { key: 'value', label: 'Block Number' },
+                  { key: 'timestamp', label: 'Interval (ms)' },
+                ],
+                l1BlockTimeData as unknown as Record<string, string | number>[],
+              )
+            }
+          >
             <BlockTimeChart data={l1BlockTimeData} lineColor="#60BD68" />
           </ChartCard>
         </div>

--- a/dashboard/components/ChartCard.tsx
+++ b/dashboard/components/ChartCard.tsx
@@ -1,18 +1,31 @@
-
 import React from 'react';
 
 interface ChartCardProps {
   title: string;
   children: React.ReactNode;
+  onMore?: () => void;
 }
 
-export const ChartCard: React.FC<ChartCardProps> = ({ title, children }) => {
+export const ChartCard: React.FC<ChartCardProps> = ({
+  title,
+  children,
+  onMore,
+}) => {
   return (
-    <div className="bg-white p-4 md:p-6 rounded-lg border border-gray-200">
-      <h3 className="text-lg font-semibold text-gray-700 mb-4">{title}</h3>
-      <div className="h-64 md:h-80 w-full"> {/* Ensure chart has height */}
-        {children}
+    <div className="bg-white p-4 md:p-6 rounded-lg border border-gray-200 relative">
+      <div className="flex justify-between items-start mb-4">
+        <h3 className="text-lg font-semibold text-gray-700">{title}</h3>
+        {onMore && (
+          <button
+            onClick={onMore}
+            className="text-gray-500 hover:text-gray-700"
+            aria-label="View table"
+          >
+            ⋮
+          </button>
+        )}
       </div>
+      <div className="h-64 md:h-80 w-full">{children}</div>
     </div>
   );
 };

--- a/dashboard/components/DataTable.tsx
+++ b/dashboard/components/DataTable.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+
+interface Column {
+  key: string;
+  label: string;
+}
+
+interface DataTableProps {
+  title: string;
+  columns: Column[];
+  rows: Array<Record<string, string | number>>;
+  onBack: () => void;
+}
+
+export const DataTable: React.FC<DataTableProps> = ({
+  title,
+  columns,
+  rows,
+  onBack,
+}) => {
+  return (
+    <div className="p-4">
+      <button
+        onClick={onBack}
+        className="mb-4 text-[#e81899] flex items-center space-x-1"
+      >
+        <span>&larr;</span>
+        <span>Back</span>
+      </button>
+      <h2 className="text-xl font-semibold mb-2">{title}</h2>
+      <div className="overflow-x-auto">
+        <table className="min-w-full border divide-y divide-gray-200">
+          <thead>
+            <tr>
+              {columns.map((col) => (
+                <th key={col.key} className="px-2 py-1 text-left">
+                  {col.label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, idx) => (
+              <tr key={idx} className="border-t">
+                {columns.map((col) => (
+                  <td key={col.key} className="px-2 py-1">
+                    {row[col.key] as React.ReactNode}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- add reusable `DataTable` component
- extend `ChartCard` with ellipsis button
- allow switching from charts to a table view via new button

## Testing
- `npm --prefix dashboard run check`
- `npm --prefix dashboard run test`
