### PR TITLE
Fix Avg TPS metric display

### DIFF
--- a/dashboard/App.tsx
+++ b/dashboard/App.tsx
@@ -140,6 +140,22 @@ const App: React.FC = () => {
   }, [avgTpsQuery.loading]);
 
   useEffect(() => {
+    setMetrics((m) =>
+      m.map((metric) =>
+        metric.title === 'Avg. L2 TPS'
+          ? {
+              ...metric,
+              value:
+                avgTpsQuery.data != null
+                  ? avgTpsQuery.data.toFixed(2)
+                  : 'N/A',
+            }
+          : metric,
+      ),
+    );
+  }, [avgTpsQuery.data]);
+
+  useEffect(() => {
     let pollId: NodeJS.Timeout | null = null;
 
     const updateHeads = async () => {


### PR DESCRIPTION
## Summary
- update metrics when avg TPS query data updates

## Testing
- `just fmt`
- `just lint` *(fails: failed to download Swagger UI due to network)*
- `just test` *(fails: failed to download Swagger UI due to network)*

------
https://chatgpt.com/codex/tasks/task_b_683dbb0f64b08328b9b73a4b6d644730