### PR TITLE
Add missing dashboard component tests

### DIFF
--- a/dashboard/components/BatchProcessChart.tsx
+++ b/dashboard/components/BatchProcessChart.tsx
@@ -14,7 +14,7 @@ import {
   formatDecimal,
   formatBatchDuration,
   computeBatchDurationFlags,
-} from '../utils';
+} from '../utils.js';
 
 interface BatchProcessChartProps {
   data: TimeSeriesData[];

--- a/dashboard/components/BlockTimeChart.tsx
+++ b/dashboard/components/BlockTimeChart.tsx
@@ -10,7 +10,7 @@ import {
   ResponsiveContainer,
 } from 'recharts';
 import { TimeSeriesData } from '../types';
-import { formatDecimal, formatInterval, shouldShowMinutes } from '../utils';
+import { formatDecimal, formatInterval, shouldShowMinutes } from '../utils.js';
 
 interface BlockTimeChartProps {
   data: TimeSeriesData[];

--- a/dashboard/components/SequencerPieChart.tsx
+++ b/dashboard/components/SequencerPieChart.tsx
@@ -8,7 +8,7 @@ import {
   ResponsiveContainer,
 } from 'recharts';
 import { PieChartDataItem } from '../types';
-import { formatSequencerTooltip } from '../utils';
+import { formatSequencerTooltip } from '../utils.js';
 
 interface SequencerPieChartProps {
   data: PieChartDataItem[];

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "check": "tsc --noEmit",
-    "test": "tsc -p tsconfig.tests.json && node tests-build/tests/utils.test.js && node tests-build/tests/helpers.test.js && node tests-build/tests/metricCard.test.js && node tests-build/tests/utils.extra.test.js",
+    "test": "tsc -p tsconfig.tests.json && node tests-build/tests/utils.test.js && node tests-build/tests/helpers.test.js && node tests-build/tests/metricCard.test.js && node tests-build/tests/utils.extra.test.js && node tests-build/tests/chartCard.test.js && node tests-build/tests/dataTable.test.js && node tests-build/tests/blockTimeChart.test.js && node tests-build/tests/batchProcessChart.test.js && node tests-build/tests/sequencerPieChart.test.js",
     "format": "prettier --write .",
     "lint": "eslint . --ext .ts,.tsx"
   },

--- a/dashboard/tests/batchProcessChart.test.ts
+++ b/dashboard/tests/batchProcessChart.test.ts
@@ -1,0 +1,20 @@
+import assert from 'assert';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { BatchProcessChart } from '../components/BatchProcessChart.js';
+
+const emptyHtml = renderToStaticMarkup(
+  React.createElement(BatchProcessChart, { data: [], lineColor: '#000' }),
+);
+assert(emptyHtml.includes('No data available'));
+
+const data = [{ name: '1', value: 60, timestamp: 1000 }];
+const html = renderToStaticMarkup(
+  React.createElement(BatchProcessChart, {
+    data,
+    lineColor: '#000',
+  }),
+);
+assert(html.includes('recharts-responsive-container'));
+
+console.log('BatchProcessChart tests passed.');

--- a/dashboard/tests/blockTimeChart.test.ts
+++ b/dashboard/tests/blockTimeChart.test.ts
@@ -1,0 +1,20 @@
+import assert from 'assert';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { BlockTimeChart } from '../components/BlockTimeChart.js';
+
+const emptyHtml = renderToStaticMarkup(
+  React.createElement(BlockTimeChart, { data: [], lineColor: '#000' }),
+);
+assert(emptyHtml.includes('No data available'));
+
+const data = [
+  { value: 1, timestamp: 1000 },
+  { value: 2, timestamp: 130000 },
+];
+const chartHtml = renderToStaticMarkup(
+  React.createElement(BlockTimeChart, { data, lineColor: '#000' }),
+);
+assert(chartHtml.includes('recharts-responsive-container'));
+
+console.log('BlockTimeChart tests passed.');

--- a/dashboard/tests/chartCard.test.ts
+++ b/dashboard/tests/chartCard.test.ts
@@ -1,0 +1,22 @@
+import assert from 'assert';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { ChartCard } from '../components/ChartCard.js';
+
+const htmlNoMore = renderToStaticMarkup(
+  React.createElement(ChartCard, { title: 'Chart', children: 'content' }),
+);
+assert(!htmlNoMore.includes('aria-label="View table"'));
+assert(htmlNoMore.includes('Chart'));
+assert(htmlNoMore.includes('content'));
+
+const htmlMore = renderToStaticMarkup(
+  React.createElement(ChartCard, {
+    title: 'Chart',
+    onMore: () => {},
+    children: 'body',
+  }),
+);
+assert(htmlMore.includes('aria-label="View table"'));
+
+console.log('ChartCard tests passed.');

--- a/dashboard/tests/dataTable.test.ts
+++ b/dashboard/tests/dataTable.test.ts
@@ -1,0 +1,26 @@
+import assert from 'assert';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { DataTable } from '../components/DataTable.js';
+
+const columns = [
+  { key: 'a', label: 'A' },
+  { key: 'b', label: 'B' },
+];
+const rows = [{ a: '1', b: '2' }];
+
+const html = renderToStaticMarkup(
+  React.createElement(DataTable, {
+    title: 'Numbers',
+    columns,
+    rows,
+    onBack: () => {},
+  }),
+);
+assert(html.includes('Numbers'));
+assert(html.includes('A'));
+assert(html.includes('B'));
+assert(html.includes('1'));
+assert(html.includes('2'));
+
+console.log('DataTable tests passed.');

--- a/dashboard/tests/sequencerPieChart.test.ts
+++ b/dashboard/tests/sequencerPieChart.test.ts
@@ -1,0 +1,21 @@
+import assert from 'assert';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { SequencerPieChart } from '../components/SequencerPieChart.js';
+
+const emptyHtml = renderToStaticMarkup(
+  React.createElement(SequencerPieChart, { data: [] }),
+);
+assert(emptyHtml.includes('No data available'));
+
+const data = [
+  { name: 'Nethermind', value: 2 },
+  { name: 'Other', value: 1 },
+];
+const html = renderToStaticMarkup(
+  React.createElement(SequencerPieChart, { data }),
+);
+assert(html.includes('recharts-responsive-container'));
+assert(!html.includes('No data available'));
+
+console.log('SequencerPieChart tests passed.');


### PR DESCRIPTION
## Summary
- test ChartCard conditional "More" button logic
- test DataTable column and row rendering
- test BlockTimeChart empty state
- test BatchProcessChart empty state
- test SequencerPieChart empty state
- update imports in chart components for node tests
- run the new tests in npm script

## Testing
- `npm run check`
- `npm run test`
