### PR TITLE
Add sequencer blocks endpoint and UI table

### DIFF
--- a/crates/clickhouse/src/models.rs
+++ b/crates/clickhouse/src/models.rs
@@ -127,6 +127,15 @@ pub struct SequencerDistributionRow {
     pub blocks: u64,
 }
 
+/// Row representing a single block proposed by a sequencer
+#[derive(Debug, Row, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SequencerBlockRow {
+    /// Sequencer address
+    pub sequencer: [u8; 20],
+    /// L2 block number proposed by the sequencer
+    pub l2_block_number: u64,
+}
+
 /// Row representing the time it took for a batch to be proven
 #[derive(Debug, Row, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BatchProveTimeRow {

--- a/dashboard/App.tsx
+++ b/dashboard/App.tsx
@@ -43,6 +43,7 @@ import {
   fetchL2BlockTimes,
   fetchL2GasUsed,
   fetchSequencerDistribution,
+  fetchSequencerBlocks,
 } from './services/apiService';
 
 // Updated Taiko Pink
@@ -76,6 +77,7 @@ const App: React.FC = () => {
     title: string;
     columns: { key: string; label: string }[];
     rows: Record<string, string | number>[];
+    onRowClick?: (row: Record<string, string | number>) => void;
   }>(null);
 
   useEffect(() => {
@@ -312,8 +314,18 @@ const App: React.FC = () => {
     title: string,
     columns: { key: string; label: string }[],
     rows: Record<string, string | number>[],
+    onRowClick?: (row: Record<string, string | number>) => void,
   ) => {
-    setTableView({ title, columns, rows });
+    setTableView({ title, columns, rows, onRowClick });
+  };
+
+  const openSequencerBlocks = async (address: string) => {
+    const blocksRes = await fetchSequencerBlocks(timeRange, address);
+    openTable(
+      `Blocks proposed by ${address}`,
+      [{ key: 'block', label: 'Block Number' }],
+      (blocksRes.data || []).map((b) => ({ block: b })),
+    );
   };
 
   if (tableView) {
@@ -323,6 +335,7 @@ const App: React.FC = () => {
         columns={tableView.columns}
         rows={tableView.rows}
         onBack={() => setTableView(null)}
+        onRowClick={tableView.onRowClick}
       />
     );
   }
@@ -427,6 +440,7 @@ const App: React.FC = () => {
                   string,
                   string | number
                 >[],
+                (row) => openSequencerBlocks(row.name as string),
               )
             }
           >

--- a/dashboard/components/DataTable.tsx
+++ b/dashboard/components/DataTable.tsx
@@ -10,6 +10,7 @@ interface DataTableProps {
   columns: Column[];
   rows: Array<Record<string, string | number>>;
   onBack: () => void;
+  onRowClick?: (row: Record<string, string | number>) => void;
 }
 
 export const DataTable: React.FC<DataTableProps> = ({
@@ -17,6 +18,7 @@ export const DataTable: React.FC<DataTableProps> = ({
   columns,
   rows,
   onBack,
+  onRowClick,
 }) => {
   return (
     <div className="p-4">
@@ -41,7 +43,11 @@ export const DataTable: React.FC<DataTableProps> = ({
           </thead>
           <tbody>
             {rows.map((row, idx) => (
-              <tr key={idx} className="border-t">
+              <tr
+                key={idx}
+                className="border-t hover:bg-gray-50 cursor-pointer"
+                onClick={onRowClick ? () => onRowClick(row) : undefined}
+              >
                 {columns.map((col) => (
                   <td key={col.key} className="px-2 py-1">
                     {row[col.key] as React.ReactNode}

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -331,3 +331,17 @@ export const fetchSequencerDistribution = async (
     badRequest: res.badRequest,
   };
 };
+
+export const fetchSequencerBlocks = async (
+  range: '1h' | '24h' | '7d',
+  address: string,
+): Promise<RequestResult<number[]>> => {
+  const url = `${API_BASE}/sequencer-blocks?range=${range}&address=${address}`;
+  const res = await fetchJson<{
+    sequencers: { address: string; blocks: number[] }[];
+  }>(url);
+  const blocks = res.data?.sequencers.find(
+    (s) => s.address.toLowerCase() === address.toLowerCase(),
+  )?.blocks;
+  return { data: blocks ?? null, badRequest: res.badRequest };
+};


### PR DESCRIPTION
## Summary
- expose blocks proposed by each sequencer via new `sequencer-blocks` API endpoint
- query ClickHouse for sequencer block numbers
- update dashboard API service and table view to show blocks per sequencer
- allow table rows to be clickable to open block lists

## Testing
- `just dashboard-check`
- `just ci`
