### PR TITLE
Create api-types crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -727,6 +727,7 @@ dependencies = [
 name = "api"
 version = "0.1.0"
 dependencies = [
+ "api-types",
  "async-stream",
  "axum",
  "chrono",
@@ -759,6 +760,14 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "api-types"
+version = "0.1.0"
+dependencies = [
+ "clickhouse 0.1.0",
+ "serde",
 ]
 
 [[package]]

--- a/crates/api-types/Cargo.toml
+++ b/crates/api-types/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "api-types"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+exclude.workspace = true
+repository.workspace = true
+
+[dependencies]
+serde.workspace = true
+clickhouse_lib = { path = "../clickhouse", package = "clickhouse" }
+
+[lints]
+workspace = true

--- a/crates/api-types/src/lib.rs
+++ b/crates/api-types/src/lib.rs
@@ -1,0 +1,148 @@
+//! Data types for the Taikoscope API.
+//!
+//! These structs define the JSON responses returned by the API server. They
+//! are provided in a separate crate so that consumers such as the dashboard can
+//! depend on them without pulling in the rest of the server implementation.
+
+#![allow(missing_docs)]
+
+use clickhouse_lib::{
+    BatchProveTimeRow, BatchVerifyTimeRow, ForcedInclusionProcessedRow, L1BlockTimeRow,
+    L2BlockTimeRow, L2GasUsedRow, L2ReorgRow, SlashingEventRow,
+};
+
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub struct L2HeadResponse {
+    pub last_l2_head_time: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct L1HeadResponse {
+    pub last_l1_head_time: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SlashingEventsResponse {
+    pub events: Vec<SlashingEventRow>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ForcedInclusionEventsResponse {
+    pub events: Vec<ForcedInclusionProcessedRow>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ReorgEventsResponse {
+    pub events: Vec<L2ReorgRow>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ActiveGatewaysResponse {
+    pub gateways: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CurrentOperatorResponse {
+    pub operator: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct NextOperatorResponse {
+    pub operator: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AvgProveTimeResponse {
+    pub avg_prove_time_ms: Option<u64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AvgVerifyTimeResponse {
+    pub avg_verify_time_ms: Option<u64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct L2BlockCadenceResponse {
+    pub l2_block_cadence_ms: Option<u64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct BatchPostingCadenceResponse {
+    pub batch_posting_cadence_ms: Option<u64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AvgL2TpsResponse {
+    pub avg_tps: Option<f64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ProveTimesResponse {
+    pub batches: Vec<BatchProveTimeRow>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct VerifyTimesResponse {
+    pub batches: Vec<BatchVerifyTimeRow>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct L1BlockTimesResponse {
+    pub blocks: Vec<L1BlockTimeRow>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct L2BlockTimesResponse {
+    pub blocks: Vec<L2BlockTimeRow>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct L2GasUsedResponse {
+    pub blocks: Vec<L2GasUsedRow>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SequencerDistributionItem {
+    pub address: String,
+    pub blocks: u64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SequencerDistributionResponse {
+    pub sequencers: Vec<SequencerDistributionItem>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SequencerBlocksItem {
+    pub address: String,
+    pub blocks: Vec<u64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SequencerBlocksResponse {
+    pub sequencers: Vec<SequencerBlocksItem>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct BlockTransactionsItem {
+    pub block: u64,
+    pub txs: u32,
+    pub sequencer: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct BlockTransactionsResponse {
+    pub blocks: Vec<BlockTransactionsItem>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct L2HeadBlockResponse {
+    pub l2_head_block: Option<u64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct L1HeadBlockResponse {
+    pub l1_head_block: Option<u64>,
+}

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 [dependencies]
 clickhouse_lib = { path = "../clickhouse", package = "clickhouse" }
 primitives = { path = "../primitives" }
+api-types = { path = "../api-types" }
 
 axum.workspace = true
 chrono = { workspace = true, features = ["serde"] }

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -2,6 +2,7 @@
 
 use std::net::SocketAddr;
 
+use api_types::*;
 use async_stream::stream;
 use axum::{
     Json, Router,
@@ -20,7 +21,7 @@ use eyre::Result;
 use futures::stream::Stream;
 use hex::encode;
 use primitives::rate_limiter::RateLimiter;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::{convert::Infallible, time::Duration as StdDuration};
 use tower_http::{
     cors::{AllowOrigin, Any, CorsLayer},
@@ -81,140 +82,6 @@ fn range_duration(range: &Option<String>) -> ChronoDuration {
     }
 
     ChronoDuration::hours(1)
-}
-
-#[derive(Debug, Serialize)]
-struct L2HeadResponse {
-    last_l2_head_time: Option<String>,
-}
-
-#[derive(Debug, Serialize)]
-struct L1HeadResponse {
-    last_l1_head_time: Option<String>,
-}
-
-#[derive(Debug, Serialize)]
-struct SlashingEventsResponse {
-    events: Vec<clickhouse_lib::SlashingEventRow>,
-}
-
-#[derive(Debug, Serialize)]
-struct ForcedInclusionEventsResponse {
-    events: Vec<clickhouse_lib::ForcedInclusionProcessedRow>,
-}
-
-#[derive(Debug, Serialize)]
-struct ReorgEventsResponse {
-    events: Vec<clickhouse_lib::L2ReorgRow>,
-}
-
-#[derive(Debug, Serialize)]
-struct ActiveGatewaysResponse {
-    gateways: Vec<String>,
-}
-
-#[derive(Debug, Serialize)]
-struct CurrentOperatorResponse {
-    operator: Option<String>,
-}
-
-#[derive(Debug, Serialize)]
-struct NextOperatorResponse {
-    operator: Option<String>,
-}
-
-#[derive(Debug, Serialize)]
-struct AvgProveTimeResponse {
-    avg_prove_time_ms: Option<u64>,
-}
-
-#[derive(Debug, Serialize)]
-struct AvgVerifyTimeResponse {
-    avg_verify_time_ms: Option<u64>,
-}
-
-#[derive(Debug, Serialize)]
-struct L2BlockCadenceResponse {
-    l2_block_cadence_ms: Option<u64>,
-}
-
-#[derive(Debug, Serialize)]
-struct BatchPostingCadenceResponse {
-    batch_posting_cadence_ms: Option<u64>,
-}
-
-#[derive(Debug, Serialize)]
-struct AvgL2TpsResponse {
-    avg_tps: Option<f64>,
-}
-
-#[derive(Debug, Serialize)]
-struct ProveTimesResponse {
-    batches: Vec<clickhouse_lib::BatchProveTimeRow>,
-}
-
-#[derive(Debug, Serialize)]
-struct VerifyTimesResponse {
-    batches: Vec<clickhouse_lib::BatchVerifyTimeRow>,
-}
-
-#[derive(Debug, Serialize)]
-struct L1BlockTimesResponse {
-    blocks: Vec<clickhouse_lib::L1BlockTimeRow>,
-}
-
-#[derive(Debug, Serialize)]
-struct L2BlockTimesResponse {
-    blocks: Vec<clickhouse_lib::L2BlockTimeRow>,
-}
-
-#[derive(Debug, Serialize)]
-struct L2GasUsedResponse {
-    blocks: Vec<clickhouse_lib::L2GasUsedRow>,
-}
-
-#[derive(Debug, Serialize)]
-struct SequencerDistributionItem {
-    address: String,
-    blocks: u64,
-}
-
-#[derive(Debug, Serialize)]
-struct SequencerDistributionResponse {
-    sequencers: Vec<SequencerDistributionItem>,
-}
-
-#[derive(Debug, Serialize)]
-struct SequencerBlocksItem {
-    address: String,
-    blocks: Vec<u64>,
-}
-
-#[derive(Debug, Serialize)]
-struct SequencerBlocksResponse {
-    sequencers: Vec<SequencerBlocksItem>,
-}
-
-#[derive(Debug, Serialize)]
-struct BlockTransactionsItem {
-    block: u64,
-    txs: u32,
-    sequencer: String,
-}
-
-#[derive(Debug, Serialize)]
-struct BlockTransactionsResponse {
-    blocks: Vec<BlockTransactionsItem>,
-}
-
-#[derive(Debug, Serialize)]
-struct L2HeadBlockResponse {
-    l2_head_block: Option<u64>,
-}
-
-#[derive(Debug, Serialize)]
-struct L1HeadBlockResponse {
-    l1_head_block: Option<u64>,
 }
 
 async fn l2_head(State(state): State<ApiState>) -> Json<L2HeadResponse> {


### PR DESCRIPTION
## Summary
- extract API response structs to new `api-types` crate
- import the shared types in the main API crate

## Testing
- `just ci`