### PR TITLE
Add transactions table to Sequencer view

### DIFF
--- a/crates/clickhouse/src/models.rs
+++ b/crates/clickhouse/src/models.rs
@@ -136,6 +136,17 @@ pub struct SequencerBlockRow {
     pub l2_block_number: u64,
 }
 
+/// Row representing the transaction count of a block and its sequencer
+#[derive(Debug, Row, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BlockTransactionRow {
+    /// Sequencer address
+    pub sequencer: [u8; 20],
+    /// L2 block number
+    pub l2_block_number: u64,
+    /// Number of transactions in the block
+    pub sum_tx: u32,
+}
+
 /// Row representing the time it took for a batch to be proven
 #[derive(Debug, Row, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BatchProveTimeRow {

--- a/dashboard/App.tsx
+++ b/dashboard/App.tsx
@@ -44,6 +44,7 @@ import {
   fetchL2GasUsed,
   fetchSequencerDistribution,
   fetchSequencerBlocks,
+  fetchBlockTransactions,
 } from './services/apiService';
 
 // Updated Taiko Pink
@@ -78,6 +79,7 @@ const App: React.FC = () => {
     columns: { key: string; label: string }[];
     rows: Record<string, string | number>[];
     onRowClick?: (row: Record<string, string | number>) => void;
+    extraAction?: { label: string; onClick: () => void };
   }>(null);
 
   useEffect(() => {
@@ -315,8 +317,9 @@ const App: React.FC = () => {
     columns: { key: string; label: string }[],
     rows: Record<string, string | number>[],
     onRowClick?: (row: Record<string, string | number>) => void,
+    extraAction?: { label: string; onClick: () => void },
   ) => {
-    setTableView({ title, columns, rows, onRowClick });
+    setTableView({ title, columns, rows, onRowClick, extraAction });
   };
 
   const openSequencerBlocks = async (address: string) => {
@@ -328,6 +331,19 @@ const App: React.FC = () => {
     );
   };
 
+  const openBlockTransactions = async () => {
+    const txRes = await fetchBlockTransactions(timeRange);
+    openTable(
+      `Transactions (${timeRange})`,
+      [
+        { key: 'block', label: 'Block Number' },
+        { key: 'txs', label: 'Tx Count' },
+        { key: 'sequencer', label: 'Sequencer' },
+      ],
+      (txRes.data || []) as unknown as Record<string, string | number>[],
+    );
+  };
+
   if (tableView) {
     return (
       <DataTable
@@ -336,6 +352,7 @@ const App: React.FC = () => {
         rows={tableView.rows}
         onBack={() => setTableView(null)}
         onRowClick={tableView.onRowClick}
+        extraAction={tableView.extraAction}
       />
     );
   }
@@ -441,6 +458,7 @@ const App: React.FC = () => {
                   string | number
                 >[],
                 (row) => openSequencerBlocks(row.name as string),
+                { label: 'Transactions', onClick: openBlockTransactions },
               )
             }
           >

--- a/dashboard/components/DataTable.tsx
+++ b/dashboard/components/DataTable.tsx
@@ -11,6 +11,7 @@ interface DataTableProps {
   rows: Array<Record<string, string | number>>;
   onBack: () => void;
   onRowClick?: (row: Record<string, string | number>) => void;
+  extraAction?: { label: string; onClick: () => void };
 }
 
 export const DataTable: React.FC<DataTableProps> = ({
@@ -19,6 +20,7 @@ export const DataTable: React.FC<DataTableProps> = ({
   rows,
   onBack,
   onRowClick,
+  extraAction,
 }) => {
   return (
     <div className="p-4">
@@ -29,6 +31,14 @@ export const DataTable: React.FC<DataTableProps> = ({
         <span>&larr;</span>
         <span>Back</span>
       </button>
+      {extraAction && (
+        <button
+          onClick={extraAction.onClick}
+          className="ml-4 mb-4 text-[#e81899]"
+        >
+          {extraAction.label}
+        </button>
+      )}
       <h2 className="text-xl font-semibold mb-2">{title}</h2>
       <div className="overflow-x-auto">
         <table className="min-w-full border divide-y divide-gray-200">

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -343,3 +343,17 @@ export const fetchSequencerBlocks = async (
   )?.blocks;
   return { data: blocks ?? null, badRequest: res.badRequest };
 };
+
+export interface BlockTransaction {
+  block: number;
+  txs: number;
+  sequencer: string;
+}
+
+export const fetchBlockTransactions = async (
+  range: '1h' | '24h' | '7d',
+): Promise<RequestResult<BlockTransaction[]>> => {
+  const url = `${API_BASE}/block-transactions?range=${range}`;
+  const res = await fetchJson<{ blocks: BlockTransaction[] }>(url);
+  return { data: res.data?.blocks ?? null, badRequest: res.badRequest };
+};

--- a/dashboard/tests/apiService.test.ts
+++ b/dashboard/tests/apiService.test.ts
@@ -4,6 +4,7 @@ import fs from 'fs/promises';
 let fetchAvgProveTime: typeof import('../services/apiService.js').fetchAvgProveTime;
 let fetchActiveGateways: typeof import('../services/apiService.js').fetchActiveGateways;
 let fetchL2BlockTimes: typeof import('../services/apiService.js').fetchL2BlockTimes;
+let fetchBlockTransactions: typeof import('../services/apiService.js').fetchBlockTransactions;
 
 const originalFetch = globalThis.fetch;
 
@@ -33,6 +34,7 @@ describe('apiService', () => {
     fetchAvgProveTime = service.fetchAvgProveTime;
     fetchActiveGateways = service.fetchActiveGateways;
     fetchL2BlockTimes = service.fetchL2BlockTimes;
+    fetchBlockTransactions = service.fetchBlockTransactions;
   });
 
   afterAll(() => {
@@ -68,5 +70,15 @@ describe('apiService', () => {
     });
     const blockTimes = await fetchL2BlockTimes('1h');
     expect(blockTimes.data).toStrictEqual([{ value: 2, timestamp: 20 }]);
+  });
+
+  it('transforms block transactions', async () => {
+    globalThis.fetch = mockFetch({
+      blocks: [
+        { block: 1, txs: 3, sequencer: '0xabc' },
+      ],
+    });
+    const txs = await fetchBlockTransactions('1h');
+    expect(txs.data).toStrictEqual([{ block: 1, txs: 3, sequencer: '0xabc' }]);
   });
 });


### PR DESCRIPTION
## Summary
- extend data models with `BlockTransactionRow`
- query block transactions per time range in ClickHouse reader
- expose `/block-transactions` API endpoint
- show an extra table for transactions from Sequencer Distribution view
- support extra actions in `DataTable` component
- add dashboard API service & tests

## Testing
- `just test`
- `just test-dashboard`
- `just ci`
