### PR TITLE
Fix TS import extensions

### DIFF
--- a/dashboard/App.tsx
+++ b/dashboard/App.tsx
@@ -43,7 +43,7 @@ import {
   MetricData,
 } from './types';
 import { loadRefreshRate, saveRefreshRate } from './utils';
-import { getSequencerAddress } from './sequencerConfig.js';
+import { getSequencerAddress } from './sequencerConfig';
 import {
   API_BASE,
   fetchAvgProveTime,
@@ -572,38 +572,62 @@ const App: React.FC = () => {
             onMore={() => openGenericTable('verify-time', timeRange)}
             loading={loadingMetrics}
           >
-            <BatchProcessChart key={timeRange} data={secondsToVerifyData} lineColor="#5DA5DA" />
+            <BatchProcessChart
+              key={timeRange}
+              data={secondsToVerifyData}
+              lineColor="#5DA5DA"
+            />
           </ChartCard>
           <ChartCard title="Gas Used Per Block" loading={loadingMetrics}>
-            <GasUsedChart key={timeRange} data={l2GasUsedData} lineColor="#E573B5" />
+            <GasUsedChart
+              key={timeRange}
+              data={l2GasUsedData}
+              lineColor="#E573B5"
+            />
           </ChartCard>
           <ChartCard
             title="Tx Count Per Block"
             onMore={() => openGenericTable('block-tx', timeRange)}
             loading={loadingMetrics}
           >
-            <BlockTxChart key={timeRange} data={blockTxData} barColor="#4E79A7" />
+            <BlockTxChart
+              key={timeRange}
+              data={blockTxData}
+              barColor="#4E79A7"
+            />
           </ChartCard>
           <ChartCard
             title="Blobs per Batch"
             onMore={() => openGenericTable('blobs-per-batch', timeRange)}
             loading={loadingMetrics}
           >
-            <BlobsPerBatchChart key={timeRange} data={batchBlobCounts} barColor="#A0CBE8" />
+            <BlobsPerBatchChart
+              key={timeRange}
+              data={batchBlobCounts}
+              barColor="#A0CBE8"
+            />
           </ChartCard>
           <ChartCard
             title="L2 Block Times"
             onMore={() => openGenericTable('l2-block-times', timeRange)}
             loading={loadingMetrics}
           >
-            <BlockTimeChart key={timeRange} data={l2BlockTimeData} lineColor="#FAA43A" />
+            <BlockTimeChart
+              key={timeRange}
+              data={l2BlockTimeData}
+              lineColor="#FAA43A"
+            />
           </ChartCard>
           <ChartCard
             title="L1 Block Times"
             onMore={() => openGenericTable('l1-block-times', timeRange)}
             loading={loadingMetrics}
           >
-            <BlockTimeChart key={timeRange} data={l1BlockTimeData} lineColor="#60BD68" />
+            <BlockTimeChart
+              key={timeRange}
+              data={l1BlockTimeData}
+              lineColor="#60BD68"
+            />
           </ChartCard>
         </div>
       </main>

--- a/dashboard/helpers.ts
+++ b/dashboard/helpers.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import { type MetricData } from './types';
-import { formatSeconds } from './utils.js';
-import { getSequencerName } from './sequencerConfig.js';
+import { formatSeconds } from './utils';
+import { getSequencerName } from './sequencerConfig';
 import type { RequestResult } from './services/apiService';
 
 export interface MetricInputData {

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -1,7 +1,7 @@
 const metaEnv = import.meta.env;
 export const API_BASE = metaEnv.VITE_API_BASE || metaEnv.API_BASE || '';
 
-import { getSequencerName } from '../sequencerConfig.js';
+import { getSequencerName } from '../sequencerConfig';
 
 import type {
   TimeSeriesData,

--- a/dashboard/tests/app.integration.test.ts
+++ b/dashboard/tests/app.integration.test.ts
@@ -25,8 +25,8 @@ import {
   fetchSequencerDistribution,
   API_BASE,
 } from '../services/apiService.ts';
-import { createMetrics, hasBadRequest } from '../helpers.js';
-import type { MetricData } from '../types.js';
+import { createMetrics, hasBadRequest } from '../helpers';
+import type { MetricData } from '../types';
 
 type TimeRange = '1h' | '24h' | '7d';
 

--- a/dashboard/tests/chartCard.test.ts
+++ b/dashboard/tests/chartCard.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { ChartCard } from '../components/ChartCard.js';
+import { ChartCard } from '../components/ChartCard';
 
 describe('ChartCard', () => {
   it('renders title and children', () => {
@@ -20,7 +20,7 @@ describe('ChartCard', () => {
     const html = renderToStaticMarkup(
       React.createElement(ChartCard, {
         title: 'Other Chart',
-        onMore: () => { },
+        onMore: () => {},
         children: React.createElement('div', null, 'data'),
       }),
     );

--- a/dashboard/tests/dashboardHeader.test.ts
+++ b/dashboard/tests/dashboardHeader.test.ts
@@ -1,21 +1,21 @@
 import { describe, it, expect } from 'vitest';
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { DashboardHeader } from '../components/DashboardHeader.js';
+import { DashboardHeader } from '../components/DashboardHeader';
 
 describe('DashboardHeader', () => {
   it('renders time range and refresh controls', () => {
     const html = renderToStaticMarkup(
       React.createElement(DashboardHeader, {
         timeRange: '1h',
-        onTimeRangeChange: () => { },
+        onTimeRangeChange: () => {},
         refreshRate: 60000,
-        onRefreshRateChange: () => { },
+        onRefreshRateChange: () => {},
         lastRefresh: Date.now(),
-        onManualRefresh: () => { },
+        onManualRefresh: () => {},
         sequencers: ['seq1', 'seq2'],
         selectedSequencer: null,
-        onSequencerChange: () => { },
+        onSequencerChange: () => {},
       }),
     );
     expect(html.includes('Taiko Masaya Testnet')).toBe(true);

--- a/dashboard/tests/dataTable.test.ts
+++ b/dashboard/tests/dataTable.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { DataTable } from '../components/DataTable.js';
+import { DataTable } from '../components/DataTable';
 
 describe('DataTable', () => {
   it('renders table rows and columns', () => {

--- a/dashboard/tests/helpers.test.ts
+++ b/dashboard/tests/helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { createMetrics, hasBadRequest } from '../helpers.js';
+import { createMetrics, hasBadRequest } from '../helpers';
 
 const metrics = createMetrics({
   avgTps: 3,

--- a/dashboard/tests/metricCard.test.ts
+++ b/dashboard/tests/metricCard.test.ts
@@ -1,15 +1,22 @@
 import { describe, it, expect } from 'vitest';
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { MetricCard } from '../components/MetricCard.js';
+import { MetricCard } from '../components/MetricCard';
 
 describe('MetricCard', () => {
   it('renders addresses with special classes', () => {
     const addressValue = '0x1234567890123456789012345678901234567890';
     const htmlAddress = renderToStaticMarkup(
-      React.createElement(MetricCard, { title: 'Operator', value: addressValue }),
+      React.createElement(MetricCard, {
+        title: 'Operator',
+        value: addressValue,
+      }),
     );
-    expect(htmlAddress.includes('min-w-0 w-full sm:col-span-2 md:col-span-2 lg:col-span-2 xl:col-span-2 2xl:col-span-2')).toBe(true);
+    expect(
+      htmlAddress.includes(
+        'min-w-0 w-full sm:col-span-2 md:col-span-2 lg:col-span-2 xl:col-span-2 2xl:col-span-2',
+      ),
+    ).toBe(true);
     expect(htmlAddress.includes('text-base sm:text-lg break-all')).toBe(true);
   });
 

--- a/dashboard/tests/utils.extra.test.ts
+++ b/dashboard/tests/utils.extra.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatDecimal, formatSeconds } from '../utils.js';
+import { formatDecimal, formatSeconds } from '../utils';
 
 describe('extra utils', () => {
   it('formats decimals and seconds', () => {

--- a/dashboard/tests/utils.test.ts
+++ b/dashboard/tests/utils.test.ts
@@ -12,7 +12,7 @@ import {
   bytesToHex,
   loadRefreshRate,
   saveRefreshRate,
-} from '../utils.js';
+} from '../utils';
 
 describe('utils', () => {
   it('formats numbers and durations', () => {
@@ -93,8 +93,8 @@ describe('utils', () => {
       setItem: (k: string, v: string) => {
         store[k] = v;
       },
-      removeItem: () => { },
-      clear: () => { },
+      removeItem: () => {},
+      clear: () => {},
       key: () => null,
       length: 0,
     } as Storage;


### PR DESCRIPTION
## Summary
- remove `.js` extensions from TypeScript imports in the dashboard

## Testing
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_683d83576b208328b72e4ea4b32fa111