### PR TITLE
Add transactions per block chart

### DIFF
--- a/dashboard/components/BlockTxChart.tsx
+++ b/dashboard/components/BlockTxChart.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts';
+import type { BlockTransaction } from '../services/apiService';
+
+interface BlockTxChartProps {
+  data: BlockTransaction[];
+  barColor: string;
+}
+
+export const BlockTxChart: React.FC<BlockTxChartProps> = ({
+  data,
+  barColor,
+}) => {
+  if (!data || data.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-full text-gray-500">
+        No data available
+      </div>
+    );
+  }
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <BarChart
+        data={data}
+        margin={{ top: 5, right: 30, left: 20, bottom: 50 }}
+      >
+        <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
+        <XAxis
+          dataKey="block"
+          tickFormatter={(v: number) => v.toLocaleString()}
+          stroke="#666666"
+          fontSize={12}
+          label={{
+            value: 'Block Number',
+            position: 'insideBottom',
+            offset: -10,
+            fontSize: 10,
+            fill: '#666666',
+          }}
+          padding={{ left: 10, right: 10 }}
+        />
+        <YAxis
+          stroke="#666666"
+          fontSize={12}
+          domain={[0, 'auto']}
+          tickFormatter={(v: number) => v.toLocaleString()}
+          label={{
+            value: 'Tx Count',
+            angle: -90,
+            position: 'insideLeft',
+            offset: -16,
+            fontSize: 10,
+            fill: '#666666',
+          }}
+        />
+        <Tooltip
+          labelFormatter={(label: number) => `Block ${label.toLocaleString()}`}
+          formatter={(value: number) => [value.toLocaleString(), 'txs']}
+          contentStyle={{
+            backgroundColor: 'rgba(255, 255, 255, 0.8)',
+            borderColor: barColor,
+          }}
+          labelStyle={{ color: '#333' }}
+        />
+        <Legend
+          verticalAlign="bottom"
+          align="right"
+          wrapperStyle={{ right: 20, bottom: 0 }}
+        />
+        <Bar dataKey="txs" fill={barColor} name="Txs" />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+};


### PR DESCRIPTION
## Summary
- visualize tx count per block in the dashboard
- fetch block transactions from the API

## Testing
- `just ci`
