### PR TITLE
Remove allowJs from tsconfig

### DIFF
--- a/dashboard/tsconfig.json
+++ b/dashboard/tsconfig.json
@@ -13,7 +13,6 @@
     "isolatedModules": true,
     "moduleDetection": "force",
     "noEmit": true,
-    "allowJs": true,
     "jsx": "react-jsx",
 
     /* Linting */


### PR DESCRIPTION
## Summary
- drop unused allowJs option from dashboard tsconfig

## Testing
- `just ci` *(fails: failed to download Swagger UI)*

------
https://chatgpt.com/codex/tasks/task_b_683eaf3ad44c8328b97728ae03f46fe5