### PR TITLE
Add sequencer blocks bar chart

### DIFF
--- a/dashboard/App.tsx
+++ b/dashboard/App.tsx
@@ -12,6 +12,11 @@ const SequencerPieChart = lazy(() =>
     default: m.SequencerPieChart,
   })),
 );
+const SequencerBarChart = lazy(() =>
+  import('./components/SequencerBarChart').then((m) => ({
+    default: m.SequencerBarChart,
+  })),
+);
 const BlockTimeChart = lazy(() =>
   import('./components/BlockTimeChart').then((m) => ({
     default: m.BlockTimeChart,
@@ -550,6 +555,18 @@ const App: React.FC = () => {
             loading={loadingMetrics}
           >
             <SequencerPieChart
+              key={timeRange}
+              data={sequencerDistribution.filter(
+                (d) => !selectedSequencer || d.name === selectedSequencer,
+              )}
+            />
+          </ChartCard>
+          <ChartCard
+            title="Blocks Proposed per Sequencer"
+            onMore={() => openSequencerDistributionTable(timeRange, 0)}
+            loading={loadingMetrics}
+          >
+            <SequencerBarChart
               key={timeRange}
               data={sequencerDistribution.filter(
                 (d) => !selectedSequencer || d.name === selectedSequencer,

--- a/dashboard/components/SequencerBarChart.tsx
+++ b/dashboard/components/SequencerBarChart.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import { PieChartDataItem } from '../types';
+import { TAIKO_PINK } from '../theme';
+
+interface SequencerBarChartProps {
+  data: PieChartDataItem[];
+}
+
+export const SequencerBarChart: React.FC<SequencerBarChartProps> = ({ data }) => {
+  if (!data || data.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-full text-gray-500">
+        No data available
+      </div>
+    );
+  }
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <BarChart data={data} margin={{ top: 5, right: 30, left: 20, bottom: 40 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
+        <XAxis
+          dataKey="name"
+          stroke="#666666"
+          fontSize={12}
+          label={{
+            value: 'Sequencer',
+            position: 'insideBottom',
+            offset: -35,
+            fontSize: 10,
+            fill: '#666666',
+          }}
+          padding={{ left: 10, right: 10 }}
+        />
+        <YAxis
+          stroke="#666666"
+          fontSize={12}
+          domain={[0, 'auto']}
+          allowDecimals={false}
+          tickFormatter={(v: number) => v.toLocaleString()}
+          label={{
+            value: 'Blocks',
+            angle: -90,
+            position: 'insideLeft',
+            offset: -16,
+            fontSize: 10,
+            fill: '#666666',
+          }}
+        />
+        <Tooltip
+          formatter={(value: number) => [value.toLocaleString(), 'blocks']}
+          contentStyle={{
+            backgroundColor: 'rgba(255, 255, 255, 0.8)',
+            borderColor: TAIKO_PINK,
+          }}
+          labelStyle={{ color: '#333' }}
+        />
+        <Bar dataKey="value" fill={TAIKO_PINK} name="Blocks" />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+};

--- a/dashboard/config/tableConfig.ts
+++ b/dashboard/config/tableConfig.ts
@@ -198,6 +198,12 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
       { key: 'value', label: 'Blocks' }
     ],
     mapData: (data) => data as Record<string, string | number>[],
+    chart: (data) => {
+      const SequencerBarChart = React.lazy(() =>
+        import('../components/SequencerBarChart').then((m) => ({ default: m.SequencerBarChart }))
+      );
+      return React.createElement(SequencerBarChart, { data });
+    },
     supportsPagination: true,
     urlKey: 'sequencer-dist'
   }


### PR DESCRIPTION
## Summary
- add SequencerBarChart component
- display Blocks Proposed per Sequencer chart
- include chart in sequencer distribution table view

## Testing
- `npm run --silent --prefix dashboard check`
- `just ci` *(fails: failed to download Swagger UI)*

------
https://chatgpt.com/codex/tasks/task_b_683ea355b32c83288b48c1781f33a7bf