### PR TITLE
Remove unused API_KEY definition

### DIFF
--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -1,12 +1,8 @@
 import path from 'path';
-import { defineConfig, loadEnv } from 'vite';
+import { defineConfig } from 'vite';
 
-export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, '.', '');
+export default defineConfig(() => {
   return {
-    define: {
-      'process.env.API_KEY': JSON.stringify(env.API_KEY),
-    },
     resolve: {
       alias: {
         '@': path.resolve(__dirname, '.'),


### PR DESCRIPTION
## Summary
- clean up `vite.config.ts` by dropping the unused `process.env.API_KEY` define

## Testing
- `just ci` *(fails: failed to download Swagger UI)*

------
https://chatgpt.com/codex/tasks/task_b_683eaf12dab48328ab9cb3c35dd8a1c8