### PR TITLE
Add sequencer filter to API queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1297,6 +1297,7 @@ dependencies = [
  "derive_more 1.0.0",
  "extractor",
  "eyre",
+ "hex",
  "serde",
  "tokio",
  "tracing",

--- a/crates/clickhouse/Cargo.toml
+++ b/crates/clickhouse/Cargo.toml
@@ -18,6 +18,7 @@ eyre.workspace = true
 serde.workspace = true
 tracing.workspace = true
 url.workspace = true
+hex.workspace = true
 
 [dev-dependencies]
 clickhouse.workspace = true


### PR DESCRIPTION
## Summary
- allow filtering by sequencer address
- support optional address in block transaction query
- add address-based queries in Clickhouse reader

## Testing
- `just lint`
- `just test`
- `just ci`