### PR TITLE
Add Docker Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,20 @@ through a thin HTTP API consumed by the dashboard frontend.
 1. Clone the repository and install dependencies.
 2. Copy `dev.env` and adjust the values for your setup or provide your own env
    file via the `ENV_FILE` variable.
-3. Start the extractor and API server:
+3. (Optional) Start ClickHouse and the dashboard via Docker Compose:
+
+   ```bash
+   docker compose up
+   ```
+
+4. Start the extractor and API server:
 
    ```bash
    just dev         # runs the extractor/driver
    just dev-api     # runs the HTTP API
    ```
 
-4. Start the dashboard (optional):
+5. Start the dashboard (optional if not using Docker Compose):
 
    ```bash
    just dev-dashboard

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: "3.8"
+services:
+  clickhouse:
+    image: clickhouse/clickhouse-server:latest
+    ports:
+      - "8123:8123"
+    volumes:
+      - clickhouse-data:/var/lib/clickhouse
+    environment:
+      CLICKHOUSE_DB: taikoscope
+  dashboard:
+    image: node:20
+    working_dir: /app
+    volumes:
+      - ./dashboard:/app
+      - dashboard-node-modules:/app/node_modules
+    command: sh -c "npm install && VITE_API_BASE=http://localhost:3000 npm run dev -- --host 0.0.0.0"
+    ports:
+      - "5173:5173"
+    depends_on:
+      - clickhouse
+volumes:
+  clickhouse-data:
+  dashboard-node-modules:


### PR DESCRIPTION
## Summary
- add a docker-compose.yml for ClickHouse and dashboard
- document how to start it in the Quick Start guide

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_683d82e68afc8328b3d08b17ff1dac5b