### PR TITLE
feat(dashboard): make DataTable page size configurable

### DIFF
--- a/dashboard/components/DataTable.tsx
+++ b/dashboard/components/DataTable.tsx
@@ -3,7 +3,7 @@ import { TimeRange } from '../types';
 import { TimeRangeSelector, RefreshRateInput } from './DashboardHeader';
 import { TAIKO_PINK } from '../theme';
 
-const ROWS_PER_PAGE = 50;
+const DEFAULT_ROWS_PER_PAGE = 50;
 
 interface Column {
   key: string;
@@ -38,6 +38,7 @@ interface DataTableProps {
   refreshRate?: number;
   onRefreshRateChange?: (rate: number) => void;
   chart?: React.ReactNode;
+  rowsPerPage?: number;
 }
 
 export const DataTable: React.FC<DataTableProps> = ({
@@ -54,6 +55,7 @@ export const DataTable: React.FC<DataTableProps> = ({
   refreshRate,
   onRefreshRateChange,
   chart,
+  rowsPerPage = DEFAULT_ROWS_PER_PAGE,
 }) => {
   const [page, setPage] = React.useState(0);
 
@@ -62,12 +64,12 @@ export const DataTable: React.FC<DataTableProps> = ({
   }, [rows]);
 
   const pageRows = React.useMemo(
-    () => rows.slice(page * ROWS_PER_PAGE, (page + 1) * ROWS_PER_PAGE),
-    [rows, page],
+    () => rows.slice(page * rowsPerPage, (page + 1) * rowsPerPage),
+    [rows, page, rowsPerPage],
   );
 
   const disablePrev = page === 0;
-  const disableNext = (page + 1) * ROWS_PER_PAGE >= rows.length;
+  const disableNext = (page + 1) * rowsPerPage >= rows.length;
 
   return (
     <div className="p-4">
@@ -81,7 +83,11 @@ export const DataTable: React.FC<DataTableProps> = ({
           <span>Back</span>
         </button>
         {extraAction && (
-          <button onClick={extraAction.onClick} className="" style={{ color: TAIKO_PINK }}>
+          <button
+            onClick={extraAction.onClick}
+            className=""
+            style={{ color: TAIKO_PINK }}
+          >
             {extraAction.label}
           </button>
         )}
@@ -99,9 +105,7 @@ export const DataTable: React.FC<DataTableProps> = ({
         )}
       </div>
       <h2 className="text-xl font-semibold mb-2">{title}</h2>
-      {description && (
-        <p className="text-gray-600 mb-2">{description}</p>
-      )}
+      {description && <p className="text-gray-600 mb-2">{description}</p>}
       {chart && <div className="h-64 md:h-80 w-full mb-4">{chart}</div>}
       <div className="overflow-x-auto">
         <table className="min-w-full border divide-y divide-gray-200">

--- a/dashboard/tests/dataTable.test.ts
+++ b/dashboard/tests/dataTable.test.ts
@@ -17,7 +17,7 @@ describe('DataTable', () => {
           { a: '1', b: '2' },
           { a: '3', b: '4' },
         ],
-        onBack: () => {},
+        onBack: () => { },
       }),
     );
     expect(html.includes('A')).toBe(true);
@@ -33,8 +33,8 @@ describe('DataTable', () => {
         title: 'Main',
         columns: [{ key: 'x', label: 'X' }],
         rows: [{ x: '10' }],
-        onBack: () => {},
-        extraAction: { label: 'More', onClick: () => {} },
+        onBack: () => { },
+        extraAction: { label: 'More', onClick: () => { } },
         extraTable: {
           title: 'Extra',
           columns: [{ key: 'y', label: 'Y' }],
@@ -53,9 +53,9 @@ describe('DataTable', () => {
         title: 'Range',
         columns: [{ key: 'v', label: 'V' }],
         rows: [{ v: 1 }],
-        onBack: () => {},
+        onBack: () => { },
         timeRange: '1h',
-        onTimeRangeChange: () => {},
+        onTimeRangeChange: () => { },
       }),
     );
     expect(html.includes('1H')).toBe(true);
@@ -69,9 +69,9 @@ describe('DataTable', () => {
         title: 'Refresh',
         columns: [{ key: 'v', label: 'V' }],
         rows: [{ v: 1 }],
-        onBack: () => {},
+        onBack: () => { },
         refreshRate: 60000,
-        onRefreshRateChange: () => {},
+        onRefreshRateChange: () => { },
       }),
     );
     expect(html.includes('Refresh')).toBe(true);
@@ -84,7 +84,7 @@ describe('DataTable', () => {
         title: 'Paged',
         columns: [{ key: 'a', label: 'A' }],
         rows,
-        onBack: () => {},
+        onBack: () => { },
       }),
     );
     expect(html.includes('49')).toBe(true);
@@ -99,12 +99,13 @@ describe('DataTable', () => {
         title: 'Custom',
         columns: [{ key: 'a', label: 'A' }],
         rows,
-        onBack: () => {},
+        onBack: () => { },
         rowsPerPage: 5,
       }),
     );
-    expect(html.includes('4')).toBe(true);
-    expect(html.includes('5')).toBe(false);
+    // Check for actual cell content, not just any occurrence of the character
+    expect(html.includes('>4<')).toBe(true);
+    expect(html.includes('>5<')).toBe(false);
     expect(html.includes('Next')).toBe(true);
   });
 });

--- a/dashboard/tests/dataTable.test.ts
+++ b/dashboard/tests/dataTable.test.ts
@@ -91,4 +91,20 @@ describe('DataTable', () => {
     expect(html.includes('54')).toBe(false);
     expect(html.includes('Next')).toBe(true);
   });
+
+  it('supports custom rows per page', () => {
+    const rows = Array.from({ length: 10 }, (_, i) => ({ a: String(i) }));
+    const html = renderToStaticMarkup(
+      React.createElement(DataTable, {
+        title: 'Custom',
+        columns: [{ key: 'a', label: 'A' }],
+        rows,
+        onBack: () => {},
+        rowsPerPage: 5,
+      }),
+    );
+    expect(html.includes('4')).toBe(true);
+    expect(html.includes('5')).toBe(false);
+    expect(html.includes('Next')).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- allow configuring rows per page for DataTable
- test custom rows-per-page behavior

## Testing
- `npm run check`
- `just ci` *(fails: failed to download Swagger UI)*

------
https://chatgpt.com/codex/tasks/task_b_683eaf2f9d908328bf611846a3120a6a