### PR TITLE
Add API versioned routes

### DIFF
--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -18,6 +18,9 @@ use tracing::{Level, info};
 /// Allowed CORS origins for dashboard requests.
 const ALLOWED_ORIGINS: &[&str] = &["https://taikoscope.xyz", "https://www.taikoscope.xyz"];
 
+/// Version prefix for all API routes.
+pub const API_VERSION: &str = "v1";
+
 /// Build the API router with CORS and tracing layers.
 pub fn router(state: ApiState, extra_origins: Vec<String>) -> Router {
     let extra = Arc::new(extra_origins);
@@ -40,7 +43,7 @@ pub fn router(state: ApiState, extra_origins: Vec<String>) -> Router {
         .on_request(DefaultOnRequest::new().level(Level::INFO))
         .on_response(DefaultOnResponse::new().level(Level::INFO));
 
-    api::router(state).layer(cors).layer(trace)
+    Router::new().nest(&format!("/{API_VERSION}"), api::router(state)).layer(cors).layer(trace)
 }
 
 /// Run the API server on the given address.

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -1,5 +1,6 @@
 const metaEnv = import.meta.env;
-export const API_BASE = metaEnv.VITE_API_BASE || metaEnv.API_BASE || '';
+export const API_BASE =
+  (metaEnv.VITE_API_BASE || metaEnv.API_BASE || '') + '/v1';
 
 import { getSequencerName } from '../sequencerConfig';
 

--- a/dashboard/tests/app.integration.test.ts
+++ b/dashboard/tests/app.integration.test.ts
@@ -52,47 +52,47 @@ interface MockFetchResponse {
 }
 
 const responses: Record<string, Record<string, unknown>> = {
-  '/l2-block-cadence?range=1h': { l2_block_cadence_ms: 60000 },
-  '/batch-posting-cadence?range=1h': { batch_posting_cadence_ms: 120000 },
-  '/avg-prove-time?range=1h': { avg_prove_time_ms: 1500 },
-  '/avg-verify-time?range=1h': { avg_verify_time_ms: 2500 },
-  '/active-gateways?range=1h': { gateways: ['gw1', 'gw2'] },
-  '/current-operator': { operator: '0xaaa' },
-  '/next-operator': { operator: '0xbbb' },
-  '/reorgs?range=1h': { events: [{ l2_block_number: 10, depth: 1 }] },
-  '/slashings?range=1h': {
+  '/v1/l2-block-cadence?range=1h': { l2_block_cadence_ms: 60000 },
+  '/v1/batch-posting-cadence?range=1h': { batch_posting_cadence_ms: 120000 },
+  '/v1/avg-prove-time?range=1h': { avg_prove_time_ms: 1500 },
+  '/v1/avg-verify-time?range=1h': { avg_verify_time_ms: 2500 },
+  '/v1/active-gateways?range=1h': { gateways: ['gw1', 'gw2'] },
+  '/v1/current-operator': { operator: '0xaaa' },
+  '/v1/next-operator': { operator: '0xbbb' },
+  '/v1/reorgs?range=1h': { events: [{ l2_block_number: 10, depth: 1 }] },
+  '/v1/slashings?range=1h': {
     events: [{ l1_block_number: 5, validator_addr: [1, 2] }],
   },
-  '/forced-inclusions?range=1h': { events: [{ blob_hash: [3, 4] }] },
-  '/l2-block-times?range=1h': {
+  '/v1/forced-inclusions?range=1h': { events: [{ blob_hash: [3, 4] }] },
+  '/v1/l2-block-times?range=1h': {
     blocks: [
       { l2_block_number: 1, ms_since_prev_block: 1000 },
       { l2_block_number: 2, ms_since_prev_block: 2000 },
     ],
   },
-  '/l1-block-times?range=1h': {
+  '/v1/l1-block-times?range=1h': {
     blocks: [
       { block_number: 50, minute: 1 },
       { block_number: 52, minute: 2 },
     ],
   },
-  '/prove-times?range=1h': {
+  '/v1/prove-times?range=1h': {
     batches: [{ batch_id: 1, seconds_to_prove: 3 }],
   },
-  '/verify-times?range=1h': {
+  '/v1/verify-times?range=1h': {
     batches: [{ batch_id: 1, seconds_to_verify: 4 }],
   },
-  '/l2-gas-used?range=1h': {
+  '/v1/l2-gas-used?range=1h': {
     blocks: [
       { l2_block_number: 1, gas_used: 100 },
       { l2_block_number: 2, gas_used: 150 },
     ],
   },
-  '/sequencer-distribution?range=1h': {
+  '/v1/sequencer-distribution?range=1h': {
     sequencers: [{ address: 'addr1', blocks: 10 }],
   },
-  '/l2-head-block': { l2_head_block: 123 },
-  '/l1-head-block': { l1_head_block: 456 },
+  '/v1/l2-head-block': { l2_head_block: 123 },
+  '/v1/l1-head-block': { l1_head_block: 456 },
 };
 
 (

--- a/tests/api_integration.rs
+++ b/tests/api_integration.rs
@@ -9,7 +9,7 @@ use serde::Serialize;
 use tokio::time::sleep;
 use url::Url;
 
-use server::run;
+use server::{run, API_VERSION};
 use clickhouse_lib::ClickhouseReader;
 
 #[derive(Serialize, Row)]
@@ -38,7 +38,7 @@ async fn l2_head_integration() {
 
     sleep(Duration::from_millis(100)).await;
 
-    let resp = reqwest::get(format!("http://{addr}/l2-head")).await.unwrap();
+    let resp = reqwest::get(format!("http://{addr}/{API_VERSION}/l2-head")).await.unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
     let body: serde_json::Value = resp.json().await.unwrap();
     let expected = chrono::Utc.timestamp_opt(ts as i64, 0).single().unwrap().to_rfc3339();


### PR DESCRIPTION
## Summary
- prefix API routes with `/v1` using server constant
- adjust dashboard API base URL to include `/v1`
- update tests and docs for versioned routes

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_683d81c46f788328b2484dd482c63415