### PR TITLE
Enable configurable dashboard refresh rate

### DIFF
--- a/dashboard/App.tsx
+++ b/dashboard/App.tsx
@@ -19,7 +19,7 @@ import {
   SlashingEvent,
   ForcedInclusionEvent,
 } from './types';
-import { bytesToHex } from './utils';
+import { bytesToHex, loadRefreshRate, saveRefreshRate } from './utils';
 import {
   API_BASE,
   fetchAvgProveTime,
@@ -71,7 +71,9 @@ const App: React.FC = () => {
   >([]);
   const [l2HeadBlock, setL2HeadBlock] = useState<string>('0');
   const [l1HeadBlock, setL1HeadBlock] = useState<string>('0');
-  const [refreshRate, setRefreshRate] = useState<number>(60000);
+  const [refreshRate, setRefreshRate] = useState<number>(() =>
+    loadRefreshRate(),
+  );
   const [errorMessage, setErrorMessage] = useState<string>('');
   const [seqDistTxPage, setSeqDistTxPage] = useState<number>(0);
   const [tableView, setTableView] = useState<null | {
@@ -292,6 +294,10 @@ const App: React.FC = () => {
   }, [timeRange]);
 
   useEffect(() => {
+    saveRefreshRate(refreshRate);
+  }, [refreshRate]);
+
+  useEffect(() => {
     if (tableView) return;
     fetchData();
     const interval = setInterval(fetchData, Math.max(refreshRate, 10000));
@@ -421,7 +427,8 @@ const App: React.FC = () => {
     const txData = txRes.data || [];
     const disablePrev = page === 0;
     const disableNext = txData.length < 50;
-    const nextCursor = txData.length > 0 ? txData[txData.length - 1].block : undefined;
+    const nextCursor =
+      txData.length > 0 ? txData[txData.length - 1].block : undefined;
     const prevCursor = txData.length > 0 ? txData[0].block : undefined;
     openTable(
       'Sequencer Distribution',
@@ -446,9 +453,19 @@ const App: React.FC = () => {
         pagination: {
           page,
           onPrev: () =>
-            openSequencerDistributionTable(range, page - 1, undefined, prevCursor),
+            openSequencerDistributionTable(
+              range,
+              page - 1,
+              undefined,
+              prevCursor,
+            ),
           onNext: () =>
-            openSequencerDistributionTable(range, page + 1, nextCursor, undefined),
+            openSequencerDistributionTable(
+              range,
+              page + 1,
+              nextCursor,
+              undefined,
+            ),
           disablePrev,
           disableNext,
         },

--- a/dashboard/tests/utils.test.ts
+++ b/dashboard/tests/utils.test.ts
@@ -10,6 +10,8 @@ import {
   formatSequencerTooltip,
   formatLargeNumber,
   bytesToHex,
+  loadRefreshRate,
+  saveRefreshRate,
 } from '../utils.js';
 
 describe('utils', () => {
@@ -47,13 +49,13 @@ describe('utils', () => {
   });
 
   it('determines minute display correctly', () => {
-    expect(shouldShowMinutes([{ timestamp: 1000 }, { timestamp: 200000 }])).toBe(
-      true,
-    );
+    expect(
+      shouldShowMinutes([{ timestamp: 1000 }, { timestamp: 200000 }]),
+    ).toBe(true);
 
-    expect(shouldShowMinutes([{ timestamp: 1000 }, { timestamp: 110000 }])).toBe(
-      false,
-    );
+    expect(
+      shouldShowMinutes([{ timestamp: 1000 }, { timestamp: 110000 }]),
+    ).toBe(false);
   });
 
   it('finds metric values', () => {
@@ -82,5 +84,26 @@ describe('utils', () => {
 
   it('converts bytes to hex', () => {
     expect(bytesToHex([0, 1, 255])).toBe('0x0001ff');
+  });
+
+  it('saves and loads refresh rate', () => {
+    const store: Record<string, string> = {};
+    // @ts-ignore
+    globalThis.localStorage = {
+      getItem: (k: string) => (k in store ? store[k] : null),
+      setItem: (k: string, v: string) => {
+        store[k] = v;
+      },
+      removeItem: () => {},
+      clear: () => {},
+      key: () => null,
+      length: 0,
+    } as Storage;
+
+    expect(loadRefreshRate()).toBe(60000);
+    saveRefreshRate(10000);
+    expect(store.refreshRate).toBe('10000');
+    store.refreshRate = '2000';
+    expect(loadRefreshRate()).toBe(2000);
   });
 });

--- a/dashboard/utils.ts
+++ b/dashboard/utils.ts
@@ -73,3 +73,15 @@ export const formatSequencerTooltip = (
 
 export const bytesToHex = (bytes: number[]): string =>
   `0x${bytes.map((b) => b.toString(16).padStart(2, '0')).join('')}`;
+
+export const loadRefreshRate = (): number => {
+  if (typeof localStorage === 'undefined') return 60000;
+  const stored = localStorage.getItem('refreshRate');
+  const value = stored ? parseInt(stored, 10) : NaN;
+  return Number.isFinite(value) && value > 0 ? value : 60000;
+};
+
+export const saveRefreshRate = (rate: number): void => {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.setItem('refreshRate', String(rate));
+};


### PR DESCRIPTION
## Summary
- support persisting refresh rate via localStorage
- use stored refresh rate when the dashboard loads
- test the new helpers to store and load refresh rate

## Testing
- `just ci`