### PR TITLE
Implement named sequencer mapping

### DIFF
--- a/dashboard/App.tsx
+++ b/dashboard/App.tsx
@@ -50,6 +50,7 @@ import {
   ForcedInclusionEvent,
 } from './types';
 import { bytesToHex, loadRefreshRate, saveRefreshRate } from './utils';
+import { getSequencerAddress, getSequencerName } from './sequencerConfig.js';
 import {
   API_BASE,
   fetchAvgProveTime,
@@ -239,7 +240,10 @@ const App: React.FC = () => {
       blockTxRes,
       batchBlobCountsRes,
     ] = await Promise.all([
-      fetchL2BlockCadence(range, selectedSequencer ?? undefined),
+      fetchL2BlockCadence(
+        range,
+        selectedSequencer ? getSequencerAddress(selectedSequencer) : undefined,
+      ),
       fetchBatchPostingCadence(range),
       fetchAvgProveTime(range),
       fetchAvgVerifyTime(range),
@@ -254,15 +258,21 @@ const App: React.FC = () => {
       fetchProveTimes(range),
       fetchVerifyTimes(range),
       fetchL1BlockTimes(range),
-      fetchL2BlockTimes(range, selectedSequencer ?? undefined),
-      fetchL2GasUsed(range, selectedSequencer ?? undefined),
+      fetchL2BlockTimes(
+        range,
+        selectedSequencer ? getSequencerAddress(selectedSequencer) : undefined,
+      ),
+      fetchL2GasUsed(
+        range,
+        selectedSequencer ? getSequencerAddress(selectedSequencer) : undefined,
+      ),
       fetchSequencerDistribution(range),
       fetchBlockTransactions(
         range,
         50,
         undefined,
         undefined,
-        selectedSequencer ?? undefined,
+        selectedSequencer ? getSequencerAddress(selectedSequencer) : undefined,
       ),
       fetchBatchBlobCounts(range),
     ]);
@@ -445,12 +455,14 @@ const App: React.FC = () => {
     setTableLoading(false);
   };
 
-  const openSequencerBlocks = async (address: string) => {
+  const openSequencerBlocks = async (identifier: string) => {
     setTableLoading(true);
+    const address = getSequencerAddress(identifier) ?? identifier;
+    const name = getSequencerName(address);
     const blocksRes = await fetchSequencerBlocks(timeRange, address);
     setTableUrl('sequencer-blocks', { address });
     openTable(
-      `Blocks proposed by ${address}`,
+      `Blocks proposed by ${name}`,
       [{ key: 'block', label: 'Block Number' }],
       (blocksRes.data || []).map((b) => ({ block: b })),
     );
@@ -557,7 +569,7 @@ const App: React.FC = () => {
         50,
         startingAfter,
         endingBefore,
-        selectedSequencer ?? undefined,
+        selectedSequencer ? getSequencerAddress(selectedSequencer) : undefined,
       ),
     ]);
     const txData = txRes.data || [];
@@ -569,7 +581,7 @@ const App: React.FC = () => {
     openTable(
       'Sequencer Distribution',
       [
-        { key: 'name', label: 'Address' },
+        { key: 'name', label: 'Sequencer' },
         { key: 'value', label: 'Blocks' },
       ],
       (distRes.data || []) as unknown as Record<string, string | number>[],
@@ -729,13 +741,13 @@ const App: React.FC = () => {
                         typeof m.title === 'string' && m.title === 'L2 Reorgs'
                           ? () => openL2ReorgsTable()
                           : typeof m.title === 'string' &&
-                              m.title === 'Slashing Events'
+                            m.title === 'Slashing Events'
                             ? () => openSlashingEventsTable()
                             : typeof m.title === 'string' &&
-                                m.title === 'Forced Inclusions'
+                              m.title === 'Forced Inclusions'
                               ? () => openForcedInclusionsTable()
                               : typeof m.title === 'string' &&
-                                  m.title === 'Active Gateways'
+                                m.title === 'Active Gateways'
                                 ? () => openActiveGatewaysTable()
                                 : undefined
                       }

--- a/dashboard/helpers.ts
+++ b/dashboard/helpers.ts
@@ -1,6 +1,7 @@
 import React from 'react';
 import { type MetricData } from './types';
 import { formatSeconds } from './utils.js';
+import { getSequencerName } from './sequencerConfig.js';
 import type { RequestResult } from './services/apiService';
 
 export interface MetricInputData {
@@ -65,12 +66,16 @@ export const createMetrics = (data: MetricInputData): MetricData[] => [
   },
   {
     title: 'Current Operator',
-    value: data.currentOperator ?? 'N/A',
+    value:
+      data.currentOperator != null
+        ? getSequencerName(data.currentOperator)
+        : 'N/A',
     group: 'Operators',
   },
   {
     title: 'Next Operator',
-    value: data.nextOperator ?? 'N/A',
+    value:
+      data.nextOperator != null ? getSequencerName(data.nextOperator) : 'N/A',
     group: 'Operators',
   },
   {

--- a/dashboard/sequencerConfig.ts
+++ b/dashboard/sequencerConfig.ts
@@ -1,6 +1,6 @@
 export const SEQUENCER_PAIRS: Array<[string, string]> = [
-  ['0x00a00800c28f2616360dcfadee02d761d14ad94e', 'chainbound A'],
-  ['0x00b00194cdc219921784ab1eb4eaa9634fe1f1a8', 'chainbound B'],
+  ['0x00a00800c28f2616360dcfadee02d761d14ad94e', 'Chainbound A'],
+  ['0x00b00194cdc219921784ab1eb4eaa9634fe1f1a8', 'Chainbound B'],
 ];
 
 export const SEQUENCER_NAME_BY_ADDRESS: Record<string, string> =

--- a/dashboard/sequencerConfig.ts
+++ b/dashboard/sequencerConfig.ts
@@ -1,0 +1,18 @@
+export const SEQUENCER_PAIRS: Array<[string, string]> = [
+  ['0x00a00800c28f2616360dcfadee02d761d14ad94e', 'chainbound A'],
+  ['0x00b00194cdc219921784ab1eb4eaa9634fe1f1a8', 'chainbound B'],
+];
+
+export const SEQUENCER_NAME_BY_ADDRESS: Record<string, string> =
+  Object.fromEntries(
+    SEQUENCER_PAIRS.map(([addr, name]) => [addr.toLowerCase(), name]),
+  );
+
+export const SEQUENCER_ADDRESS_BY_NAME: Record<string, string> =
+  Object.fromEntries(SEQUENCER_PAIRS.map(([addr, name]) => [name, addr]));
+
+export const getSequencerName = (address: string): string =>
+  SEQUENCER_NAME_BY_ADDRESS[address.toLowerCase()] ?? address;
+
+export const getSequencerAddress = (name: string): string | undefined =>
+  SEQUENCER_ADDRESS_BY_NAME[name];

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -1,6 +1,8 @@
 const metaEnv = import.meta.env;
 export const API_BASE = metaEnv.VITE_API_BASE || metaEnv.API_BASE || '';
 
+import { getSequencerName } from '../sequencerConfig.js';
+
 import type {
   TimeSeriesData,
   PieChartDataItem,
@@ -335,7 +337,10 @@ export const fetchSequencerDistribution = async (
   }>(url);
   return {
     data: res.data
-      ? res.data.sequencers.map((s) => ({ name: s.address, value: s.blocks }))
+      ? res.data.sequencers.map((s) => ({
+          name: getSequencerName(s.address),
+          value: s.blocks,
+        }))
       : null,
     badRequest: res.badRequest,
   };
@@ -378,7 +383,15 @@ export const fetchBlockTransactions = async (
     url += `&address=${address}`;
   }
   const res = await fetchJson<{ blocks: BlockTransaction[] }>(url);
-  return { data: res.data?.blocks ?? null, badRequest: res.badRequest };
+  return {
+    data: res.data?.blocks
+      ? res.data.blocks.map((b) => ({
+          ...b,
+          sequencer: getSequencerName(b.sequencer),
+        }))
+      : null,
+    badRequest: res.badRequest,
+  };
 };
 
 export interface BatchBlobCount {


### PR DESCRIPTION
## Summary
- introduce `sequencerConfig` to map known sequencer addresses to names
- use the mapping when fetching data so UI displays names instead of addresses
- support mapping in metrics and table views

## Testing
- `just ci`