### PR TITLE
Fix layout flash in dashboard

### DIFF
--- a/dashboard/App.tsx
+++ b/dashboard/App.tsx
@@ -7,7 +7,6 @@ import { ChartCard } from './components/ChartCard';
 import { DataTable } from './components/DataTable';
 import { useTableActions } from './hooks/useTableActions';
 import { useSearchParams } from './hooks/useSearchParams';
-import { useApiQuery } from './hooks/useApiQuery';
 const SequencerPieChart = lazy(() =>
   import('./components/SequencerPieChart').then((m) => ({
     default: m.SequencerPieChart,
@@ -76,7 +75,6 @@ import {
   type BatchBlobCount,
 } from './services/apiService';
 
-
 const App: React.FC = () => {
   const [timeRange, setTimeRange] = useState<TimeRange>('1h');
   const [selectedSequencer, setSelectedSequencer] = useState<string | null>(
@@ -124,7 +122,6 @@ const App: React.FC = () => {
     blockTxData,
     l2BlockTimeData,
   );
-
 
   useEffect(() => {
     let pollId: NodeJS.Timeout | null = null;
@@ -525,16 +522,16 @@ const App: React.FC = () => {
                         typeof m.title === 'string' && m.title === 'Avg. L2 TPS'
                           ? () => openTpsTable()
                           : typeof m.title === 'string' &&
-                            m.title === 'L2 Reorgs'
+                              m.title === 'L2 Reorgs'
                             ? () => openGenericTable('reorgs')
                             : typeof m.title === 'string' &&
-                              m.title === 'Slashing Events'
+                                m.title === 'Slashing Events'
                               ? () => openGenericTable('slashings')
                               : typeof m.title === 'string' &&
-                                m.title === 'Forced Inclusions'
+                                  m.title === 'Forced Inclusions'
                                 ? () => openGenericTable('forced-inclusions')
                                 : typeof m.title === 'string' &&
-                                  m.title === 'Active Sequencers'
+                                    m.title === 'Active Sequencers'
                                   ? () => openGenericTable('gateways')
                                   : undefined
                       }

--- a/dashboard/index.css
+++ b/dashboard/index.css
@@ -5,6 +5,7 @@
   src: url('/fonts/DejaVuSans.ttf') format('truetype');
   font-weight: 400;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -12,6 +13,7 @@
   src: url('/fonts/DejaVuSans-Bold.ttf') format('truetype');
   font-weight: 700;
   font-style: normal;
+  font-display: swap;
 }
 
 button:hover {


### PR DESCRIPTION
## Summary
- avoid layout shift by ensuring fallback fonts display until custom fonts load
- clean up unused React hook import

## Testing
- `npm run test`
- `npm run check`
- `just ci` *(fails: failed to download swagger UI, network unavailable)*

------
https://chatgpt.com/codex/tasks/task_b_683dc8f8ccf08328b351647970ee0f53