### PR TITLE
Add table view for L2 reorg events

### DIFF
--- a/dashboard/App.tsx
+++ b/dashboard/App.tsx
@@ -12,6 +12,7 @@ import {
   TimeSeriesData,
   PieChartDataItem,
   MetricData,
+  L2ReorgEvent,
 } from './types';
 import {
   API_BASE,
@@ -21,6 +22,7 @@ import {
   fetchBatchPostingCadence,
   fetchActiveGateways,
   fetchL2Reorgs,
+  fetchL2ReorgEvents,
   fetchSlashingEvents,
   fetchForcedInclusions,
   fetchCurrentOperator,
@@ -53,6 +55,7 @@ const App: React.FC = () => {
   const [sequencerDistribution, setSequencerDistribution] = useState<
     PieChartDataItem[]
   >([]);
+  const [l2ReorgEvents, setL2ReorgEvents] = useState<L2ReorgEvent[]>([]);
   const [l2HeadBlock, setL2HeadBlock] = useState<string>('0');
   const [l1HeadBlock, setL1HeadBlock] = useState<string>('0');
   const [refreshRate, setRefreshRate] = useState<number>(60000);
@@ -150,6 +153,7 @@ const App: React.FC = () => {
       currentOperatorRes,
       nextOperatorRes,
       l2ReorgsRes,
+      l2ReorgEventsRes,
       slashingsRes,
       forcedInclusionsRes,
       l2BlockRes,
@@ -168,6 +172,7 @@ const App: React.FC = () => {
       fetchCurrentOperator(),
       fetchNextOperator(),
       fetchL2Reorgs(range),
+      fetchL2ReorgEvents(range),
       fetchSlashingEvents(range),
       fetchForcedInclusions(range),
       fetchL2HeadBlock(range),
@@ -187,6 +192,7 @@ const App: React.FC = () => {
     const currentOperator = currentOperatorRes.data;
     const nextOperator = nextOperatorRes.data;
     const l2Reorgs = l2ReorgsRes.data;
+    const reorgEvents = l2ReorgEventsRes.data || [];
     const slashings = slashingsRes.data;
     const forcedInclusions = forcedInclusionsRes.data;
     const l2Block = l2BlockRes.data;
@@ -206,6 +212,7 @@ const App: React.FC = () => {
       currentOperatorRes,
       nextOperatorRes,
       l2ReorgsRes,
+      l2ReorgEventsRes,
       slashingsRes,
       forcedInclusionsRes,
       l2BlockRes,
@@ -238,6 +245,7 @@ const App: React.FC = () => {
     setL2BlockTimeData(l2Times);
     setL1BlockTimeData(l1Times);
     setSequencerDistribution(sequencerDist);
+    setL2ReorgEvents(reorgEvents);
     setL2HeadBlock(
       currentMetrics.find((m) => m.title === 'L2 Head Block')?.value || 'N/A',
     );
@@ -326,6 +334,25 @@ const App: React.FC = () => {
                     key={`${group}-${idx}`}
                     title={m.title}
                     value={m.value}
+                    onMore={
+                      typeof m.title === 'string' && m.title === 'L2 Reorgs'
+                        ? () =>
+                            openTable(
+                              'L2 Reorgs',
+                              [
+                                {
+                                  key: 'l2_block_number',
+                                  label: 'Block Number',
+                                },
+                                { key: 'depth', label: 'Depth' },
+                              ],
+                              l2ReorgEvents as unknown as Record<
+                                string,
+                                string | number
+                              >[],
+                            )
+                        : undefined
+                    }
                   />
                 ))}
               </div>

--- a/dashboard/components/MetricCard.tsx
+++ b/dashboard/components/MetricCard.tsx
@@ -6,6 +6,7 @@ interface MetricCardProps {
   unit?: string; // Unit is passed but not displayed in the title directly as (unit)
   description?: React.ReactNode;
   className?: string;
+  onMore?: () => void;
 }
 
 export const MetricCard: React.FC<MetricCardProps> = ({
@@ -13,6 +14,7 @@ export const MetricCard: React.FC<MetricCardProps> = ({
   value,
   description,
   className,
+  onMore,
 }) => {
   // Check if value looks like an Ethereum address (0x followed by 40 hex characters)
   const isAddress = /^0x[a-fA-F0-9]{40}$/.test(value);
@@ -21,8 +23,18 @@ export const MetricCard: React.FC<MetricCardProps> = ({
     <div
       className={`bg-white p-4 rounded-lg border border-gray-200 transition-shadow duration-200 ${isAddress ? 'min-w-0 w-full sm:col-span-2' : ''} ${className ?? ''}`.trim()}
     >
-      {/* Removed {unit && `(${unit})`} from here */}
-      <h3 className="text-sm font-medium text-gray-500 truncate">{title}</h3>
+      <div className="flex justify-between items-start">
+        <h3 className="text-sm font-medium text-gray-500 truncate">{title}</h3>
+        {onMore && (
+          <button
+            onClick={onMore}
+            className="text-gray-500 hover:text-gray-700 text-2xl"
+            aria-label="View table"
+          >
+            ⋮
+          </button>
+        )}
+      </div>
       <p
         className={`mt-1 font-semibold text-gray-900 ${isAddress ? 'text-lg whitespace-nowrap' : 'text-3xl break-all'}`}
       >

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -3,7 +3,7 @@ export const API_BASE =
   (import.meta as any).env.API_BASE ||
   '';
 
-import type { TimeSeriesData, PieChartDataItem } from '../types';
+import type { TimeSeriesData, PieChartDataItem, L2ReorgEvent } from '../types';
 
 export interface RequestResult<T> {
   data: T | null;
@@ -89,6 +89,17 @@ export const fetchL2Reorgs = async (
   const res = await fetchJson<{ events: unknown[] }>(url);
   return {
     data: res.data ? res.data.events.length : null,
+    badRequest: res.badRequest,
+  };
+};
+
+export const fetchL2ReorgEvents = async (
+  range: '1h' | '24h' | '7d',
+): Promise<RequestResult<L2ReorgEvent[]>> => {
+  const url = `${API_BASE}/reorgs?range=${range}`;
+  const res = await fetchJson<{ events: L2ReorgEvent[] }>(url);
+  return {
+    data: res.data ? res.data.events : null,
     badRequest: res.badRequest,
   };
 };

--- a/dashboard/types.ts
+++ b/dashboard/types.ts
@@ -21,3 +21,8 @@ export interface MetricData {
   description?: ReactNode;
   group?: string;
 }
+
+export interface L2ReorgEvent {
+  l2_block_number: number;
+  depth: number;
+}


### PR DESCRIPTION
## Summary
- enable optional three-dot menu on MetricCard
- define `L2ReorgEvent` type and API call
- fetch reorg event data and show table via MetricCard

## Testing
- `npm run format`
- `npm run check`
