### PR TITLE
Add proposer distribution support

### DIFF
--- a/crates/clickhouse/src/models.rs
+++ b/crates/clickhouse/src/models.rs
@@ -127,6 +127,15 @@ pub struct SequencerDistributionRow {
     pub blocks: u64,
 }
 
+/// Row representing the number of blocks proposed by a sequencer
+#[derive(Debug, Row, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProposerDistributionRow {
+    /// Sequencer address that proposed the block
+    pub proposer: [u8; 20],
+    /// Number of blocks proposed by the sequencer
+    pub blocks: u64,
+}
+
 /// Row representing the time it took for a batch to be proven
 #[derive(Debug, Row, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BatchProveTimeRow {

--- a/dashboard/App.tsx
+++ b/dashboard/App.tsx
@@ -34,6 +34,8 @@ import {
   fetchL1BlockTimes,
   fetchL2BlockTimes,
   fetchSequencerDistribution,
+  fetchSequencerProposals,
+  type ProposerDistributionItem,
 } from './services/apiService';
 
 // Updated Taiko Pink
@@ -52,6 +54,9 @@ const App: React.FC = () => {
   const [l1BlockTimeData, setL1BlockTimeData] = useState<TimeSeriesData[]>([]);
   const [sequencerDistribution, setSequencerDistribution] = useState<
     PieChartDataItem[]
+  >([]);
+  const [sequencerProposals, setSequencerProposals] = useState<
+    ProposerDistributionItem[]
   >([]);
   const [l2HeadBlock, setL2HeadBlock] = useState<string>('0');
   const [l1HeadBlock, setL1HeadBlock] = useState<string>('0');
@@ -159,6 +164,7 @@ const App: React.FC = () => {
       l1TimesRes,
       l2TimesRes,
       sequencerDistRes,
+      sequencerPropRes,
     ] = await Promise.all([
       fetchL2BlockCadence(range),
       fetchBatchPostingCadence(range),
@@ -177,6 +183,7 @@ const App: React.FC = () => {
       fetchL1BlockTimes(range),
       fetchL2BlockTimes(range),
       fetchSequencerDistribution(range),
+      fetchSequencerProposals(range),
     ]);
 
     const l2Cadence = l2CadenceRes.data;
@@ -196,6 +203,7 @@ const App: React.FC = () => {
     const l1Times = l1TimesRes.data || [];
     const l2Times = l2TimesRes.data || [];
     const sequencerDist = sequencerDistRes.data || [];
+    const sequencerProp = sequencerPropRes.data || [];
 
     const anyBadRequest = hasBadRequest([
       l2CadenceRes,
@@ -215,6 +223,7 @@ const App: React.FC = () => {
       l1TimesRes,
       l2TimesRes,
       sequencerDistRes,
+      sequencerPropRes,
     ]);
 
     const currentMetrics: MetricData[] = createMetrics({
@@ -238,6 +247,7 @@ const App: React.FC = () => {
     setL2BlockTimeData(l2Times);
     setL1BlockTimeData(l1Times);
     setSequencerDistribution(sequencerDist);
+    setSequencerProposals(sequencerProp);
     setL2HeadBlock(
       currentMetrics.find((m) => m.title === 'L2 Head Block')?.value || 'N/A',
     );
@@ -343,11 +353,15 @@ const App: React.FC = () => {
                 [
                   { key: 'name', label: 'Address' },
                   { key: 'value', label: 'Blocks' },
+                  { key: 'proposed', label: 'Proposed' },
                 ],
-                sequencerDistribution as unknown as Record<
-                  string,
-                  string | number
-                >[],
+                sequencerDistribution.map((d) => ({
+                  name: d.name,
+                  value: d.value,
+                  proposed:
+                    sequencerProposals.find((p) => p.address === d.name)
+                      ?.blocks ?? 0,
+                })),
               )
             }
           >

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -271,3 +271,16 @@ export const fetchSequencerDistribution = async (
     badRequest: res.badRequest,
   };
 };
+
+export interface ProposerDistributionItem {
+  address: string;
+  blocks: number;
+}
+
+export const fetchSequencerProposals = async (
+  range: '1h' | '24h' | '7d',
+): Promise<RequestResult<ProposerDistributionItem[]>> => {
+  const url = `${API_BASE}/sequencer-proposals?range=${range}`;
+  const res = await fetchJson<{ sequencers: ProposerDistributionItem[] }>(url);
+  return { data: res.data?.sequencers ?? null, badRequest: res.badRequest };
+};


### PR DESCRIPTION
## Summary
- extend ClickHouse models with proposer distribution row
- add `get_proposer_distribution_since` reader method
- expose `/sequencer-proposals` API endpoint
- fetch proposer data in dashboard and show in sequencer table

## Testing
- `cargo clippy --examples --tests --benches --all-features --locked`
- `cargo nextest run --workspace --all-targets`
- `npm run check`
- `just ci`