### PR TITLE
Rename operators to sequencers in dashboard

### DIFF
--- a/dashboard/App.tsx
+++ b/dashboard/App.tsx
@@ -383,13 +383,13 @@ const App: React.FC = () => {
   const groupOrder = [
     'Network Performance',
     'Network Health',
-    'Operators',
+    'Sequencers',
     'Other',
   ];
   const skeletonGroupCounts: Record<string, number> = {
     'Network Performance': 5,
     'Network Health': 3,
-    Operators: 3,
+    Sequencers: 3,
   };
 
 
@@ -529,7 +529,7 @@ const App: React.FC = () => {
                                 m.title === 'Forced Inclusions'
                                 ? () => openGenericTable('forced-inclusions')
                                 : typeof m.title === 'string' &&
-                                  m.title === 'Active Gateways'
+                                m.title === 'Active Sequencers'
                                   ? () => openGenericTable('gateways')
                                   : undefined
                       }

--- a/dashboard/config/tableConfig.ts
+++ b/dashboard/config/tableConfig.ts
@@ -85,7 +85,7 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
   },
 
   'gateways': {
-    title: 'Active Gateways',
+    title: 'Active Sequencers',
     fetcher: fetchActiveGatewayAddresses,
     columns: [{ key: 'address', label: 'Address' }],
     mapData: (data) => data.map((g) => ({ address: g })),

--- a/dashboard/helpers.ts
+++ b/dashboard/helpers.ts
@@ -66,23 +66,23 @@ export const createMetrics = (data: MetricInputData): MetricData[] => [
     group: 'Network Performance',
   },
   {
-    title: 'Active Gateways',
+    title: 'Active Sequencers',
     value: data.activeGateways != null ? data.activeGateways.toString() : 'N/A',
-    group: 'Operators',
+    group: 'Sequencers',
   },
   {
-    title: 'Current Operator',
+    title: 'Current Sequencer',
     value:
       data.currentOperator != null
         ? getSequencerName(data.currentOperator)
         : 'N/A',
-    group: 'Operators',
+    group: 'Sequencers',
   },
   {
-    title: 'Next Operator',
+    title: 'Next Sequencer',
     value:
       data.nextOperator != null ? getSequencerName(data.nextOperator) : 'N/A',
-    group: 'Operators',
+    group: 'Sequencers',
   },
   {
     title: 'L2 Reorgs',

--- a/dashboard/tests/app.integration.test.ts
+++ b/dashboard/tests/app.integration.test.ts
@@ -385,11 +385,11 @@ it('app integration', async () => {
   const groupOrder = [
     'Network Performance',
     'Network Health',
-    'Operators',
+    'Sequencers',
     'Other',
   ];
   const visible = groupOrder.filter((g) => grouped[g] && grouped[g].length > 0);
-  const expected = ['Network Performance', 'Network Health', 'Operators'];
+  const expected = ['Network Performance', 'Network Health', 'Sequencers'];
   expect(visible).toStrictEqual(expected);
 
   console.log('App integration tests passed.');

--- a/dashboard/tests/chartCard.test.ts
+++ b/dashboard/tests/chartCard.test.ts
@@ -6,13 +6,10 @@ import { ChartCard } from '../components/ChartCard.js';
 describe('ChartCard', () => {
   it('renders title and children', () => {
     const html = renderToStaticMarkup(
-      React.createElement(
-        ChartCard,
-        {
-          title: 'My Chart',
-        } as any,
-        React.createElement('span', null, 'child'),
-      ),
+      React.createElement(ChartCard, {
+        title: 'My Chart',
+        children: React.createElement('span', null, 'child'),
+      }),
     );
     expect(html.includes('My Chart')).toBe(true);
     expect(html.includes('child')).toBe(true);
@@ -21,14 +18,11 @@ describe('ChartCard', () => {
 
   it('shows more button when handler provided', () => {
     const html = renderToStaticMarkup(
-      React.createElement(
-        ChartCard,
-        {
-          title: 'Other Chart',
-          onMore: () => {},
-        } as any,
-        React.createElement('div', null, 'data'),
-      ),
+      React.createElement(ChartCard, {
+        title: 'Other Chart',
+        onMore: () => { },
+        children: React.createElement('div', null, 'data'),
+      }),
     );
     expect(html.includes('data')).toBe(true);
     expect(html.includes('aria-label="View table"')).toBe(true);

--- a/dashboard/tests/helpers.test.ts
+++ b/dashboard/tests/helpers.test.ts
@@ -51,11 +51,11 @@ describe('helpers', () => {
     expect(metrics[4].value).toBe('N/A');
     expect(metrics[4].group).toBe('Network Performance');
     expect(metrics[5].value).toBe('2');
-    expect(metrics[5].group).toBe('Operators');
+    expect(metrics[5].group).toBe('Sequencers');
     expect(metrics[6].value).toBe('0xabc');
-    expect(metrics[6].group).toBe('Operators');
+    expect(metrics[6].group).toBe('Sequencers');
     expect(metrics[7].value).toBe('N/A');
-    expect(metrics[7].group).toBe('Operators');
+    expect(metrics[7].group).toBe('Sequencers');
     expect(metrics[8].value).toBe('1');
     expect(metrics[8].group).toBe('Network Health');
     expect(metrics[9].value).toBe('N/A');
@@ -82,9 +82,9 @@ describe('helpers', () => {
     expect(metricsAllNull[2].group).toBe('Network Performance');
     expect(metricsAllNull[3].group).toBe('Network Performance');
     expect(metricsAllNull[4].group).toBe('Network Performance');
-    expect(metricsAllNull[5].group).toBe('Operators');
-    expect(metricsAllNull[6].group).toBe('Operators');
-    expect(metricsAllNull[7].group).toBe('Operators');
+    expect(metricsAllNull[5].group).toBe('Sequencers');
+    expect(metricsAllNull[6].group).toBe('Sequencers');
+    expect(metricsAllNull[7].group).toBe('Sequencers');
     expect(metricsAllNull[8].group).toBe('Network Health');
     expect(metricsAllNull[9].group).toBe('Network Health');
     expect(metricsAllNull[10].group).toBe('Network Health');


### PR DESCRIPTION
## Summary
- rename dashboard metric labels to use "Sequencer"
- adjust table titles and group headers
- update tests for new wording
- fix type check failures in dashboard tests

## Testing
- `just lint`
- `just test`
- `npm run check`
- `npm run test`
- `just ci`
