### PR TITLE
Fix chart brush spacing

### DIFF
--- a/dashboard/components/BatchProcessChart.tsx
+++ b/dashboard/components/BatchProcessChart.tsx
@@ -69,7 +69,7 @@ export const BatchProcessChart: React.FC<BatchProcessChartProps> = ({
     <ResponsiveContainer width="100%" height="100%">
       <LineChart
         data={data}
-        margin={{ top: 5, right: 30, left: 20, bottom: 80 }}
+        margin={{ top: 5, right: 30, left: 20, bottom: 60 }}
       >
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis

--- a/dashboard/components/BlobsPerBatchChart.tsx
+++ b/dashboard/components/BlobsPerBatchChart.tsx
@@ -60,7 +60,7 @@ export const BlobsPerBatchChart: React.FC<BlobsPerBatchChartProps> = ({
     <ResponsiveContainer width="100%" height="100%">
       <BarChart
         data={data}
-        margin={{ top: 5, right: 30, left: 20, bottom: 80 }}
+        margin={{ top: 5, right: 30, left: 20, bottom: 60 }}
       >
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis

--- a/dashboard/components/BlockTimeChart.tsx
+++ b/dashboard/components/BlockTimeChart.tsx
@@ -60,7 +60,7 @@ export const BlockTimeChart: React.FC<BlockTimeChartProps> = ({
     <ResponsiveContainer width="100%" height="100%">
       <LineChart
         data={data}
-        margin={{ top: 5, right: 30, left: 20, bottom: 80 }}
+        margin={{ top: 5, right: 30, left: 20, bottom: 60 }}
       >
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis

--- a/dashboard/components/GasUsedChart.tsx
+++ b/dashboard/components/GasUsedChart.tsx
@@ -59,7 +59,7 @@ export const GasUsedChart: React.FC<GasUsedChartProps> = ({
     <ResponsiveContainer width="100%" height="100%">
       <LineChart
         data={data}
-        margin={{ top: 5, right: 30, left: 20, bottom: 80 }}
+        margin={{ top: 5, right: 30, left: 20, bottom: 60 }}
       >
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis

--- a/dashboard/components/ReorgDepthChart.tsx
+++ b/dashboard/components/ReorgDepthChart.tsx
@@ -58,7 +58,7 @@ export const ReorgDepthChart: React.FC<ReorgDepthChartProps> = ({ data }) => {
     <ResponsiveContainer width="100%" height="100%">
       <BarChart
         data={data}
-        margin={{ top: 5, right: 30, left: 20, bottom: 80 }}
+        margin={{ top: 5, right: 30, left: 20, bottom: 60 }}
       >
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis


### PR DESCRIPTION
## Summary
- reduce bottom margin on dashboard charts so there isn't so much space under the brush

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_683d6343b6b88328901aa11f9079ff10