### PR TITLE
Introduce caching hook for dashboard

### DIFF
--- a/dashboard/hooks/useApiQuery.ts
+++ b/dashboard/hooks/useApiQuery.ts
@@ -1,0 +1,42 @@
+import { useCallback, useEffect, useState } from 'react';
+
+export interface ApiQueryResult<T> {
+  data: T | null;
+  badRequest: boolean;
+}
+
+const cache = new Map<string, ApiQueryResult<unknown>>();
+
+export function useApiQuery<T>(
+  key: string,
+  fetcher: () => Promise<ApiQueryResult<T>>,
+) {
+  const [result, setResult] = useState<ApiQueryResult<T> | null>(
+    () => cache.get(key) as ApiQueryResult<T> | null,
+  );
+  const [loading, setLoading] = useState<boolean>(!cache.has(key));
+  const [error, setError] = useState<unknown>(null);
+
+  const execute = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetcher();
+      cache.set(key, res as ApiQueryResult<unknown>);
+      setResult(res);
+    } catch (err) {
+      setError(err);
+    } finally {
+      setLoading(false);
+    }
+  }, [key, fetcher]);
+
+  useEffect(() => {
+    if (!cache.has(key)) {
+      void execute();
+    } else {
+      setResult(cache.get(key) as ApiQueryResult<T>);
+    }
+  }, [key, execute]);
+
+  return { ...(result ?? { data: null, badRequest: false }), loading, error, refetch: execute };
+}


### PR DESCRIPTION
## Summary
- create `useApiQuery` hook to handle cached fetching
- wire up `App.tsx` to use the hook for Avg TPS metric

## Testing
- `just ci` *(fails: `cargo` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683d83aae0808328bb8ad02483ed0797