### PR TITLE
Implement chart loading overlay

### DIFF
--- a/dashboard/App.tsx
+++ b/dashboard/App.tsx
@@ -741,13 +741,13 @@ const App: React.FC = () => {
                         typeof m.title === 'string' && m.title === 'L2 Reorgs'
                           ? () => openL2ReorgsTable()
                           : typeof m.title === 'string' &&
-                            m.title === 'Slashing Events'
+                              m.title === 'Slashing Events'
                             ? () => openSlashingEventsTable()
                             : typeof m.title === 'string' &&
-                              m.title === 'Forced Inclusions'
+                                m.title === 'Forced Inclusions'
                               ? () => openForcedInclusionsTable()
                               : typeof m.title === 'string' &&
-                                m.title === 'Active Gateways'
+                                  m.title === 'Active Gateways'
                                 ? () => openActiveGatewaysTable()
                                 : undefined
                       }
@@ -763,6 +763,7 @@ const App: React.FC = () => {
           <ChartCard
             title="Sequencer Distribution"
             onMore={() => openSequencerDistributionTable(timeRange, 0)}
+            loading={loadingMetrics}
           >
             <SequencerPieChart
               data={sequencerDistribution.filter(
@@ -785,6 +786,7 @@ const App: React.FC = () => {
                 >[],
               )
             }
+            loading={loadingMetrics}
           >
             <BatchProcessChart
               data={secondsToProveData}
@@ -806,10 +808,11 @@ const App: React.FC = () => {
                 >[],
               )
             }
+            loading={loadingMetrics}
           >
             <BatchProcessChart data={secondsToVerifyData} lineColor="#5DA5DA" />
           </ChartCard>
-          <ChartCard title="Gas Used Per Block">
+          <ChartCard title="Gas Used Per Block" loading={loadingMetrics}>
             <GasUsedChart data={l2GasUsedData} lineColor="#E573B5" />
           </ChartCard>
           <ChartCard
@@ -825,12 +828,14 @@ const App: React.FC = () => {
                 blockTxData as unknown as Record<string, string | number>[],
               )
             }
+            loading={loadingMetrics}
           >
             <BlockTxChart data={blockTxData} barColor="#4E79A7" />
           </ChartCard>
           <ChartCard
             title="Blobs per Batch"
             onMore={() => openBlobsPerBatchTable()}
+            loading={loadingMetrics}
           >
             <BlobsPerBatchChart data={batchBlobCounts} barColor="#A0CBE8" />
           </ChartCard>
@@ -846,6 +851,7 @@ const App: React.FC = () => {
                 l2BlockTimeData as unknown as Record<string, string | number>[],
               )
             }
+            loading={loadingMetrics}
           >
             <BlockTimeChart data={l2BlockTimeData} lineColor="#FAA43A" />
           </ChartCard>
@@ -861,6 +867,7 @@ const App: React.FC = () => {
                 l1BlockTimeData as unknown as Record<string, string | number>[],
               )
             }
+            loading={loadingMetrics}
           >
             <BlockTimeChart data={l1BlockTimeData} lineColor="#60BD68" />
           </ChartCard>

--- a/dashboard/components/ChartCard.tsx
+++ b/dashboard/components/ChartCard.tsx
@@ -4,12 +4,14 @@ interface ChartCardProps {
   title: string;
   children: React.ReactNode;
   onMore?: () => void;
+  loading?: boolean;
 }
 
 export const ChartCard: React.FC<ChartCardProps> = ({
   title,
   children,
   onMore,
+  loading,
 }) => {
   return (
     <div className="bg-white p-4 md:p-6 rounded-lg border border-gray-200 relative">
@@ -25,7 +27,7 @@ export const ChartCard: React.FC<ChartCardProps> = ({
           </button>
         )}
       </div>
-      <div className="h-64 md:h-80 w-full">
+      <div className="h-64 md:h-80 w-full relative">
         <Suspense
           fallback={
             <div className="flex items-center justify-center h-full text-gray-500">
@@ -35,6 +37,11 @@ export const ChartCard: React.FC<ChartCardProps> = ({
         >
           {children}
         </Suspense>
+        {loading && (
+          <div className="absolute inset-0 flex items-center justify-center bg-white/60">
+            <span className="text-gray-500">Loading...</span>
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add a `loading` overlay to `ChartCard`
- show metric skeletons and overlay charts during dashboard fetch

## Testing
- `just ci`