### PR TITLE
Add pagination for block transactions API

### DIFF
--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -352,8 +352,11 @@ export interface BlockTransaction {
 
 export const fetchBlockTransactions = async (
   range: '1h' | '24h' | '7d',
+  page = 0,
+  limit = 50,
 ): Promise<RequestResult<BlockTransaction[]>> => {
-  const url = `${API_BASE}/block-transactions?range=${range}`;
+  const offset = page * limit;
+  const url = `${API_BASE}/block-transactions?range=${range}&limit=${limit}&offset=${offset}`;
   const res = await fetchJson<{ blocks: BlockTransaction[] }>(url);
   return { data: res.data?.blocks ?? null, badRequest: res.badRequest };
 };


### PR DESCRIPTION
## Summary
- support paginated block transactions queries in ClickHouse reader
- expose pagination parameters via API with a default limit of 50
- update dashboard API service to use limit and offset

## Testing
- `just ci`