### PR TITLE
Fix chart brush time formatting

### DIFF
--- a/dashboard/components/BlockTimeChart.tsx
+++ b/dashboard/components/BlockTimeChart.tsx
@@ -120,6 +120,7 @@ export const BlockTimeChart: React.FC<BlockTimeChartProps> = ({
           startIndex={brushRange.startIndex}
           endIndex={brushRange.endIndex}
           onChange={handleBrushChange}
+          tickFormatter={(v: number) => formatInterval(v, showMinutes)}
         />
       </LineChart>
     </ResponsiveContainer>

--- a/dashboard/components/GasUsedChart.tsx
+++ b/dashboard/components/GasUsedChart.tsx
@@ -109,12 +109,13 @@ export const GasUsedChart: React.FC<GasUsedChartProps> = ({
           name="Gas Used"
         />
         <Brush
-          dataKey="timestamp"
+          dataKey="value"
           height={20}
           stroke={lineColor}
           startIndex={brushRange.startIndex}
           endIndex={brushRange.endIndex}
           onChange={handleBrushChange}
+          tickFormatter={(v: number) => v.toLocaleString()}
         />
       </LineChart>
     </ResponsiveContainer>


### PR DESCRIPTION
## Summary
- show block numbers in GasUsedChart brush
- format time for BlockTimeChart brush

## Testing
- `npm run check --prefix dashboard`
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_683d7b429d70832886c744f2ddb48e75