### PR TITLE
fix: extract data table constant

### DIFF
--- a/dashboard/components/DataTable.tsx
+++ b/dashboard/components/DataTable.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { TimeRange } from '../types';
 import { TimeRangeSelector, RefreshRateInput } from './DashboardHeader';
 
+const ROWS_PER_PAGE = 50;
+
 interface Column {
   key: string;
   label: string;
@@ -50,7 +52,6 @@ export const DataTable: React.FC<DataTableProps> = ({
   onRefreshRateChange,
   chart,
 }) => {
-  const ROWS_PER_PAGE = 50;
   const [page, setPage] = React.useState(0);
 
   React.useEffect(() => {


### PR DESCRIPTION
## Summary
- avoid recreating pagination constant for the dashboard table

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_683d837212a48328b9270af9fa72f98b