### PR TITLE
Implement large number formatting on dashboard

### DIFF
--- a/dashboard/components/GasUsedChart.tsx
+++ b/dashboard/components/GasUsedChart.tsx
@@ -10,6 +10,7 @@ import {
   ResponsiveContainer,
 } from 'recharts';
 import { TimeSeriesData } from '../types';
+import { formatLargeNumber } from '../utils';
 
 interface GasUsedChartProps {
   data: TimeSeriesData[];
@@ -46,7 +47,7 @@ export const GasUsedChart: React.FC<GasUsedChartProps> = ({ data, lineColor }) =
           stroke="#666666"
           fontSize={12}
           domain={['auto', 'auto']}
-          tickFormatter={(v: number) => v.toLocaleString()}
+          tickFormatter={(v: number) => formatLargeNumber(v)}
           label={{
             value: 'Gas Used',
             angle: -90,
@@ -58,7 +59,7 @@ export const GasUsedChart: React.FC<GasUsedChartProps> = ({ data, lineColor }) =
         />
         <Tooltip
           labelFormatter={(label: number) => `Block ${label.toLocaleString()}`}
-          formatter={(value: number) => [value.toLocaleString(), 'gas']}
+          formatter={(value: number) => [formatLargeNumber(value), 'gas']}
           contentStyle={{ backgroundColor: 'rgba(255, 255, 255, 0.8)', borderColor: lineColor }}
           labelStyle={{ color: '#333' }}
         />

--- a/dashboard/tests/utils.test.ts
+++ b/dashboard/tests/utils.test.ts
@@ -8,6 +8,7 @@ import {
   shouldShowMinutes,
   findMetricValue,
   formatSequencerTooltip,
+  formatLargeNumber,
   bytesToHex,
 } from '../utils.js';
 
@@ -71,6 +72,12 @@ describe('utils', () => {
 
     const zeroTooltip = formatSequencerTooltip([{ value: 0 }], 0);
     expect(zeroTooltip).toBe('0 blocks (0%)');
+  });
+
+  it('formats large numbers', () => {
+    expect(formatLargeNumber(1500)).toBe('1.5K');
+    expect(formatLargeNumber(15_000_000)).toBe('15M');
+    expect(formatLargeNumber(50)).toBe('50');
   });
 
   it('converts bytes to hex', () => {

--- a/dashboard/utils.ts
+++ b/dashboard/utils.ts
@@ -13,6 +13,16 @@ export const formatSeconds = (seconds: number): string => {
   return `${formatDecimal(seconds)}s`;
 };
 
+export const formatLargeNumber = (value: number): string => {
+  if (Math.abs(value) >= 1_000_000) {
+    return `${Number(formatDecimal(value / 1_000_000))}M`;
+  }
+  if (Math.abs(value) >= 1_000) {
+    return `${Number(formatDecimal(value / 1_000))}K`;
+  }
+  return value.toLocaleString();
+};
+
 export const formatInterval = (ms: number, showMinutes: boolean): string => {
   return showMinutes
     ? `${formatDecimal(ms / 60000)} minutes`


### PR DESCRIPTION
## Summary
- add `formatLargeNumber` utility for compact `K`/`M` display
- use new formatter in `GasUsedChart`
- test number formatting logic

## Testing
- `just ci`