### PR TITLE
Add dashboard status link

### DIFF
--- a/dashboard/components/DashboardHeader.tsx
+++ b/dashboard/components/DashboardHeader.tsx
@@ -27,11 +27,21 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({
 }) => {
   return (
     <header className="flex flex-col md:flex-row justify-between items-center pb-4 border-b border-gray-200">
-      <h1 className="text-3xl font-bold" style={{ color: '#e81899' }}>
-        {' '}
-        {/* Updated Taiko Pink */}
-        Taiko Masaya Testnet
-      </h1>
+      <div className="flex items-baseline space-x-4">
+        <h1 className="text-3xl font-bold" style={{ color: '#e81899' }}>
+          {' '}
+          {/* Updated Taiko Pink */}
+          Taiko Masaya Testnet
+        </h1>
+        <a
+          href="https://taikoscope.instatus.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-sm text-[#e81899] hover:underline"
+        >
+          Status
+        </a>
+      </div>
       <div className="flex items-center space-x-2 mt-4 md:mt-0">
         <TimeRangeSelector
           currentTimeRange={timeRange}

--- a/dashboard/tests/chartCard.test.ts
+++ b/dashboard/tests/chartCard.test.ts
@@ -6,9 +6,13 @@ import { ChartCard } from '../components/ChartCard.js';
 describe('ChartCard', () => {
   it('renders title and children', () => {
     const html = renderToStaticMarkup(
-      React.createElement(ChartCard, {
-        title: 'My Chart',
-      }, React.createElement('span', null, 'child')),
+      React.createElement(
+        ChartCard,
+        {
+          title: 'My Chart',
+        } as any,
+        React.createElement('span', null, 'child'),
+      ),
     );
     expect(html.includes('My Chart')).toBe(true);
     expect(html.includes('child')).toBe(true);
@@ -17,10 +21,14 @@ describe('ChartCard', () => {
 
   it('shows more button when handler provided', () => {
     const html = renderToStaticMarkup(
-      React.createElement(ChartCard, {
-        title: 'Other Chart',
-        onMore: () => {},
-      }, React.createElement('div', null, 'data')),
+      React.createElement(
+        ChartCard,
+        {
+          title: 'Other Chart',
+          onMore: () => {},
+        } as any,
+        React.createElement('div', null, 'data'),
+      ),
     );
     expect(html.includes('data')).toBe(true);
     expect(html.includes('aria-label="View table"')).toBe(true);

--- a/dashboard/tests/dashboardHeader.test.ts
+++ b/dashboard/tests/dashboardHeader.test.ts
@@ -23,5 +23,6 @@ describe('DashboardHeader', () => {
     expect(html.includes('24H')).toBe(true);
     expect(html.includes('7D')).toBe(true);
     expect(html.includes('Refresh')).toBe(true);
+    expect(html.includes('Status')).toBe(true);
   });
 });

--- a/dashboard/tests/utils.test.ts
+++ b/dashboard/tests/utils.test.ts
@@ -93,8 +93,8 @@ describe('utils', () => {
       setItem: (k: string, v: string) => {
         store[k] = v;
       },
-      removeItem: () => {},
-      clear: () => {},
+      removeItem: () => { },
+      clear: () => { },
       key: () => null,
       length: 0,
     } as Storage;


### PR DESCRIPTION
## Summary
- link to the public status page from DashboardHeader
- adjust dashboard tests to match new link
- fix TypeScript checks for dashboard tests

## Testing
- `just ci`