### PR TITLE
Reset dashboard brushes on sequencer filter

### DIFF
--- a/dashboard/components/BatchProcessChart.tsx
+++ b/dashboard/components/BatchProcessChart.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   LineChart,
   Line,
@@ -42,6 +42,13 @@ export const BatchProcessChart: React.FC<BatchProcessChartProps> = ({
     startIndex: Math.max(0, data.length - 50),
     endIndex: data.length - 1,
   });
+
+  useEffect(() => {
+    setBrushRange({
+      startIndex: Math.max(0, data.length - 50),
+      endIndex: data.length - 1,
+    });
+  }, [data]);
 
   const handleBrushChange = (range: {
     startIndex?: number;

--- a/dashboard/components/BlobsPerBatchChart.tsx
+++ b/dashboard/components/BlobsPerBatchChart.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   BarChart,
   Bar,
@@ -33,6 +33,13 @@ export const BlobsPerBatchChart: React.FC<BlobsPerBatchChartProps> = ({
     startIndex: Math.max(0, data.length - 50),
     endIndex: data.length - 1,
   });
+
+  useEffect(() => {
+    setBrushRange({
+      startIndex: Math.max(0, data.length - 50),
+      endIndex: data.length - 1,
+    });
+  }, [data]);
 
   const handleBrushChange = (range: {
     startIndex?: number;

--- a/dashboard/components/BlockTimeChart.tsx
+++ b/dashboard/components/BlockTimeChart.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   LineChart,
   Line,
@@ -34,6 +34,13 @@ export const BlockTimeChart: React.FC<BlockTimeChartProps> = ({
     startIndex: Math.max(0, data.length - 50),
     endIndex: data.length - 1,
   });
+
+  useEffect(() => {
+    setBrushRange({
+      startIndex: Math.max(0, data.length - 50),
+      endIndex: data.length - 1,
+    });
+  }, [data]);
 
   const handleBrushChange = (range: {
     startIndex?: number;

--- a/dashboard/components/BlockTxChart.tsx
+++ b/dashboard/components/BlockTxChart.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   BarChart,
   Bar,
@@ -32,6 +32,13 @@ export const BlockTxChart: React.FC<BlockTxChartProps> = ({
     startIndex: Math.max(0, data.length - 50),
     endIndex: data.length - 1,
   });
+
+  useEffect(() => {
+    setBrushRange({
+      startIndex: Math.max(0, data.length - 50),
+      endIndex: data.length - 1,
+    });
+  }, [data]);
 
   const handleBrushChange = (range: {
     startIndex?: number;

--- a/dashboard/components/ChartCard.tsx
+++ b/dashboard/components/ChartCard.tsx
@@ -1,11 +1,10 @@
 import React, { Suspense } from 'react';
 
-interface ChartCardProps {
+type ChartCardProps = React.PropsWithChildren<{
   title: string;
-  children: React.ReactNode;
   onMore?: () => void;
   loading?: boolean;
-}
+}>;
 
 export const ChartCard: React.FC<ChartCardProps> = ({
   title,

--- a/dashboard/components/GasUsedChart.tsx
+++ b/dashboard/components/GasUsedChart.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   LineChart,
   Line,
@@ -33,6 +33,13 @@ export const GasUsedChart: React.FC<GasUsedChartProps> = ({
     startIndex: Math.max(0, data.length - 50),
     endIndex: data.length - 1,
   });
+
+  useEffect(() => {
+    setBrushRange({
+      startIndex: Math.max(0, data.length - 50),
+      endIndex: data.length - 1,
+    });
+  }, [data]);
 
   const handleBrushChange = (range: {
     startIndex?: number;

--- a/dashboard/components/ReorgDepthChart.tsx
+++ b/dashboard/components/ReorgDepthChart.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   BarChart,
   Bar,
@@ -31,6 +31,13 @@ export const ReorgDepthChart: React.FC<ReorgDepthChartProps> = ({ data }) => {
     startIndex: Math.max(0, data.length - 50),
     endIndex: data.length - 1,
   });
+
+  useEffect(() => {
+    setBrushRange({
+      startIndex: Math.max(0, data.length - 50),
+      endIndex: data.length - 1,
+    });
+  }, [data]);
 
   const handleBrushChange = (range: {
     startIndex?: number;

--- a/dashboard/tests/utils.test.ts
+++ b/dashboard/tests/utils.test.ts
@@ -88,7 +88,6 @@ describe('utils', () => {
 
   it('saves and loads refresh rate', () => {
     const store: Record<string, string> = {};
-    // @ts-expect-error
     globalThis.localStorage = {
       getItem: (k: string) => (k in store ? store[k] : null),
       setItem: (k: string, v: string) => {


### PR DESCRIPTION
## Summary
- reset chart brush state when data updates
- update ChartCard props typing
- fix utils test types

## Testing
- `just ci`
