### PR TITLE
Show transactions in sequencer table

### DIFF
--- a/dashboard/components/DataTable.tsx
+++ b/dashboard/components/DataTable.tsx
@@ -5,6 +5,13 @@ interface Column {
   label: string;
 }
 
+interface ExtraTable {
+  title: string;
+  columns: Column[];
+  rows: Array<Record<string, string | number>>;
+  onRowClick?: (row: Record<string, string | number>) => void;
+}
+
 interface DataTableProps {
   title: string;
   columns: Column[];
@@ -12,6 +19,7 @@ interface DataTableProps {
   onBack: () => void;
   onRowClick?: (row: Record<string, string | number>) => void;
   extraAction?: { label: string; onClick: () => void };
+  extraTable?: ExtraTable;
 }
 
 export const DataTable: React.FC<DataTableProps> = ({
@@ -21,6 +29,7 @@ export const DataTable: React.FC<DataTableProps> = ({
   onBack,
   onRowClick,
   extraAction,
+  extraTable,
 }) => {
   return (
     <div className="p-4">
@@ -68,6 +77,44 @@ export const DataTable: React.FC<DataTableProps> = ({
           </tbody>
         </table>
       </div>
+
+      {extraTable ? (
+        <div className="mt-8">
+          <h3 className="text-lg font-semibold mb-2">{extraTable.title}</h3>
+          <div className="overflow-x-auto">
+            <table className="min-w-full border divide-y divide-gray-200">
+              <thead>
+                <tr>
+                  {extraTable.columns.map((col) => (
+                    <th key={col.key} className="px-2 py-1 text-left">
+                      {col.label}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {extraTable.rows.map((row, idx) => (
+                  <tr
+                    key={idx}
+                    className="border-t hover:bg-gray-50 cursor-pointer"
+                    onClick={
+                      extraTable.onRowClick
+                        ? () => extraTable.onRowClick!(row)
+                        : undefined
+                    }
+                  >
+                    {extraTable.columns.map((col) => (
+                      <td key={col.key} className="px-2 py-1">
+                        {row[col.key] as React.ReactNode}
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- extend `DataTable` to support an optional extra table
- embed block transactions table in the Sequencer Distribution table

## Testing
- `npm run check`
- `npm run test` *(fails: ENOENT no such file or directory services/apiService.js)*
- `just ci` *(fails during `test-dashboard`)*