### PR TITLE
Move API server setup into dedicated crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -757,6 +757,7 @@ dependencies = [
  "dotenvy",
  "eyre",
  "primitives",
+ "server",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -3666,6 +3667,19 @@ checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
 dependencies = [
  "base16ct",
  "serde",
+]
+
+[[package]]
+name = "server"
+version = "0.1.0"
+dependencies = [
+ "api",
+ "axum",
+ "clickhouse 0.1.0",
+ "eyre",
+ "tokio",
+ "tower-http",
+ "tracing",
 ]
 
 [[package]]

--- a/bin/api-server/Cargo.toml
+++ b/bin/api-server/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+server = { path = "../../crates/server" }
 api = { path = "../../crates/api" }
 clickhouse = { path = "../../crates/clickhouse" }
 config = { path = "../../crates/config" }

--- a/bin/api-server/src/main.rs
+++ b/bin/api-server/src/main.rs
@@ -2,12 +2,12 @@
 
 use std::net::SocketAddr;
 
-use api::run;
 use clap::Parser;
 use clickhouse::ClickhouseReader;
 use config::Opts;
 use dotenvy::dotenv;
 use primitives::shutdown::{ShutdownSignal, run_until_shutdown};
+use server::run;
 use tracing::info;
 use tracing_subscriber::filter::EnvFilter;
 

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "server"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+api = { path = "../api" }
+clickhouse_lib = { path = "../clickhouse", package = "clickhouse" }
+axum.workspace = true
+tower-http.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+eyre.workspace = true
+
+[lints]
+workspace = true

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -1,0 +1,59 @@
+//! Helper utilities to launch the Taikoscope API server.
+
+use std::{net::SocketAddr, sync::Arc};
+
+use api::{self, ApiState};
+use axum::{
+    Router,
+    http::{HeaderValue, Method},
+};
+use clickhouse_lib::ClickhouseReader;
+use eyre::Result;
+use tower_http::{
+    cors::{AllowOrigin, Any, CorsLayer},
+    trace::{DefaultMakeSpan, DefaultOnRequest, DefaultOnResponse, TraceLayer},
+};
+use tracing::{Level, info};
+
+/// Allowed CORS origins for dashboard requests.
+const ALLOWED_ORIGINS: &[&str] = &["https://taikoscope.xyz", "https://www.taikoscope.xyz"];
+
+/// Build the API router with CORS and tracing layers.
+pub fn router(state: ApiState, extra_origins: Vec<String>) -> Router {
+    let extra = Arc::new(extra_origins);
+    let cors = CorsLayer::new()
+        .allow_origin(AllowOrigin::predicate({
+            let extra = Arc::clone(&extra);
+            move |origin: &HeaderValue, _| match origin.to_str() {
+                Ok(origin) => {
+                    ALLOWED_ORIGINS.contains(&origin) ||
+                        origin.ends_with(".vercel.app") ||
+                        extra.iter().any(|o| o == origin)
+                }
+                Err(_) => false,
+            }
+        }))
+        .allow_methods([Method::GET])
+        .allow_headers(Any);
+    let trace = TraceLayer::new_for_http()
+        .make_span_with(DefaultMakeSpan::new().level(Level::INFO))
+        .on_request(DefaultOnRequest::new().level(Level::INFO))
+        .on_response(DefaultOnResponse::new().level(Level::INFO));
+
+    api::router(state).layer(cors).layer(trace)
+}
+
+/// Run the API server on the given address.
+pub async fn run(
+    addr: SocketAddr,
+    client: ClickhouseReader,
+    extra_origins: Vec<String>,
+) -> Result<()> {
+    let state = ApiState::new(client);
+    let app = router(state, extra_origins);
+
+    info!("Starting API server on {}", addr);
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    axum::serve(listener, app).await?;
+    Ok(())
+}

--- a/tests/api_integration.rs
+++ b/tests/api_integration.rs
@@ -9,7 +9,7 @@ use serde::Serialize;
 use tokio::time::sleep;
 use url::Url;
 
-use api::run;
+use server::run;
 use clickhouse_lib::ClickhouseReader;
 
 #[derive(Serialize, Row)]


### PR DESCRIPTION
## Summary
- move `run` function into new `server` crate
- expose `ApiState` and router builder from `api`
- update API server binary and tests to use new crate

## Testing
- `just ci`