### PR TITLE
Remove chart legends from dashboard

### DIFF
--- a/dashboard/components/BatchProcessChart.tsx
+++ b/dashboard/components/BatchProcessChart.tsx
@@ -6,7 +6,6 @@ import {
   YAxis,
   CartesianGrid,
   Tooltip,
-  Legend,
   ResponsiveContainer,
   Brush,
 } from 'recharts';
@@ -114,11 +113,6 @@ export const BatchProcessChart: React.FC<BatchProcessChartProps> = ({
             borderRadius: '4px',
           }}
           labelStyle={{ color: '#333', fontWeight: 'bold' }}
-        />
-        <Legend
-          verticalAlign="bottom"
-          align="right"
-          wrapperStyle={{ right: 20, bottom: 0 }}
         />
         <Line
           type="monotone"

--- a/dashboard/components/BlobsPerBatchChart.tsx
+++ b/dashboard/components/BlobsPerBatchChart.tsx
@@ -6,7 +6,6 @@ import {
   YAxis,
   CartesianGrid,
   Tooltip,
-  Legend,
   ResponsiveContainer,
   Brush,
 } from 'recharts';
@@ -101,11 +100,6 @@ export const BlobsPerBatchChart: React.FC<BlobsPerBatchChartProps> = ({
             borderColor: barColor,
           }}
           labelStyle={{ color: '#333' }}
-        />
-        <Legend
-          verticalAlign="bottom"
-          align="right"
-          wrapperStyle={{ right: 20, bottom: 0 }}
         />
         <Bar dataKey="blobs" fill={barColor} name="Blobs" />
         <Brush

--- a/dashboard/components/BlockTimeChart.tsx
+++ b/dashboard/components/BlockTimeChart.tsx
@@ -6,7 +6,6 @@ import {
   YAxis,
   CartesianGrid,
   Tooltip,
-  Legend,
   ResponsiveContainer,
   Brush,
 } from 'recharts';
@@ -104,11 +103,6 @@ export const BlockTimeChart: React.FC<BlockTimeChartProps> = ({
             borderColor: lineColor,
           }}
           labelStyle={{ color: '#333' }}
-        />
-        <Legend
-          verticalAlign="bottom"
-          align="right"
-          wrapperStyle={{ right: 20, bottom: 0 }}
         />
         <Line
           type="monotone"

--- a/dashboard/components/BlockTxChart.tsx
+++ b/dashboard/components/BlockTxChart.tsx
@@ -6,7 +6,6 @@ import {
   YAxis,
   CartesianGrid,
   Tooltip,
-  Legend,
   ResponsiveContainer,
   Brush,
 } from 'recharts';
@@ -104,11 +103,6 @@ export const BlockTxChart: React.FC<BlockTxChartProps> = ({
             borderColor: barColor,
           }}
           labelStyle={{ color: '#333' }}
-        />
-        <Legend
-          verticalAlign="bottom"
-          align="right"
-          wrapperStyle={{ right: 20, bottom: 0 }}
         />
         <Bar dataKey="txs" fill={barColor} name="Txs" />
         <Brush

--- a/dashboard/components/GasUsedChart.tsx
+++ b/dashboard/components/GasUsedChart.tsx
@@ -6,7 +6,6 @@ import {
   YAxis,
   CartesianGrid,
   Tooltip,
-  Legend,
   ResponsiveContainer,
   Brush,
 } from 'recharts';
@@ -99,11 +98,6 @@ export const GasUsedChart: React.FC<GasUsedChartProps> = ({
             borderColor: lineColor,
           }}
           labelStyle={{ color: '#333' }}
-        />
-        <Legend
-          verticalAlign="bottom"
-          align="right"
-          wrapperStyle={{ right: 20, bottom: 0 }}
         />
         <Line
           type="monotone"

--- a/dashboard/components/ReorgDepthChart.tsx
+++ b/dashboard/components/ReorgDepthChart.tsx
@@ -6,7 +6,6 @@ import {
   YAxis,
   CartesianGrid,
   Tooltip,
-  Legend,
   ResponsiveContainer,
   Brush,
 } from 'recharts';
@@ -97,11 +96,6 @@ export const ReorgDepthChart: React.FC<ReorgDepthChartProps> = ({ data }) => {
             borderColor: TAIKO_PINK,
           }}
           labelStyle={{ color: '#333' }}
-        />
-        <Legend
-          verticalAlign="bottom"
-          align="right"
-          wrapperStyle={{ right: 20, bottom: 0 }}
         />
         <Bar dataKey="depth" fill={TAIKO_PINK} name="Depth" />
         <Brush

--- a/dashboard/components/SequencerPieChart.tsx
+++ b/dashboard/components/SequencerPieChart.tsx
@@ -1,12 +1,5 @@
 import React from 'react';
-import {
-  PieChart,
-  Pie,
-  Cell,
-  Tooltip,
-  Legend,
-  ResponsiveContainer,
-} from 'recharts';
+import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer } from 'recharts';
 import type { Payload } from 'recharts/types/component/DefaultTooltipContent';
 import { PieChartDataItem } from '../types';
 import { formatSequencerTooltip } from '../utils';
@@ -67,16 +60,11 @@ export const SequencerPieChart: React.FC<SequencerPieChartProps> = ({
           })}
         </Pie>
         <Tooltip
-          formatter={(
-            _,
-            name: string,
-            item: Payload<number, string>,
-          ) => {
+          formatter={(_, name: string, item: Payload<number, string>) => {
             const payload = item.payload as PieChartDataItem;
             return [formatSequencerTooltip(data, payload.value), name];
           }}
         />
-        <Legend verticalAlign="bottom" wrapperStyle={{ paddingTop: '10px' }} />
       </PieChart>
     </ResponsiveContainer>
   );

--- a/dashboard/components/TpsChart.tsx
+++ b/dashboard/components/TpsChart.tsx
@@ -6,7 +6,6 @@ import {
   YAxis,
   CartesianGrid,
   Tooltip,
-  Legend,
   ResponsiveContainer,
 } from 'recharts';
 
@@ -30,7 +29,10 @@ export const TpsChart: React.FC<TpsChartProps> = ({ data, lineColor }) => {
   }
   return (
     <ResponsiveContainer width="100%" height="100%">
-      <LineChart data={data} margin={{ top: 5, right: 30, left: 20, bottom: 50 }}>
+      <LineChart
+        data={data}
+        margin={{ top: 5, right: 30, left: 20, bottom: 50 }}
+      >
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis
           dataKey="block"
@@ -63,11 +65,20 @@ export const TpsChart: React.FC<TpsChartProps> = ({ data, lineColor }) => {
         <Tooltip
           labelFormatter={(label: number) => `Block ${label.toLocaleString()}`}
           formatter={(value: number) => [value.toFixed(2), 'tps']}
-          contentStyle={{ backgroundColor: 'rgba(255, 255, 255, 0.8)', borderColor: lineColor }}
+          contentStyle={{
+            backgroundColor: 'rgba(255, 255, 255, 0.8)',
+            borderColor: lineColor,
+          }}
           labelStyle={{ color: '#333' }}
         />
-        <Legend verticalAlign="bottom" align="right" wrapperStyle={{ right: 20, bottom: 0 }} />
-        <Line type="monotone" dataKey="tps" stroke={lineColor} strokeWidth={2} dot={false} name="TPS" />
+        <Line
+          type="monotone"
+          dataKey="tps"
+          stroke={lineColor}
+          strokeWidth={2}
+          dot={false}
+          name="TPS"
+        />
       </LineChart>
     </ResponsiveContainer>
   );


### PR DESCRIPTION
## Summary
- drop `Legend` usage from dashboard charts

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_683d613e201c83288cf7feade42533cd