### PR TITLE
Add blobs per batch metric

### DIFF
--- a/crates/api-types/src/lib.rs
+++ b/crates/api-types/src/lib.rs
@@ -7,8 +7,8 @@
 #![allow(missing_docs)]
 
 use clickhouse_lib::{
-    BatchProveTimeRow, BatchVerifyTimeRow, ForcedInclusionProcessedRow, L1BlockTimeRow,
-    L2BlockTimeRow, L2GasUsedRow, L2ReorgRow, SlashingEventRow,
+    BatchBlobCountRow, BatchProveTimeRow, BatchVerifyTimeRow, ForcedInclusionProcessedRow,
+    L1BlockTimeRow, L2BlockTimeRow, L2GasUsedRow, L2ReorgRow, SlashingEventRow,
 };
 
 use serde::Serialize;
@@ -135,6 +135,16 @@ pub struct BlockTransactionsItem {
 #[derive(Debug, Serialize)]
 pub struct BlockTransactionsResponse {
     pub blocks: Vec<BlockTransactionsItem>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct BatchBlobsResponse {
+    pub batches: Vec<BatchBlobCountRow>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AvgBlobsPerBatchResponse {
+    pub avg_blobs: Option<f64>,
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/clickhouse/src/models.rs
+++ b/crates/clickhouse/src/models.rs
@@ -193,3 +193,12 @@ pub struct L2GasUsedRow {
     /// Total gas used in the block
     pub gas_used: u64,
 }
+
+/// Row representing the blob count for each batch
+#[derive(Debug, Row, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BatchBlobCountRow {
+    /// Batch ID
+    pub batch_id: u64,
+    /// Number of blobs in the batch
+    pub blob_count: u8,
+}

--- a/dashboard/helpers.ts
+++ b/dashboard/helpers.ts
@@ -8,6 +8,7 @@ export interface MetricInputData {
   batchCadence: number | null;
   avgProve: number | null;
   avgVerify: number | null;
+  avgBlobsPerBatch: number | null;
   activeGateways: number | null;
   currentOperator: string | null;
   nextOperator: string | null;
@@ -56,6 +57,12 @@ export const createMetrics = (data: MetricInputData): MetricData[] => [
       data.avgVerify != null && data.avgVerify > 0
         ? formatSeconds(data.avgVerify / 1000)
         : 'N/A',
+    group: 'Network Performance',
+  },
+  {
+    title: 'Blobs per Batch',
+    value:
+      data.avgBlobsPerBatch != null ? data.avgBlobsPerBatch.toFixed(2) : 'N/A',
     group: 'Network Performance',
   },
   {

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -373,3 +373,34 @@ export const fetchBlockTransactions = async (
   const res = await fetchJson<{ blocks: BlockTransaction[] }>(url);
   return { data: res.data?.blocks ?? null, badRequest: res.badRequest };
 };
+
+export interface BatchBlobCount {
+  batch: number;
+  blobs: number;
+}
+
+export const fetchBatchBlobCounts = async (
+  range: '1h' | '24h' | '7d',
+): Promise<RequestResult<BatchBlobCount[]>> => {
+  const url = `${API_BASE}/blobs-per-batch?range=${range}`;
+  const res = await fetchJson<{
+    batches: { batch_id: number; blob_count: number }[];
+  }>(url);
+  return {
+    data: res.data
+      ? res.data.batches.map((b) => ({
+          batch: b.batch_id,
+          blobs: b.blob_count,
+        }))
+      : null,
+    badRequest: res.badRequest,
+  };
+};
+
+export const fetchAvgBlobsPerBatch = async (
+  range: '1h' | '24h' | '7d',
+): Promise<RequestResult<number>> => {
+  const url = `${API_BASE}/avg-blobs-per-batch?range=${range}`;
+  const res = await fetchJson<{ avg_blobs?: number }>(url);
+  return { data: res.data?.avg_blobs ?? null, badRequest: res.badRequest };
+};

--- a/dashboard/tests/app.integration.test.ts
+++ b/dashboard/tests/app.integration.test.ts
@@ -95,9 +95,11 @@ const responses: Record<string, Record<string, unknown>> = {
   '/l1-head-block': { l1_head_block: 456 },
 };
 
-(globalThis as {
-  fetch?: (url: string) => Promise<MockFetchResponse>;
-}).fetch = async (url: string): Promise<MockFetchResponse> => {
+(
+  globalThis as {
+    fetch?: (url: string) => Promise<MockFetchResponse>;
+  }
+).fetch = async (url: string): Promise<MockFetchResponse> => {
   const u = new URL(url, 'http://localhost');
   const key = u.pathname + (u.search ? `?${u.searchParams.toString()}` : '');
   return {
@@ -127,11 +129,16 @@ class MockEventSource {
 (globalThis as unknown as { EventSource: unknown }).EventSource =
   MockEventSource as unknown as EventSource;
 
-interface IntervalId { fn: () => Promise<void> | void; ms: number }
+interface IntervalId {
+  fn: () => Promise<void> | void;
+  ms: number;
+}
 let intervals: IntervalId[] = [];
-(globalThis as unknown as {
-  setInterval: (fn: () => Promise<void> | void, ms: number) => NodeJS.Timeout;
-}).setInterval = (
+(
+  globalThis as unknown as {
+    setInterval: (fn: () => Promise<void> | void, ms: number) => NodeJS.Timeout;
+  }
+).setInterval = (
   fn: () => Promise<void> | void,
   ms: number,
 ): NodeJS.Timeout => {
@@ -139,9 +146,9 @@ let intervals: IntervalId[] = [];
   intervals.push(id);
   return id as unknown as NodeJS.Timeout;
 };
-(globalThis as unknown as { clearInterval: (id: NodeJS.Timeout) => void }).clearInterval = (
-  id: NodeJS.Timeout,
-) => {
+(
+  globalThis as unknown as { clearInterval: (id: NodeJS.Timeout) => void }
+).clearInterval = (id: NodeJS.Timeout) => {
   intervals = intervals.filter((i) => i !== (id as unknown as IntervalId));
 };
 
@@ -241,6 +248,7 @@ async function fetchData(range: TimeRange, state: State) {
     batchCadence,
     avgProve,
     avgVerify,
+    avgBlobsPerBatch: null,
     activeGateways,
     currentOperator,
     nextOperator,

--- a/dashboard/tests/helpers.test.ts
+++ b/dashboard/tests/helpers.test.ts
@@ -9,6 +9,7 @@ const metrics = createMetrics({
   activeGateways: 2,
   currentOperator: '0xabc',
   nextOperator: null,
+  avgBlobsPerBatch: 1,
   l2Reorgs: 1,
   slashings: null,
   forcedInclusions: 0,
@@ -27,6 +28,7 @@ const metricsAllNull = createMetrics({
   avgProve: null,
   avgVerify: null,
   activeGateways: null,
+  avgBlobsPerBatch: null,
   l2Reorgs: null,
   slashings: null,
   forcedInclusions: null,
@@ -46,22 +48,24 @@ describe('helpers', () => {
     expect(metrics[2].group).toBe('Network Performance');
     expect(metrics[3].value).toBe('N/A');
     expect(metrics[3].group).toBe('Network Performance');
-    expect(metrics[4].value).toBe('2');
-    expect(metrics[4].group).toBe('Operators');
-    expect(metrics[5].value).toBe('0xabc');
+    expect(metrics[4].value).toBe('1.00');
+    expect(metrics[4].group).toBe('Network Performance');
+    expect(metrics[5].value).toBe('2');
     expect(metrics[5].group).toBe('Operators');
-    expect(metrics[6].value).toBe('N/A');
+    expect(metrics[6].value).toBe('0xabc');
     expect(metrics[6].group).toBe('Operators');
-    expect(metrics[7].value).toBe('1');
-    expect(metrics[7].group).toBe('Network Health');
-    expect(metrics[8].value).toBe('N/A');
+    expect(metrics[7].value).toBe('N/A');
+    expect(metrics[7].group).toBe('Operators');
+    expect(metrics[8].value).toBe('1');
     expect(metrics[8].group).toBe('Network Health');
-    expect(metrics[9].value).toBe('0');
+    expect(metrics[9].value).toBe('N/A');
     expect(metrics[9].group).toBe('Network Health');
-    expect(metrics[10].value).toBe('100');
-    expect(metrics[10].group).toBe('Block Information');
-    expect(metrics[11].value).toBe('50');
+    expect(metrics[10].value).toBe('0');
+    expect(metrics[10].group).toBe('Network Health');
+    expect(metrics[11].value).toBe('100');
     expect(metrics[11].group).toBe('Block Information');
+    expect(metrics[12].value).toBe('50');
+    expect(metrics[12].group).toBe('Block Information');
   });
 
   it('detects bad requests', () => {
@@ -77,14 +81,15 @@ describe('helpers', () => {
     expect(metricsAllNull[1].group).toBe('Network Performance');
     expect(metricsAllNull[2].group).toBe('Network Performance');
     expect(metricsAllNull[3].group).toBe('Network Performance');
-    expect(metricsAllNull[4].group).toBe('Operators');
+    expect(metricsAllNull[4].group).toBe('Network Performance');
     expect(metricsAllNull[5].group).toBe('Operators');
     expect(metricsAllNull[6].group).toBe('Operators');
-    expect(metricsAllNull[7].group).toBe('Network Health');
+    expect(metricsAllNull[7].group).toBe('Operators');
     expect(metricsAllNull[8].group).toBe('Network Health');
     expect(metricsAllNull[9].group).toBe('Network Health');
-    expect(metricsAllNull[10].group).toBe('Block Information');
+    expect(metricsAllNull[10].group).toBe('Network Health');
     expect(metricsAllNull[11].group).toBe('Block Information');
+    expect(metricsAllNull[12].group).toBe('Block Information');
   });
 
   it('handles all successful requests', () => {


### PR DESCRIPTION
## Summary
- support `BatchBlobCountRow` in ClickHouse models and reader
- expose new endpoints in the API server for blob stats
- fetch blob metrics from the dashboard API service
- surface `Blobs per Batch` metric with table view in the dashboard
- update TypeScript tests for the new metric

## Testing
- `just ci`