### PR TITLE
Add zoom brush to charts

### DIFF
--- a/dashboard/components/BatchProcessChart.tsx
+++ b/dashboard/components/BatchProcessChart.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   LineChart,
   Line,
@@ -8,6 +8,7 @@ import {
   Tooltip,
   Legend,
   ResponsiveContainer,
+  Brush,
 } from 'recharts';
 import { TimeSeriesData } from '../types';
 import {
@@ -36,6 +37,27 @@ export const BatchProcessChart: React.FC<BatchProcessChartProps> = ({
   const { showHours, showMinutes } = computeBatchDurationFlags(data);
   const formatValue = (value: number) =>
     formatBatchDuration(value, showHours, showMinutes);
+
+  const [brushRange, setBrushRange] = useState({
+    startIndex: Math.max(0, data.length - 50),
+    endIndex: data.length - 1,
+  });
+
+  const handleBrushChange = (range: {
+    startIndex?: number;
+    endIndex?: number;
+  }) => {
+    if (range.startIndex == null || range.endIndex == null) return;
+    const maxRange = 500;
+    if (range.endIndex - range.startIndex > maxRange) {
+      setBrushRange({
+        startIndex: range.endIndex - maxRange,
+        endIndex: range.endIndex,
+      });
+    } else {
+      setBrushRange({ startIndex: range.startIndex, endIndex: range.endIndex });
+    }
+  };
 
   return (
     <ResponsiveContainer width="100%" height="100%">
@@ -99,6 +121,14 @@ export const BatchProcessChart: React.FC<BatchProcessChartProps> = ({
           dot={false}
           activeDot={data.length <= 100 ? { r: 6 } : false}
           name="Time"
+        />
+        <Brush
+          dataKey="name"
+          height={20}
+          stroke={lineColor}
+          startIndex={brushRange.startIndex}
+          endIndex={brushRange.endIndex}
+          onChange={handleBrushChange}
         />
       </LineChart>
     </ResponsiveContainer>

--- a/dashboard/components/BlobsPerBatchChart.tsx
+++ b/dashboard/components/BlobsPerBatchChart.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   BarChart,
   Bar,
@@ -8,6 +8,7 @@ import {
   Tooltip,
   Legend,
   ResponsiveContainer,
+  Brush,
 } from 'recharts';
 import type { BatchBlobCount } from '../services/apiService';
 
@@ -16,7 +17,10 @@ interface BlobsPerBatchChartProps {
   barColor: string;
 }
 
-export const BlobsPerBatchChart: React.FC<BlobsPerBatchChartProps> = ({ data, barColor }) => {
+export const BlobsPerBatchChart: React.FC<BlobsPerBatchChartProps> = ({
+  data,
+  barColor,
+}) => {
   if (!data || data.length === 0) {
     return (
       <div className="flex items-center justify-center h-full text-gray-500">
@@ -25,9 +29,33 @@ export const BlobsPerBatchChart: React.FC<BlobsPerBatchChartProps> = ({ data, ba
     );
   }
 
+  const [brushRange, setBrushRange] = useState({
+    startIndex: Math.max(0, data.length - 50),
+    endIndex: data.length - 1,
+  });
+
+  const handleBrushChange = (range: {
+    startIndex?: number;
+    endIndex?: number;
+  }) => {
+    if (range.startIndex == null || range.endIndex == null) return;
+    const maxRange = 500;
+    if (range.endIndex - range.startIndex > maxRange) {
+      setBrushRange({
+        startIndex: range.endIndex - maxRange,
+        endIndex: range.endIndex,
+      });
+    } else {
+      setBrushRange({ startIndex: range.startIndex, endIndex: range.endIndex });
+    }
+  };
+
   return (
     <ResponsiveContainer width="100%" height="100%">
-      <BarChart data={data} margin={{ top: 5, right: 30, left: 20, bottom: 50 }}>
+      <BarChart
+        data={data}
+        margin={{ top: 5, right: 30, left: 20, bottom: 50 }}
+      >
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis
           dataKey="batch"
@@ -61,11 +89,26 @@ export const BlobsPerBatchChart: React.FC<BlobsPerBatchChartProps> = ({ data, ba
         <Tooltip
           labelFormatter={(label: number) => `Batch ${label.toLocaleString()}`}
           formatter={(value: number) => [value.toLocaleString(), 'blobs']}
-          contentStyle={{ backgroundColor: 'rgba(255, 255, 255, 0.8)', borderColor: barColor }}
+          contentStyle={{
+            backgroundColor: 'rgba(255, 255, 255, 0.8)',
+            borderColor: barColor,
+          }}
           labelStyle={{ color: '#333' }}
         />
-        <Legend verticalAlign="bottom" align="right" wrapperStyle={{ right: 20, bottom: 0 }} />
+        <Legend
+          verticalAlign="bottom"
+          align="right"
+          wrapperStyle={{ right: 20, bottom: 0 }}
+        />
         <Bar dataKey="blobs" fill={barColor} name="Blobs" />
+        <Brush
+          dataKey="batch"
+          height={20}
+          stroke={barColor}
+          startIndex={brushRange.startIndex}
+          endIndex={brushRange.endIndex}
+          onChange={handleBrushChange}
+        />
       </BarChart>
     </ResponsiveContainer>
   );

--- a/dashboard/components/BlockTimeChart.tsx
+++ b/dashboard/components/BlockTimeChart.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   LineChart,
   Line,
@@ -8,6 +8,7 @@ import {
   Tooltip,
   Legend,
   ResponsiveContainer,
+  Brush,
 } from 'recharts';
 import { TimeSeriesData } from '../types';
 import { formatDecimal, formatInterval, shouldShowMinutes } from '../utils';
@@ -29,6 +30,26 @@ export const BlockTimeChart: React.FC<BlockTimeChartProps> = ({
     );
   }
   const showMinutes = shouldShowMinutes(data);
+  const [brushRange, setBrushRange] = useState({
+    startIndex: Math.max(0, data.length - 50),
+    endIndex: data.length - 1,
+  });
+
+  const handleBrushChange = (range: {
+    startIndex?: number;
+    endIndex?: number;
+  }) => {
+    if (range.startIndex == null || range.endIndex == null) return;
+    const maxRange = 500;
+    if (range.endIndex - range.startIndex > maxRange) {
+      setBrushRange({
+        startIndex: range.endIndex - maxRange,
+        endIndex: range.endIndex,
+      });
+    } else {
+      setBrushRange({ startIndex: range.startIndex, endIndex: range.endIndex });
+    }
+  };
   return (
     <ResponsiveContainer width="100%" height="100%">
       <LineChart
@@ -90,6 +111,14 @@ export const BlockTimeChart: React.FC<BlockTimeChartProps> = ({
           dot={false}
           activeDot={data.length <= 100 ? { r: 6 } : false}
           name="Time"
+        />
+        <Brush
+          dataKey="value"
+          height={20}
+          stroke={lineColor}
+          startIndex={brushRange.startIndex}
+          endIndex={brushRange.endIndex}
+          onChange={handleBrushChange}
         />
       </LineChart>
     </ResponsiveContainer>

--- a/dashboard/components/BlockTxChart.tsx
+++ b/dashboard/components/BlockTxChart.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   BarChart,
   Bar,
@@ -8,6 +8,7 @@ import {
   Tooltip,
   Legend,
   ResponsiveContainer,
+  Brush,
 } from 'recharts';
 import type { BlockTransaction } from '../services/apiService';
 
@@ -27,6 +28,26 @@ export const BlockTxChart: React.FC<BlockTxChartProps> = ({
       </div>
     );
   }
+  const [brushRange, setBrushRange] = useState({
+    startIndex: Math.max(0, data.length - 50),
+    endIndex: data.length - 1,
+  });
+
+  const handleBrushChange = (range: {
+    startIndex?: number;
+    endIndex?: number;
+  }) => {
+    if (range.startIndex == null || range.endIndex == null) return;
+    const maxRange = 500;
+    if (range.endIndex - range.startIndex > maxRange) {
+      setBrushRange({
+        startIndex: range.endIndex - maxRange,
+        endIndex: range.endIndex,
+      });
+    } else {
+      setBrushRange({ startIndex: range.startIndex, endIndex: range.endIndex });
+    }
+  };
   return (
     <ResponsiveContainer width="100%" height="100%">
       <BarChart
@@ -78,6 +99,14 @@ export const BlockTxChart: React.FC<BlockTxChartProps> = ({
           wrapperStyle={{ right: 20, bottom: 0 }}
         />
         <Bar dataKey="txs" fill={barColor} name="Txs" />
+        <Brush
+          dataKey="block"
+          height={20}
+          stroke={barColor}
+          startIndex={brushRange.startIndex}
+          endIndex={brushRange.endIndex}
+          onChange={handleBrushChange}
+        />
       </BarChart>
     </ResponsiveContainer>
   );

--- a/dashboard/components/GasUsedChart.tsx
+++ b/dashboard/components/GasUsedChart.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   LineChart,
   Line,
@@ -8,6 +8,7 @@ import {
   Tooltip,
   Legend,
   ResponsiveContainer,
+  Brush,
 } from 'recharts';
 import { TimeSeriesData } from '../types';
 import { formatLargeNumber } from '../utils';
@@ -17,7 +18,10 @@ interface GasUsedChartProps {
   lineColor: string;
 }
 
-export const GasUsedChart: React.FC<GasUsedChartProps> = ({ data, lineColor }) => {
+export const GasUsedChart: React.FC<GasUsedChartProps> = ({
+  data,
+  lineColor,
+}) => {
   if (!data || data.length === 0) {
     return (
       <div className="flex items-center justify-center h-full text-gray-500">
@@ -25,9 +29,32 @@ export const GasUsedChart: React.FC<GasUsedChartProps> = ({ data, lineColor }) =
       </div>
     );
   }
+  const [brushRange, setBrushRange] = useState({
+    startIndex: Math.max(0, data.length - 50),
+    endIndex: data.length - 1,
+  });
+
+  const handleBrushChange = (range: {
+    startIndex?: number;
+    endIndex?: number;
+  }) => {
+    if (range.startIndex == null || range.endIndex == null) return;
+    const maxRange = 500;
+    if (range.endIndex - range.startIndex > maxRange) {
+      setBrushRange({
+        startIndex: range.endIndex - maxRange,
+        endIndex: range.endIndex,
+      });
+    } else {
+      setBrushRange({ startIndex: range.startIndex, endIndex: range.endIndex });
+    }
+  };
   return (
     <ResponsiveContainer width="100%" height="100%">
-      <LineChart data={data} margin={{ top: 5, right: 30, left: 20, bottom: 50 }}>
+      <LineChart
+        data={data}
+        margin={{ top: 5, right: 30, left: 20, bottom: 50 }}
+      >
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis
           dataKey="value"
@@ -60,10 +87,17 @@ export const GasUsedChart: React.FC<GasUsedChartProps> = ({ data, lineColor }) =
         <Tooltip
           labelFormatter={(label: number) => `Block ${label.toLocaleString()}`}
           formatter={(value: number) => [formatLargeNumber(value), 'gas']}
-          contentStyle={{ backgroundColor: 'rgba(255, 255, 255, 0.8)', borderColor: lineColor }}
+          contentStyle={{
+            backgroundColor: 'rgba(255, 255, 255, 0.8)',
+            borderColor: lineColor,
+          }}
           labelStyle={{ color: '#333' }}
         />
-        <Legend verticalAlign="bottom" align="right" wrapperStyle={{ right: 20, bottom: 0 }} />
+        <Legend
+          verticalAlign="bottom"
+          align="right"
+          wrapperStyle={{ right: 20, bottom: 0 }}
+        />
         <Line
           type="monotone"
           dataKey="timestamp"
@@ -72,6 +106,14 @@ export const GasUsedChart: React.FC<GasUsedChartProps> = ({ data, lineColor }) =
           dot={false}
           activeDot={data.length <= 100 ? { r: 6 } : false}
           name="Gas Used"
+        />
+        <Brush
+          dataKey="value"
+          height={20}
+          stroke={lineColor}
+          startIndex={brushRange.startIndex}
+          endIndex={brushRange.endIndex}
+          onChange={handleBrushChange}
         />
       </LineChart>
     </ResponsiveContainer>

--- a/dashboard/components/ReorgDepthChart.tsx
+++ b/dashboard/components/ReorgDepthChart.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   BarChart,
   Bar,
@@ -8,6 +8,7 @@ import {
   Tooltip,
   Legend,
   ResponsiveContainer,
+  Brush,
 } from 'recharts';
 import { L2ReorgEvent } from '../types';
 
@@ -25,6 +26,27 @@ export const ReorgDepthChart: React.FC<ReorgDepthChartProps> = ({ data }) => {
       </div>
     );
   }
+
+  const [brushRange, setBrushRange] = useState({
+    startIndex: Math.max(0, data.length - 50),
+    endIndex: data.length - 1,
+  });
+
+  const handleBrushChange = (range: {
+    startIndex?: number;
+    endIndex?: number;
+  }) => {
+    if (range.startIndex == null || range.endIndex == null) return;
+    const maxRange = 500;
+    if (range.endIndex - range.startIndex > maxRange) {
+      setBrushRange({
+        startIndex: range.endIndex - maxRange,
+        endIndex: range.endIndex,
+      });
+    } else {
+      setBrushRange({ startIndex: range.startIndex, endIndex: range.endIndex });
+    }
+  };
 
   return (
     <ResponsiveContainer width="100%" height="100%">
@@ -75,6 +97,14 @@ export const ReorgDepthChart: React.FC<ReorgDepthChartProps> = ({ data }) => {
           wrapperStyle={{ right: 20, bottom: 0 }}
         />
         <Bar dataKey="depth" fill={TAIKO_PINK} name="Depth" />
+        <Brush
+          dataKey="l2_block_number"
+          height={20}
+          stroke={TAIKO_PINK}
+          startIndex={brushRange.startIndex}
+          endIndex={brushRange.endIndex}
+          onChange={handleBrushChange}
+        />
       </BarChart>
     </ResponsiveContainer>
   );


### PR DESCRIPTION
## Summary
- add Brush-based zoom controls to dashboard charts
- keep range under 500 points when dragging

## Testing
- `npm run check`
- `npm run test`
- `just ci`
