### PR TITLE
Add Blobs per Batch chart

### DIFF
--- a/dashboard/App.tsx
+++ b/dashboard/App.tsx
@@ -10,6 +10,7 @@ import { BatchProcessChart } from './components/BatchProcessChart';
 import { GasUsedChart } from './components/GasUsedChart';
 import { ReorgDepthChart } from './components/ReorgDepthChart';
 import { BlockTxChart } from './components/BlockTxChart';
+import { BlobsPerBatchChart } from './components/BlobsPerBatchChart';
 import {
   TimeRange,
   TimeSeriesData,
@@ -49,7 +50,6 @@ import {
   fetchSequencerBlocks,
   fetchBlockTransactions,
   fetchBatchBlobCounts,
-  fetchAvgBlobsPerBatch,
   type BlockTransaction,
   type BatchBlobCount,
 } from './services/apiService';
@@ -197,7 +197,6 @@ const App: React.FC = () => {
       sequencerDistRes,
       blockTxRes,
       batchBlobCountsRes,
-      avgBlobsPerBatchRes,
     ] = await Promise.all([
       fetchL2BlockCadence(range),
       fetchBatchPostingCadence(range),
@@ -219,7 +218,6 @@ const App: React.FC = () => {
       fetchSequencerDistribution(range),
       fetchBlockTransactions(range),
       fetchBatchBlobCounts(range),
-      fetchAvgBlobsPerBatch(range),
     ]);
 
     const l2Cadence = l2CadenceRes.data;
@@ -242,7 +240,6 @@ const App: React.FC = () => {
     const sequencerDist = sequencerDistRes.data || [];
     const txPerBlock = blockTxRes.data || [];
     const blobsPerBatch = batchBlobCountsRes.data || [];
-    const avgBlobs = avgBlobsPerBatchRes.data;
 
     const anyBadRequest = hasBadRequest([
       l2CadenceRes,
@@ -265,7 +262,6 @@ const App: React.FC = () => {
       sequencerDistRes,
       blockTxRes,
       batchBlobCountsRes,
-      avgBlobsPerBatchRes,
     ]);
 
     const currentMetrics: MetricData[] = createMetrics({
@@ -281,7 +277,6 @@ const App: React.FC = () => {
       forcedInclusions,
       l2Block,
       l1Block,
-      avgBlobsPerBatch: avgBlobs,
     });
 
     setMetrics(currentMetrics);
@@ -653,10 +648,7 @@ const App: React.FC = () => {
                             : typeof m.title === 'string' &&
                               m.title === 'Active Gateways'
                               ? () => openActiveGatewaysTable()
-                              : typeof m.title === 'string' &&
-                                m.title === 'Blobs per Batch'
-                                ? () => openBlobsPerBatchTable()
-                                : undefined
+                              : undefined
                     }
                   />
                 ))}
@@ -730,6 +722,9 @@ const App: React.FC = () => {
             }
           >
             <BlockTxChart data={blockTxData} barColor="#4E79A7" />
+          </ChartCard>
+          <ChartCard title="Blobs per Batch" onMore={() => openBlobsPerBatchTable()}>
+            <BlobsPerBatchChart data={batchBlobCounts} barColor="#A0CBE8" />
           </ChartCard>
           <ChartCard
             title="L2 Block Times"

--- a/dashboard/components/BlobsPerBatchChart.tsx
+++ b/dashboard/components/BlobsPerBatchChart.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts';
+import type { BatchBlobCount } from '../services/apiService';
+
+interface BlobsPerBatchChartProps {
+  data: BatchBlobCount[];
+  barColor: string;
+}
+
+export const BlobsPerBatchChart: React.FC<BlobsPerBatchChartProps> = ({ data, barColor }) => {
+  if (!data || data.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-full text-gray-500">
+        No data available
+      </div>
+    );
+  }
+
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <BarChart data={data} margin={{ top: 5, right: 30, left: 20, bottom: 50 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
+        <XAxis
+          dataKey="batch"
+          tickFormatter={(v: number) => v.toLocaleString()}
+          stroke="#666666"
+          fontSize={12}
+          label={{
+            value: 'Batch',
+            position: 'insideBottom',
+            offset: -10,
+            fontSize: 10,
+            fill: '#666666',
+          }}
+          padding={{ left: 10, right: 10 }}
+        />
+        <YAxis
+          stroke="#666666"
+          fontSize={12}
+          domain={[0, 'auto']}
+          tickFormatter={(v: number) => v.toLocaleString()}
+          label={{
+            value: 'Blobs',
+            angle: -90,
+            position: 'insideLeft',
+            offset: -16,
+            fontSize: 10,
+            fill: '#666666',
+          }}
+        />
+        <Tooltip
+          labelFormatter={(label: number) => `Batch ${label.toLocaleString()}`}
+          formatter={(value: number) => [value.toLocaleString(), 'blobs']}
+          contentStyle={{ backgroundColor: 'rgba(255, 255, 255, 0.8)', borderColor: barColor }}
+          labelStyle={{ color: '#333' }}
+        />
+        <Legend verticalAlign="bottom" align="right" wrapperStyle={{ right: 20, bottom: 0 }} />
+        <Bar dataKey="blobs" fill={barColor} name="Blobs" />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+};

--- a/dashboard/helpers.ts
+++ b/dashboard/helpers.ts
@@ -8,7 +8,6 @@ export interface MetricInputData {
   batchCadence: number | null;
   avgProve: number | null;
   avgVerify: number | null;
-  avgBlobsPerBatch: number | null;
   activeGateways: number | null;
   currentOperator: string | null;
   nextOperator: string | null;
@@ -57,12 +56,6 @@ export const createMetrics = (data: MetricInputData): MetricData[] => [
       data.avgVerify != null && data.avgVerify > 0
         ? formatSeconds(data.avgVerify / 1000)
         : 'N/A',
-    group: 'Network Performance',
-  },
-  {
-    title: 'Blobs per Batch',
-    value:
-      data.avgBlobsPerBatch != null ? data.avgBlobsPerBatch.toFixed(2) : 'N/A',
     group: 'Network Performance',
   },
   {

--- a/dashboard/tests/app.integration.test.ts
+++ b/dashboard/tests/app.integration.test.ts
@@ -248,7 +248,6 @@ async function fetchData(range: TimeRange, state: State) {
     batchCadence,
     avgProve,
     avgVerify,
-    avgBlobsPerBatch: null,
     activeGateways,
     currentOperator,
     nextOperator,

--- a/dashboard/tests/helpers.test.ts
+++ b/dashboard/tests/helpers.test.ts
@@ -9,7 +9,6 @@ const metrics = createMetrics({
   activeGateways: 2,
   currentOperator: '0xabc',
   nextOperator: null,
-  avgBlobsPerBatch: 1,
   l2Reorgs: 1,
   slashings: null,
   forcedInclusions: 0,
@@ -28,7 +27,6 @@ const metricsAllNull = createMetrics({
   avgProve: null,
   avgVerify: null,
   activeGateways: null,
-  avgBlobsPerBatch: null,
   l2Reorgs: null,
   slashings: null,
   forcedInclusions: null,
@@ -48,24 +46,22 @@ describe('helpers', () => {
     expect(metrics[2].group).toBe('Network Performance');
     expect(metrics[3].value).toBe('N/A');
     expect(metrics[3].group).toBe('Network Performance');
-    expect(metrics[4].value).toBe('1.00');
-    expect(metrics[4].group).toBe('Network Performance');
-    expect(metrics[5].value).toBe('2');
+    expect(metrics[4].value).toBe('2');
+    expect(metrics[4].group).toBe('Operators');
+    expect(metrics[5].value).toBe('0xabc');
     expect(metrics[5].group).toBe('Operators');
-    expect(metrics[6].value).toBe('0xabc');
+    expect(metrics[6].value).toBe('N/A');
     expect(metrics[6].group).toBe('Operators');
-    expect(metrics[7].value).toBe('N/A');
-    expect(metrics[7].group).toBe('Operators');
-    expect(metrics[8].value).toBe('1');
+    expect(metrics[7].value).toBe('1');
+    expect(metrics[7].group).toBe('Network Health');
+    expect(metrics[8].value).toBe('N/A');
     expect(metrics[8].group).toBe('Network Health');
-    expect(metrics[9].value).toBe('N/A');
+    expect(metrics[9].value).toBe('0');
     expect(metrics[9].group).toBe('Network Health');
-    expect(metrics[10].value).toBe('0');
-    expect(metrics[10].group).toBe('Network Health');
-    expect(metrics[11].value).toBe('100');
+    expect(metrics[10].value).toBe('100');
+    expect(metrics[10].group).toBe('Block Information');
+    expect(metrics[11].value).toBe('50');
     expect(metrics[11].group).toBe('Block Information');
-    expect(metrics[12].value).toBe('50');
-    expect(metrics[12].group).toBe('Block Information');
   });
 
   it('detects bad requests', () => {
@@ -81,15 +77,14 @@ describe('helpers', () => {
     expect(metricsAllNull[1].group).toBe('Network Performance');
     expect(metricsAllNull[2].group).toBe('Network Performance');
     expect(metricsAllNull[3].group).toBe('Network Performance');
-    expect(metricsAllNull[4].group).toBe('Network Performance');
+    expect(metricsAllNull[4].group).toBe('Operators');
     expect(metricsAllNull[5].group).toBe('Operators');
     expect(metricsAllNull[6].group).toBe('Operators');
-    expect(metricsAllNull[7].group).toBe('Operators');
+    expect(metricsAllNull[7].group).toBe('Network Health');
     expect(metricsAllNull[8].group).toBe('Network Health');
     expect(metricsAllNull[9].group).toBe('Network Health');
-    expect(metricsAllNull[10].group).toBe('Network Health');
+    expect(metricsAllNull[10].group).toBe('Block Information');
     expect(metricsAllNull[11].group).toBe('Block Information');
-    expect(metricsAllNull[12].group).toBe('Block Information');
   });
 
   it('handles all successful requests', () => {


### PR DESCRIPTION
## Summary
- replace `Blobs per Batch` metric with chart
- show the new chart after Tx Count Per Block
- update helper tests to reflect metric removal
- add tests adjustments

## Testing
- `just ci`