### PR TITLE
Fix gas used chart decimals

### DIFF
--- a/dashboard/components/GasUsedChart.tsx
+++ b/dashboard/components/GasUsedChart.tsx
@@ -10,7 +10,6 @@ import {
   ResponsiveContainer,
 } from 'recharts';
 import { TimeSeriesData } from '../types';
-import { formatDecimal } from '../utils';
 
 interface GasUsedChartProps {
   data: TimeSeriesData[];
@@ -47,7 +46,7 @@ export const GasUsedChart: React.FC<GasUsedChartProps> = ({ data, lineColor }) =
           stroke="#666666"
           fontSize={12}
           domain={['auto', 'auto']}
-          tickFormatter={(v) => formatDecimal(v)}
+          tickFormatter={(v: number) => v.toLocaleString()}
           label={{
             value: 'Gas Used',
             angle: -90,
@@ -59,7 +58,7 @@ export const GasUsedChart: React.FC<GasUsedChartProps> = ({ data, lineColor }) =
         />
         <Tooltip
           labelFormatter={(label: number) => `Block ${label.toLocaleString()}`}
-          formatter={(value: number) => [formatDecimal(value), 'gas']}
+          formatter={(value: number) => [value.toLocaleString(), 'gas']}
           contentStyle={{ backgroundColor: 'rgba(255, 255, 255, 0.8)', borderColor: lineColor }}
           labelStyle={{ color: '#333' }}
         />


### PR DESCRIPTION
## Notes
- adjust GasUsedChart to format values as integers
- updated tooltip to show commas without decimals

## Testing
- `just ci`
