### PR TITLE
Update CI instructions for frontend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,12 +7,13 @@
 - Run single test: `cargo nextest run <test_name>` or `cargo test <test_name>`
 - Linting: `just lint` or `cargo clippy --examples --tests --benches --all-features`
 - Format code: `just fmt` or `cargo +nightly fmt --all`
-- Run CI checks: `just ci` (runs fmt, lint, test)
-- Always run all CI checks after any changes (except for changes in the dashboard dir)
+- Run CI checks: `just ci` (runs fmt, lint, test, check-dashboard, test-dashboard)
+- Always run `just ci` after any changes
 - Dashboard install dependencies: `just install-dashboard`
 - Dashboard dev server: `just dev-dashboard`
 - Dashboard build: `just build-dashboard`
 - Dashboard type checks: `just check-dashboard`
+- Dashboard tests: `just test-dashboard`
 
 ## Code Style Guidelines
 - Use Rust 2024 edition

--- a/dashboard/AGENTS.md
+++ b/dashboard/AGENTS.md
@@ -4,8 +4,9 @@
 - Install dependencies with `npm install`.
 - Start the dev server with `npm run dev`.
 - Build for production with `npm run build`.
-- Run tests with `npm run tests`.
-- Run type checks with `npm run check` whenever you modify dashboard code and ensure this passes before opening a PR.
+- Run tests with `npm run test` or `just test-dashboard`.
+- Run type checks with `npm run check` or `just check-dashboard` whenever you modify dashboard code and ensure this passes before opening a PR.
+- Always run `just ci` after any changes.
 
 ## Code Style
 - Use TypeScript and keep components typed.

--- a/justfile
+++ b/justfile
@@ -30,7 +30,7 @@ masaya-api:
 
 # run all recipes required to pass CI workflows
 ci:
-    @just fmt lint test
+    @just fmt lint test check-dashboard test-dashboard
 
 # run tests
 test:


### PR DESCRIPTION
## Summary
- update `just ci` to run dashboard checks
- clarify AGENTS instructions that `just ci` must run after any change
- document dashboard commands

## Testing
- `just ci`