### PR TITLE
Fix chart Y-axis decimals

### DIFF
--- a/dashboard/components/BlobsPerBatchChart.tsx
+++ b/dashboard/components/BlobsPerBatchChart.tsx
@@ -47,6 +47,7 @@ export const BlobsPerBatchChart: React.FC<BlobsPerBatchChartProps> = ({ data, ba
           stroke="#666666"
           fontSize={12}
           domain={[0, 'auto']}
+          allowDecimals={false}
           tickFormatter={(v: number) => v.toLocaleString()}
           label={{
             value: 'Blobs',

--- a/dashboard/components/BlockTxChart.tsx
+++ b/dashboard/components/BlockTxChart.tsx
@@ -52,6 +52,7 @@ export const BlockTxChart: React.FC<BlockTxChartProps> = ({
           stroke="#666666"
           fontSize={12}
           domain={[0, 'auto']}
+          allowDecimals={false}
           tickFormatter={(v: number) => v.toLocaleString()}
           label={{
             value: 'Tx Count',


### PR DESCRIPTION
## Summary
- disable decimals on Tx Count per Block chart
- disable decimals on Blobs per Batch chart

## Testing
- `just ci`