### PR TITLE
Add event tables to dashboard

### DIFF
--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -3,7 +3,13 @@ export const API_BASE =
   (import.meta as any).env.API_BASE ||
   '';
 
-import type { TimeSeriesData, PieChartDataItem, L2ReorgEvent } from '../types';
+import type {
+  TimeSeriesData,
+  PieChartDataItem,
+  L2ReorgEvent,
+  SlashingEvent,
+  ForcedInclusionEvent,
+} from '../types';
 
 export interface RequestResult<T> {
   data: T | null;
@@ -104,7 +110,7 @@ export const fetchL2ReorgEvents = async (
   };
 };
 
-export const fetchSlashingEvents = async (
+export const fetchSlashingEventCount = async (
   range: '1h' | '24h' | '7d',
 ): Promise<RequestResult<number>> => {
   const url = `${API_BASE}/slashings?range=${range}`;
@@ -115,13 +121,35 @@ export const fetchSlashingEvents = async (
   };
 };
 
-export const fetchForcedInclusions = async (
+export const fetchForcedInclusionCount = async (
   range: '1h' | '24h' | '7d',
 ): Promise<RequestResult<number>> => {
   const url = `${API_BASE}/forced-inclusions?range=${range}`;
   const res = await fetchJson<{ events: unknown[] }>(url);
   return {
     data: res.data ? res.data.events.length : null,
+    badRequest: res.badRequest,
+  };
+};
+
+export const fetchSlashingEvents = async (
+  range: '1h' | '24h' | '7d',
+): Promise<RequestResult<SlashingEvent[]>> => {
+  const url = `${API_BASE}/slashings?range=${range}`;
+  const res = await fetchJson<{ events: SlashingEvent[] }>(url);
+  return {
+    data: res.data ? res.data.events : null,
+    badRequest: res.badRequest,
+  };
+};
+
+export const fetchForcedInclusionEvents = async (
+  range: '1h' | '24h' | '7d',
+): Promise<RequestResult<ForcedInclusionEvent[]>> => {
+  const url = `${API_BASE}/forced-inclusions?range=${range}`;
+  const res = await fetchJson<{ events: ForcedInclusionEvent[] }>(url);
+  return {
+    data: res.data ? res.data.events : null,
     badRequest: res.badRequest,
   };
 };

--- a/dashboard/tests/utils.test.ts
+++ b/dashboard/tests/utils.test.ts
@@ -8,6 +8,7 @@ import {
   shouldShowMinutes,
   findMetricValue,
   formatSequencerTooltip,
+  bytesToHex,
 } from '../utils.js';
 
 assert.strictEqual(formatDecimal(1), '1.00');
@@ -62,5 +63,7 @@ assert.strictEqual(tooltip, '1 blocks (25.00%)');
 
 const zeroTooltip = formatSequencerTooltip([{ value: 0 }], 0);
 assert.strictEqual(zeroTooltip, '0 blocks (0%)');
+
+assert.strictEqual(bytesToHex([0, 1, 255]), '0x0001ff');
 
 console.log('All tests passed.');

--- a/dashboard/types.ts
+++ b/dashboard/types.ts
@@ -26,3 +26,12 @@ export interface L2ReorgEvent {
   l2_block_number: number;
   depth: number;
 }
+
+export interface SlashingEvent {
+  l1_block_number: number;
+  validator_addr: number[];
+}
+
+export interface ForcedInclusionEvent {
+  blob_hash: number[];
+}

--- a/dashboard/utils.ts
+++ b/dashboard/utils.ts
@@ -60,3 +60,6 @@ export const formatSequencerTooltip = (
   const percentage = total > 0 ? ((value / total) * 100).toFixed(2) : '0';
   return `${value} blocks (${percentage}%)`;
 };
+
+export const bytesToHex = (bytes: number[]): string =>
+  `0x${bytes.map((b) => b.toString(16).padStart(2, '0')).join('')}`;


### PR DESCRIPTION
## Summary
- display slashing and forced inclusion events in table view
- expose event list APIs on the dashboard
- convert byte arrays to hex values
- test utilities

## Testing
- `just dashboard-check`
- `just dashboard-test`
