### PR TITLE
Add search params hook

### DIFF
--- a/dashboard/App.tsx
+++ b/dashboard/App.tsx
@@ -6,6 +6,7 @@ import { MetricCardSkeleton } from './components/MetricCardSkeleton';
 import { ChartCard } from './components/ChartCard';
 import { DataTable } from './components/DataTable';
 import { useTableActions } from './hooks/useTableActions';
+import { useSearchParams } from './hooks/useSearchParams';
 const SequencerPieChart = lazy(() =>
   import('./components/SequencerPieChart').then((m) => ({
     default: m.SequencerPieChart,
@@ -391,8 +392,10 @@ const App: React.FC = () => {
     Sequencers: 3,
   };
 
+  const searchParams = useSearchParams();
+
   const handleRouteChange = useCallback(() => {
-    const params = new URLSearchParams(window.location.search);
+    const params = searchParams;
     if (params.get('view') !== 'table') {
       setTableView(null);
       return;
@@ -439,10 +442,8 @@ const App: React.FC = () => {
   ]);
 
   useEffect(() => {
-    window.addEventListener('popstate', handleRouteChange);
     handleRouteChange();
-    return () => window.removeEventListener('popstate', handleRouteChange);
-  }, [handleRouteChange]);
+  }, [handleRouteChange, searchParams]);
 
   if (tableView) {
     return (

--- a/dashboard/hooks/useSearchParams.ts
+++ b/dashboard/hooks/useSearchParams.ts
@@ -1,0 +1,18 @@
+import { useCallback, useEffect, useState } from 'react';
+
+export const useSearchParams = (): URLSearchParams => {
+  const getParams = useCallback(
+    () => new URLSearchParams(window.location.search),
+    [],
+  );
+
+  const [params, setParams] = useState<URLSearchParams>(getParams);
+
+  useEffect(() => {
+    const handleChange = () => setParams(getParams());
+    window.addEventListener('popstate', handleChange);
+    return () => window.removeEventListener('popstate', handleChange);
+  }, [getParams]);
+
+  return params;
+};

--- a/dashboard/hooks/useTableActions.ts
+++ b/dashboard/hooks/useTableActions.ts
@@ -1,4 +1,5 @@
 import React, { useState, useCallback } from 'react';
+import { useSearchParams } from './useSearchParams';
 import { TimeRange } from '../types';
 import { TABLE_CONFIGS } from '../config/tableConfig';
 import { getSequencerAddress } from '../sequencerConfig';
@@ -39,8 +40,9 @@ export const useTableActions = (
   l2BlockTimeData: any[],
 ) => {
   const [tableView, setTableView] = useState<TableViewState | null>(null);
+  const searchParams = useSearchParams();
   const [tableLoading, setTableLoading] = useState<boolean>(
-    new URLSearchParams(window.location.search).get('view') === 'table',
+    searchParams.get('view') === 'table',
   );
   const [seqDistTxPage, setSeqDistTxPage] = useState<number>(0);
 


### PR DESCRIPTION
## Summary
- create useSearchParams hook in dashboard
- use it to read query params for routing

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_683d8392ff1c8328939ae1b9077f3543