### PR TITLE
Fix dashboard brush to use time range

### DIFF
--- a/dashboard/components/BlockTimeChart.tsx
+++ b/dashboard/components/BlockTimeChart.tsx
@@ -114,7 +114,7 @@ export const BlockTimeChart: React.FC<BlockTimeChartProps> = ({
           name="Time"
         />
         <Brush
-          dataKey="value"
+          dataKey="timestamp"
           height={20}
           stroke={lineColor}
           startIndex={brushRange.startIndex}

--- a/dashboard/components/GasUsedChart.tsx
+++ b/dashboard/components/GasUsedChart.tsx
@@ -109,7 +109,7 @@ export const GasUsedChart: React.FC<GasUsedChartProps> = ({
           name="Gas Used"
         />
         <Brush
-          dataKey="value"
+          dataKey="timestamp"
           height={20}
           stroke={lineColor}
           startIndex={brushRange.startIndex}


### PR DESCRIPTION
## Summary
- switch BlockTimeChart brush to use `timestamp`
- switch GasUsedChart brush to use `timestamp`

## Testing
- `just test-dashboard`
- `cargo nextest run --workspace --all-targets`

------
https://chatgpt.com/codex/tasks/task_b_683d637dc0948328842b83f9b57b687a