### PR TITLE
Increase clickable area of view table buttons

### DIFF
--- a/dashboard/components/ChartCard.tsx
+++ b/dashboard/components/ChartCard.tsx
@@ -19,7 +19,7 @@ export const ChartCard: React.FC<ChartCardProps> = ({
         {onMore && (
           <button
             onClick={onMore}
-            className="text-gray-500 hover:text-gray-700 text-2xl"
+            className="text-gray-500 hover:text-gray-700 text-2xl w-8 h-8 flex items-center justify-center rounded-md"
             aria-label="View table"
           >
             ⋮

--- a/dashboard/components/MetricCard.tsx
+++ b/dashboard/components/MetricCard.tsx
@@ -28,7 +28,7 @@ export const MetricCard: React.FC<MetricCardProps> = ({
         {onMore && (
           <button
             onClick={onMore}
-            className="text-gray-500 hover:text-gray-700 text-xl leading-none"
+            className="text-gray-500 hover:text-gray-700 text-xl leading-none w-8 h-8 flex items-center justify-center rounded-md"
             aria-label="View table"
           >
             ⋮


### PR DESCRIPTION
## Summary
- enlarge chart and metric card 'view table' buttons to make them easier to tap

## Testing
- `npm run check` in dashboard
- `npm run test` in dashboard
- `just ci` *(fails: failed to download Swagger UI due to network)*

------
https://chatgpt.com/codex/tasks/task_b_683da660bf3883288720a3897259d429