### PR TITLE
Add refresh configuration to dashboard table view

### DIFF
--- a/dashboard/components/DashboardHeader.tsx
+++ b/dashboard/components/DashboardHeader.tsx
@@ -63,12 +63,12 @@ export const TimeRangeSelector: React.FC<TimeRangeSelectorProps> = ({
   );
 };
 
-interface RefreshRateInputProps {
+export interface RefreshRateInputProps {
   refreshRate: number;
   onRefreshRateChange: (rate: number) => void;
 }
 
-const RefreshRateInput: React.FC<RefreshRateInputProps> = ({
+export const RefreshRateInput: React.FC<RefreshRateInputProps> = ({
   refreshRate,
   onRefreshRateChange,
 }) => {

--- a/dashboard/components/DataTable.tsx
+++ b/dashboard/components/DataTable.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { TimeRange } from '../types';
-import { TimeRangeSelector } from './DashboardHeader';
+import { TimeRangeSelector, RefreshRateInput } from './DashboardHeader';
 
 interface Column {
   key: string;
@@ -31,6 +31,8 @@ interface DataTableProps {
   extraTable?: ExtraTable;
   timeRange?: TimeRange;
   onTimeRangeChange?: (range: TimeRange) => void;
+  refreshRate?: number;
+  onRefreshRateChange?: (rate: number) => void;
   chart?: React.ReactNode;
 }
 
@@ -44,6 +46,8 @@ export const DataTable: React.FC<DataTableProps> = ({
   extraTable,
   timeRange,
   onTimeRangeChange,
+  refreshRate,
+  onRefreshRateChange,
   chart,
 }) => {
   const ROWS_PER_PAGE = 50;
@@ -80,6 +84,12 @@ export const DataTable: React.FC<DataTableProps> = ({
           <TimeRangeSelector
             currentTimeRange={timeRange}
             onTimeRangeChange={onTimeRangeChange}
+          />
+        )}
+        {refreshRate !== undefined && onRefreshRateChange && (
+          <RefreshRateInput
+            refreshRate={refreshRate}
+            onRefreshRateChange={onRefreshRateChange}
           />
         )}
       </div>

--- a/dashboard/tests/dataTable.test.ts
+++ b/dashboard/tests/dataTable.test.ts
@@ -61,6 +61,20 @@ describe('DataTable', () => {
     expect(html.includes('7D')).toBe(true);
   });
 
+  it('renders refresh rate input', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(DataTable, {
+        title: 'Refresh',
+        columns: [{ key: 'v', label: 'V' }],
+        rows: [{ v: 1 }],
+        onBack: () => {},
+        refreshRate: 10000,
+        onRefreshRateChange: () => {},
+      }),
+    );
+    expect(html.includes('Refresh')).toBe(true);
+  });
+
   it('paginates rows when more than 50 items', () => {
     const rows = Array.from({ length: 55 }, (_, i) => ({ a: String(i) }));
     const html = renderToStaticMarkup(


### PR DESCRIPTION
## Summary
- export `RefreshRateInput` for reuse
- show refresh selector in `DataTable`
- test refresh input rendering

## Testing
- `just ci`