### PR TITLE
Fix eslint warnings

### DIFF
--- a/dashboard/components/SequencerPieChart.tsx
+++ b/dashboard/components/SequencerPieChart.tsx
@@ -7,6 +7,7 @@ import {
   Legend,
   ResponsiveContainer,
 } from 'recharts';
+import type { Payload } from 'recharts/types/component/DefaultTooltipContent';
 import { PieChartDataItem } from '../types';
 import { formatSequencerTooltip } from '../utils';
 
@@ -66,7 +67,11 @@ export const SequencerPieChart: React.FC<SequencerPieChartProps> = ({
           })}
         </Pie>
         <Tooltip
-          formatter={(_, name: string, item: any) => {
+          formatter={(
+            _,
+            name: string,
+            item: Payload<number, string>,
+          ) => {
             const payload = item.payload as PieChartDataItem;
             return [formatSequencerTooltip(data, payload.value), name];
           }}

--- a/dashboard/custom.d.ts
+++ b/dashboard/custom.d.ts
@@ -1,1 +1,3 @@
+/// <reference types="vite/client" />
+
 declare module '*.css';

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -1,4 +1,4 @@
-const metaEnv = (import.meta as any).env ?? {};
+const metaEnv = import.meta.env;
 export const API_BASE = metaEnv.VITE_API_BASE || metaEnv.API_BASE || '';
 
 import type {


### PR DESCRIPTION
## Summary
- replace explicit `any` types in SequencerPieChart
- use typed env values in api service
- augment dashboard types with vite client reference
- tighten types in integration tests

## Testing
- `npm run check`
- `npm run lint`
- `npm run test`
- `just ci`
