### PR TITLE
Add pagination to DataTable

### DIFF
--- a/dashboard/components/DataTable.tsx
+++ b/dashboard/components/DataTable.tsx
@@ -46,6 +46,21 @@ export const DataTable: React.FC<DataTableProps> = ({
   onTimeRangeChange,
   chart,
 }) => {
+  const ROWS_PER_PAGE = 50;
+  const [page, setPage] = React.useState(0);
+
+  React.useEffect(() => {
+    setPage(0);
+  }, [rows]);
+
+  const pageRows = React.useMemo(
+    () => rows.slice(page * ROWS_PER_PAGE, (page + 1) * ROWS_PER_PAGE),
+    [rows, page],
+  );
+
+  const disablePrev = page === 0;
+  const disableNext = (page + 1) * ROWS_PER_PAGE >= rows.length;
+
   return (
     <div className="p-4">
       <div className="flex items-center mb-4 space-x-4">
@@ -82,7 +97,7 @@ export const DataTable: React.FC<DataTableProps> = ({
             </tr>
           </thead>
           <tbody>
-            {rows.map((row, idx) => (
+            {pageRows.map((row, idx) => (
               <tr
                 key={idx}
                 className="border-t hover:bg-gray-50 cursor-pointer"
@@ -97,6 +112,23 @@ export const DataTable: React.FC<DataTableProps> = ({
             ))}
           </tbody>
         </table>
+      </div>
+      <div className="flex items-center justify-between mt-2">
+        <button
+          onClick={() => setPage((p) => p - 1)}
+          disabled={disablePrev}
+          className="text-[#e81899] disabled:text-gray-400"
+        >
+          Prev
+        </button>
+        <span>Page {page + 1}</span>
+        <button
+          onClick={() => setPage((p) => p + 1)}
+          disabled={disableNext}
+          className="text-[#e81899] disabled:text-gray-400"
+        >
+          Next
+        </button>
       </div>
 
       {extraTable ? (

--- a/dashboard/tests/dataTable.test.ts
+++ b/dashboard/tests/dataTable.test.ts
@@ -60,4 +60,19 @@ describe('DataTable', () => {
     expect(html.includes('24H')).toBe(true);
     expect(html.includes('7D')).toBe(true);
   });
+
+  it('paginates rows when more than 50 items', () => {
+    const rows = Array.from({ length: 55 }, (_, i) => ({ a: String(i) }));
+    const html = renderToStaticMarkup(
+      React.createElement(DataTable, {
+        title: 'Paged',
+        columns: [{ key: 'a', label: 'A' }],
+        rows,
+        onBack: () => {},
+      }),
+    );
+    expect(html.includes('49')).toBe(true);
+    expect(html.includes('54')).toBe(false);
+    expect(html.includes('Next')).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- add internal pagination to DataTable with 50 items per page
- show Prev/Next buttons and current page
- test pagination behavior when more than 50 rows

## Testing
- `just ci`