### PR TITLE
Add explanation to reorg table

### DIFF
--- a/dashboard/App.tsx
+++ b/dashboard/App.tsx
@@ -448,6 +448,7 @@ const App: React.FC = () => {
     return (
       <DataTable
         title={tableView.title}
+        description={tableView.description}
         columns={tableView.columns}
         rows={tableView.rows}
         onBack={() => {

--- a/dashboard/components/DataTable.tsx
+++ b/dashboard/components/DataTable.tsx
@@ -23,6 +23,7 @@ interface ExtraTable {
 
 interface DataTableProps {
   title: string;
+  description?: React.ReactNode;
   columns: Column[];
   rows: Array<Record<string, string | number>>;
   onBack: () => void;
@@ -38,6 +39,7 @@ interface DataTableProps {
 
 export const DataTable: React.FC<DataTableProps> = ({
   title,
+  description,
   columns,
   rows,
   onBack,
@@ -94,6 +96,9 @@ export const DataTable: React.FC<DataTableProps> = ({
         )}
       </div>
       <h2 className="text-xl font-semibold mb-2">{title}</h2>
+      {description && (
+        <p className="text-gray-600 mb-2">{description}</p>
+      )}
       {chart && <div className="h-64 md:h-80 w-full mb-4">{chart}</div>}
       <div className="overflow-x-auto">
         <table className="min-w-full border divide-y divide-gray-200">

--- a/dashboard/hooks/useTableActions.ts
+++ b/dashboard/hooks/useTableActions.ts
@@ -9,6 +9,7 @@ import {
 
 export interface TableViewState {
   title: string;
+  description?: React.ReactNode;
   columns: { key: string; label: string }[];
   rows: Record<string, string | number>[];
   onRowClick?: (row: Record<string, string | number>) => void;
@@ -63,6 +64,7 @@ export const useTableActions = (
   const openTable = useCallback(
     (
       title: string,
+      description: React.ReactNode | undefined,
       columns: { key: string; label: string }[],
       rows: Record<string, string | number>[],
       onRowClick?: (row: Record<string, string | number>) => void,
@@ -74,6 +76,7 @@ export const useTableActions = (
     ) => {
       setTableView({
         title,
+        description,
         columns,
         rows,
         onRowClick,
@@ -129,6 +132,10 @@ export const useTableActions = (
 
         openTable(
           title,
+          tableKey === 'reorgs'
+            ?
+                'An L2 reorg occurs when the chain replaces previously published blocks. Depth shows how many blocks were replaced.'
+            : undefined,
           config.columns,
           mappedData,
           tableKey === 'sequencer-dist'
@@ -174,6 +181,7 @@ export const useTableActions = (
 
     openTable(
       'Transactions Per Second',
+      undefined,
       [
         { key: 'block', label: 'Block Number' },
         { key: 'tps', label: 'TPS' },
@@ -230,6 +238,7 @@ export const useTableActions = (
 
       openTable(
         'Sequencer Distribution',
+        undefined,
         [
           { key: 'name', label: 'Sequencer' },
           { key: 'value', label: 'Blocks' },
@@ -271,6 +280,7 @@ export const useTableActions = (
         },
         range,
         (r) => openSequencerDistributionTable(r, 0),
+        undefined,
       );
     },
     [

--- a/dashboard/tests/dataTable.test.ts
+++ b/dashboard/tests/dataTable.test.ts
@@ -8,6 +8,7 @@ describe('DataTable', () => {
     const html = renderToStaticMarkup(
       React.createElement(DataTable, {
         title: 'My Table',
+        description: 'info',
         columns: [
           { key: 'a', label: 'A' },
           { key: 'b', label: 'B' },
@@ -23,6 +24,7 @@ describe('DataTable', () => {
     expect(html.includes('B')).toBe(true);
     expect(html.includes('1')).toBe(true);
     expect(html.includes('4')).toBe(true);
+    expect(html.includes('info')).toBe(true);
   });
 
   it('renders extra action and extra table', () => {


### PR DESCRIPTION
## Summary
- show table descriptions in DataTable
- document L2 reorgs in the reorg table view

## Testing
- `just check-dashboard`
- `just test-dashboard`
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_683d8f79dabc8328a2c95d76c8a3eb0e