### PR TITLE
Fix block time units

### DIFF
--- a/dashboard/components/BlockTimeChart.tsx
+++ b/dashboard/components/BlockTimeChart.tsx
@@ -10,7 +10,7 @@ import {
   Brush,
 } from 'recharts';
 import { TimeSeriesData } from '../types';
-import { formatDecimal, formatInterval, shouldShowMinutes } from '../utils';
+import { formatDecimal, formatInterval } from '../utils';
 
 interface BlockTimeChartProps {
   data: TimeSeriesData[];
@@ -28,7 +28,6 @@ export const BlockTimeChart: React.FC<BlockTimeChartProps> = ({
       </div>
     );
   }
-  const showMinutes = shouldShowMinutes(data);
   const [brushRange, setBrushRange] = useState({
     startIndex: Math.max(0, data.length - 50),
     endIndex: data.length - 1,
@@ -81,13 +80,9 @@ export const BlockTimeChart: React.FC<BlockTimeChartProps> = ({
           stroke="#666666"
           fontSize={12}
           domain={['auto', 'auto']}
-          tickFormatter={(v) =>
-            showMinutes
-              ? String(Number(formatDecimal(v / 60000)))
-              : String(Number(formatDecimal(v / 1000)))
-          }
+          tickFormatter={(v) => String(Number(formatDecimal(v / 1000)))}
           label={{
-            value: showMinutes ? 'Minutes' : 'Seconds',
+            value: 'Seconds',
             angle: -90,
             position: 'insideLeft',
             offset: -16,
@@ -97,7 +92,7 @@ export const BlockTimeChart: React.FC<BlockTimeChartProps> = ({
         />
         <Tooltip
           labelFormatter={(label: number) => `Block ${label.toLocaleString()}`}
-          formatter={(value: number) => [formatInterval(value, showMinutes)]}
+          formatter={(value: number) => [formatInterval(value, false)]}
           contentStyle={{
             backgroundColor: 'rgba(255, 255, 255, 0.8)',
             borderColor: lineColor,

--- a/dashboard/config/tableConfig.ts
+++ b/dashboard/config/tableConfig.ts
@@ -1,4 +1,4 @@
-import { TimeRange, L2ReorgEvent, SlashingEvent, ForcedInclusionEvent } from '../types';
+import { TimeRange, L2ReorgEvent, SlashingEvent, ForcedInclusionEvent, TimeSeriesData } from '../types';
 import { 
   fetchSequencerBlocks,
   fetchL2ReorgEvents, 
@@ -14,7 +14,7 @@ import {
   fetchSequencerDistribution
 } from '../services/apiService';
 import { getSequencerName } from '../sequencerConfig';
-import { bytesToHex } from '../utils';
+import { bytesToHex, formatDecimal } from '../utils';
 import React from 'react';
 
 export interface TableColumn {
@@ -160,9 +160,13 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
     fetcher: fetchL2BlockTimes,
     columns: [
       { key: 'value', label: 'Block Number' },
-      { key: 'timestamp', label: 'Interval (ms)' }
+      { key: 'timestamp', label: 'Interval (s)' }
     ],
-    mapData: (data) => data as Record<string, string | number>[],
+    mapData: (data) =>
+      (data as TimeSeriesData[]).map((d) => ({
+        value: d.value,
+        timestamp: Number(formatDecimal(d.timestamp / 1000))
+      })) as Record<string, string | number>[],
     chart: (data) => {
       const BlockTimeChart = React.lazy(() =>
         import('../components/BlockTimeChart').then(m => ({ default: m.BlockTimeChart }))
@@ -177,9 +181,13 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
     fetcher: fetchL1BlockTimes,
     columns: [
       { key: 'value', label: 'Block Number' },
-      { key: 'timestamp', label: 'Interval (ms)' }
+      { key: 'timestamp', label: 'Interval (s)' }
     ],
-    mapData: (data) => data as Record<string, string | number>[],
+    mapData: (data) =>
+      (data as TimeSeriesData[]).map((d) => ({
+        value: d.value,
+        timestamp: Number(formatDecimal(d.timestamp / 1000))
+      })) as Record<string, string | number>[],
     chart: (data) => {
       const BlockTimeChart = React.lazy(() =>
         import('../components/BlockTimeChart').then(m => ({ default: m.BlockTimeChart }))


### PR DESCRIPTION
## Summary
- always display block times in seconds on the dashboard
- adjust tables to show seconds for L1/L2 block times
- fix tests for ChartCard and utils

## Testing
- `just ci`