### PR TITLE
Add OpenAPI docs test to CI

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -36,3 +36,5 @@ jobs:
       - uses: taiki-e/install-action@nextest
       - name: Run tests
         run: cargo nextest run --retries 3 --no-tests=warn
+      - name: Check OpenAPI docs
+        run: cargo test --test api_docs


### PR DESCRIPTION
## Summary
- run `cargo test --test api_docs` in unit workflow to check OpenAPI docs

## Testing
- `just ci` *(fails: failed to download Swagger UI)*

------
https://chatgpt.com/codex/tasks/task_b_683da445c9488328aa956dd6d9ac254b