### PR TITLE
Fix Avg. L2 TPS formatting

### DIFF
--- a/dashboard/App.tsx
+++ b/dashboard/App.tsx
@@ -7,7 +7,6 @@ import { ChartCard } from './components/ChartCard';
 import { DataTable } from './components/DataTable';
 import { useTableActions } from './hooks/useTableActions';
 import { useSearchParams } from './hooks/useSearchParams';
-import { useApiQuery } from './hooks/useApiQuery';
 const SequencerPieChart = lazy(() =>
   import('./components/SequencerPieChart').then((m) => ({
     default: m.SequencerPieChart,

--- a/dashboard/helpers.tsx
+++ b/dashboard/helpers.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { type MetricData } from './types';
-import { formatSeconds } from './utils';
+import { formatSeconds, formatDecimal } from './utils';
 import { getSequencerName } from './sequencerConfig';
 import type { RequestResult } from './services/apiService';
 
@@ -23,7 +23,7 @@ export interface MetricInputData {
 export const createMetrics = (data: MetricInputData): MetricData[] => [
   {
     title: 'Avg. L2 TPS',
-    value: data.avgTps != null ? data.avgTps.toFixed(2) : 'N/A',
+    value: data.avgTps != null ? formatDecimal(data.avgTps) : 'N/A',
     group: 'Network Performance',
   },
   {


### PR DESCRIPTION
## Summary
- use `formatDecimal` for Avg. L2 TPS values
- remove unused import in dashboard app

## Testing
- `npm run check` (via `just check-dashboard`)
- `just ci` *(fails: failed to download swagger UI)*

------
https://chatgpt.com/codex/tasks/task_b_683dc63f88e48328ba4cbc7bc1dea37b