### PR TITLE
Fix x-axis label hidden by brush

### DIFF
--- a/dashboard/components/BatchProcessChart.tsx
+++ b/dashboard/components/BatchProcessChart.tsx
@@ -63,7 +63,7 @@ export const BatchProcessChart: React.FC<BatchProcessChartProps> = ({
     <ResponsiveContainer width="100%" height="100%">
       <LineChart
         data={data}
-        margin={{ top: 5, right: 30, left: 20, bottom: 20 }}
+        margin={{ top: 5, right: 30, left: 20, bottom: 50 }}
       >
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis
@@ -72,8 +72,8 @@ export const BatchProcessChart: React.FC<BatchProcessChartProps> = ({
           fontSize={12}
           label={{
             value: 'Batch ID',
-            position: 'insideBottom',
-            offset: -10,
+            position: 'bottom',
+            offset: 0,
             fontSize: 10,
             fill: '#666666',
           }}

--- a/dashboard/components/BlobsPerBatchChart.tsx
+++ b/dashboard/components/BlobsPerBatchChart.tsx
@@ -64,8 +64,8 @@ export const BlobsPerBatchChart: React.FC<BlobsPerBatchChartProps> = ({
           fontSize={12}
           label={{
             value: 'Batch',
-            position: 'insideBottom',
-            offset: -10,
+            position: 'bottom',
+            offset: 0,
             fontSize: 10,
             fill: '#666666',
           }}

--- a/dashboard/components/BlockTimeChart.tsx
+++ b/dashboard/components/BlockTimeChart.tsx
@@ -64,8 +64,8 @@ export const BlockTimeChart: React.FC<BlockTimeChartProps> = ({
           fontSize={12}
           label={{
             value: 'Block Number',
-            position: 'insideBottom',
-            offset: -10,
+            position: 'bottom',
+            offset: 0,
             fontSize: 10,
             fill: '#666666',
           }}

--- a/dashboard/components/BlockTxChart.tsx
+++ b/dashboard/components/BlockTxChart.tsx
@@ -62,8 +62,8 @@ export const BlockTxChart: React.FC<BlockTxChartProps> = ({
           fontSize={12}
           label={{
             value: 'Block Number',
-            position: 'insideBottom',
-            offset: -10,
+            position: 'bottom',
+            offset: 0,
             fontSize: 10,
             fill: '#666666',
           }}

--- a/dashboard/components/GasUsedChart.tsx
+++ b/dashboard/components/GasUsedChart.tsx
@@ -63,8 +63,8 @@ export const GasUsedChart: React.FC<GasUsedChartProps> = ({
           fontSize={12}
           label={{
             value: 'Block Number',
-            position: 'insideBottom',
-            offset: -10,
+            position: 'bottom',
+            offset: 0,
             fontSize: 10,
             fill: '#666666',
           }}

--- a/dashboard/components/ReorgDepthChart.tsx
+++ b/dashboard/components/ReorgDepthChart.tsx
@@ -62,8 +62,8 @@ export const ReorgDepthChart: React.FC<ReorgDepthChartProps> = ({ data }) => {
           fontSize={12}
           label={{
             value: 'Block Number',
-            position: 'insideBottom',
-            offset: -10,
+            position: 'bottom',
+            offset: 0,
             fontSize: 10,
             fill: '#666666',
           }}


### PR DESCRIPTION
## Summary
- adjust chart margins and x-axis label placement so labels show when using Brush

## Testing
- `just ci` *(fails: npm run check errors)*