### PR TITLE
Add active gateways table to dashboard

### DIFF
--- a/dashboard/App.tsx
+++ b/dashboard/App.tsx
@@ -27,6 +27,7 @@ import {
   fetchL2BlockCadence,
   fetchBatchPostingCadence,
   fetchActiveGateways,
+  fetchActiveGatewayAddresses,
   fetchL2Reorgs,
   fetchL2ReorgEvents,
   fetchSlashingEventCount,
@@ -412,6 +413,18 @@ const App: React.FC = () => {
     );
   };
 
+  const openActiveGatewaysTable = async () => {
+    const gatewaysRes = await fetchActiveGatewayAddresses(timeRange);
+    openTable(
+      'Active Gateways',
+      [{ key: 'address', label: 'Address' }],
+      (gatewaysRes.data || []).map((g) => ({ address: g })) as Record<
+        string,
+        string | number
+      >[],
+    );
+  };
+
   const openSequencerDistributionTable = async (
     range: TimeRange,
     page = seqDistTxPage,
@@ -533,7 +546,10 @@ const App: React.FC = () => {
                           : typeof m.title === 'string' &&
                               m.title === 'Forced Inclusions'
                             ? () => openForcedInclusionsTable()
-                            : undefined
+                            : typeof m.title === 'string' &&
+                                m.title === 'Active Gateways'
+                              ? () => openActiveGatewaysTable()
+                              : undefined
                     }
                   />
                 ))}

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -86,6 +86,14 @@ export const fetchActiveGateways = async (
   };
 };
 
+export const fetchActiveGatewayAddresses = async (
+  range: '1h' | '24h' | '7d',
+): Promise<RequestResult<string[]>> => {
+  const url = `${API_BASE}/active-gateways?range=${range}`;
+  const res = await fetchJson<{ gateways: string[] }>(url);
+  return { data: res.data?.gateways ?? null, badRequest: res.badRequest };
+};
+
 export const fetchL2Reorgs = async (
   range: '1h' | '24h' | '7d',
 ): Promise<RequestResult<number>> => {

--- a/dashboard/tests/apiService.test.ts
+++ b/dashboard/tests/apiService.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, afterEach } from 'vitest';
 import {
   fetchAvgProveTime,
   fetchActiveGateways,
+  fetchActiveGatewayAddresses,
   fetchL2BlockTimes,
   fetchBlockTransactions,
 } from '../services/apiService.ts';
@@ -44,6 +45,12 @@ describe('apiService', () => {
     expect(gateways.data).toBe(2);
   });
 
+  it('fetches active gateway addresses', async () => {
+    globalThis.fetch = mockFetch({ gateways: ['a', 'b'] });
+    const gateways = await fetchActiveGatewayAddresses('1h');
+    expect(gateways.data).toStrictEqual(['a', 'b']);
+  });
+
   it('transforms block times', async () => {
     globalThis.fetch = mockFetch({
       blocks: [
@@ -57,9 +64,7 @@ describe('apiService', () => {
 
   it('transforms block transactions', async () => {
     globalThis.fetch = mockFetch({
-      blocks: [
-        { block: 1, txs: 3, sequencer: '0xabc' },
-      ],
+      blocks: [{ block: 1, txs: 3, sequencer: '0xabc' }],
     });
     const txs = await fetchBlockTransactions('1h');
     expect(txs.data).toStrictEqual([{ block: 1, txs: 3, sequencer: '0xabc' }]);


### PR DESCRIPTION
## Summary
- expose `fetchActiveGatewayAddresses` for list endpoint
- add table view with gateway addresses
- test new API service helper

## Testing
- `npm run check`
- `npm test`
- `just ci`
