### PR TITLE
Add cursor pagination to block tx chart

### DIFF
--- a/dashboard/App.tsx
+++ b/dashboard/App.tsx
@@ -379,15 +379,20 @@ const App: React.FC = () => {
   const openSequencerDistributionTable = async (
     range: TimeRange,
     page = seqDistTxPage,
+    startingAfter?: number,
+    endingBefore?: number,
   ) => {
     setTimeRange(range);
     setSeqDistTxPage(page);
     const [distRes, txRes] = await Promise.all([
       fetchSequencerDistribution(range),
-      fetchBlockTransactions(range, page),
+      fetchBlockTransactions(range, 50, startingAfter, endingBefore),
     ]);
+    const txData = txRes.data || [];
     const disablePrev = page === 0;
-    const disableNext = (txRes.data?.length ?? 0) < 50;
+    const disableNext = txData.length < 50;
+    const nextCursor = txData.length > 0 ? txData[txData.length - 1].block : undefined;
+    const prevCursor = txData.length > 0 ? txData[0].block : undefined;
     openTable(
       'Sequencer Distribution',
       [
@@ -410,8 +415,10 @@ const App: React.FC = () => {
         >[],
         pagination: {
           page,
-          onPrev: () => openSequencerDistributionTable(range, page - 1),
-          onNext: () => openSequencerDistributionTable(range, page + 1),
+          onPrev: () =>
+            openSequencerDistributionTable(range, page - 1, undefined, prevCursor),
+          onNext: () =>
+            openSequencerDistributionTable(range, page + 1, nextCursor, undefined),
           disablePrev,
           disableNext,
         },
@@ -533,7 +540,7 @@ const App: React.FC = () => {
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 md:gap-6 mt-6">
           <ChartCard
             title="Sequencer Distribution"
-            onMore={() => openSequencerDistributionTable(timeRange)}
+            onMore={() => openSequencerDistributionTable(timeRange, 0)}
           >
             <SequencerPieChart data={sequencerDistribution} />
           </ChartCard>

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -352,11 +352,16 @@ export interface BlockTransaction {
 
 export const fetchBlockTransactions = async (
   range: '1h' | '24h' | '7d',
-  page = 0,
   limit = 50,
+  startingAfter?: number,
+  endingBefore?: number,
 ): Promise<RequestResult<BlockTransaction[]>> => {
-  const offset = page * limit;
-  const url = `${API_BASE}/block-transactions?range=${range}&limit=${limit}&offset=${offset}`;
+  let url = `${API_BASE}/block-transactions?range=${range}&limit=${limit}`;
+  if (startingAfter !== undefined) {
+    url += `&starting_after=${startingAfter}`;
+  } else if (endingBefore !== undefined) {
+    url += `&ending_before=${endingBefore}`;
+  }
   const res = await fetchJson<{ blocks: BlockTransaction[] }>(url);
   return { data: res.data?.blocks ?? null, badRequest: res.badRequest };
 };

--- a/docs/API.md
+++ b/docs/API.md
@@ -30,6 +30,6 @@ This document lists the HTTP endpoints exposed by the Taikoscope API server. All
 | `/l2-gas-used` | Gas used per L2 block. Optional `?range` query. |
 | `/sequencer-distribution` | Number of blocks produced by each sequencer. Optional `?range` query. |
 | `/sequencer-blocks` | Blocks produced by each sequencer. Optional `?range` query. |
-| `/block-transactions` | Number of transactions per L2 block. Supports `range`, `limit` and `offset` queries. |
+| `/block-transactions` | Number of transactions per L2 block. Supports `range`, `limit` and cursor-based pagination with `starting_after` or `ending_before`. |
 
 Parameters such as `range` follow the form `1h`, `24h` or `7d` and default to one hour if omitted.


### PR DESCRIPTION
## Summary
- switch block transactions API call to use cursors
- update sequencer distribution table to navigate with cursors
- document new cursor parameters for block-transactions endpoint

## Testing
- `just ci`