### PR TITLE
Refactor SSE head endpoints

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -20,7 +20,7 @@ use futures::stream::Stream;
 use hex::encode;
 use runtime::rate_limiter::RateLimiter;
 use serde::Deserialize;
-use std::{convert::Infallible, time::Duration as StdDuration};
+use std::{convert::Infallible, future::Future, time::Duration as StdDuration};
 use utoipa::{IntoParams, OpenApi, ToSchema};
 use utoipa_swagger_ui::SwaggerUi;
 
@@ -257,10 +257,17 @@ async fn l1_head_block(State(state): State<ApiState>) -> Json<L1HeadBlockRespons
     Json(L1HeadBlockResponse { l1_head_block: num })
 }
 
-async fn sse_l2_head(
-    State(state): State<ApiState>,
-) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
-    let mut last = state.client.get_last_l2_block_number().await.ok().flatten().unwrap_or(0);
+async fn sse_head_with<F, Fut>(
+    state: ApiState,
+    mut fetch_fn: F,
+    label: &'static str,
+) -> Sse<impl Stream<Item = Result<Event, Infallible>>>
+where
+    F: FnMut(&ClickhouseReader) -> Fut + Send + 'static,
+    Fut: Future<Output = eyre::Result<Option<u64>>> + Send + 'static,
+{
+    let client = state.client.clone();
+    let mut last = fetch_fn(&client).await.ok().flatten().unwrap_or(0);
     let mut error_count = 0;
     let mut last_successful_fetch = std::time::Instant::now();
 
@@ -271,8 +278,8 @@ async fn sse_l2_head(
         loop {
             // Add timeout to the database query to prevent long-running requests
             let fetch_result = tokio::time::timeout(
-                StdDuration::from_secs(30), // 30 second timeout for database queries
-                state.client.get_last_l2_block_number()
+                StdDuration::from_secs(30),
+                fetch_fn(&client)
             ).await;
 
             match fetch_result {
@@ -289,17 +296,17 @@ async fn sse_l2_head(
                 }
                 Ok(Err(e)) => {
                     error_count += 1;
-                    tracing::error!("Failed to fetch L2 head block (attempt {}): {}", error_count, e);
+                    tracing::error!("Failed to fetch {} head block (attempt {}): {}", label, error_count, e);
 
                     // If we've had many consecutive errors, send the last known value
                     if error_count >= 5 && last_successful_fetch.elapsed() > StdDuration::from_secs(60) {
-                        tracing::warn!("L2 head SSE: Using cached value due to persistent database errors");
+                        tracing::warn!("{} head SSE: Using cached value due to persistent database errors", label);
                         yield Ok(Event::default().data(last.to_string()));
                     }
                 }
                 Err(_timeout) => {
                     error_count += 1;
-                    tracing::error!("Timeout fetching L2 head block (attempt {})", error_count);
+                    tracing::error!("Timeout fetching {} head block (attempt {})", label, error_count);
 
                     // On timeout, send cached value to keep connection alive
                     if error_count >= 3 {
@@ -326,73 +333,16 @@ async fn sse_l2_head(
     Sse::new(stream).keep_alive(keep_alive)
 }
 
+async fn sse_l2_head(
+    State(state): State<ApiState>,
+) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
+    sse_head_with(state, |c| c.get_last_l2_block_number(), "L2").await
+}
+
 async fn sse_l1_head(
     State(state): State<ApiState>,
 ) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
-    let mut last = state.client.get_last_l1_block_number().await.ok().flatten().unwrap_or(0);
-    let mut error_count = 0;
-    let mut last_successful_fetch = std::time::Instant::now();
-
-    let stream = stream! {
-        // send current head immediately
-        yield Ok(Event::default().data(last.to_string()));
-
-        loop {
-            // Add timeout to the database query to prevent long-running requests
-            let fetch_result = tokio::time::timeout(
-                StdDuration::from_secs(30), // 30 second timeout for database queries
-                state.client.get_last_l1_block_number()
-            ).await;
-
-            match fetch_result {
-                Ok(Ok(Some(num))) if num != last => {
-                    last = num;
-                    error_count = 0; // Reset error count on success
-                    last_successful_fetch = std::time::Instant::now();
-                    yield Ok(Event::default().data(num.to_string()));
-                }
-                Ok(Ok(_)) => {
-                    // No change in block number, reset error count
-                    error_count = 0;
-                    last_successful_fetch = std::time::Instant::now();
-                }
-                Ok(Err(e)) => {
-                    error_count += 1;
-                    tracing::error!("Failed to fetch L1 head block (attempt {}): {}", error_count, e);
-
-                    // If we've had many consecutive errors, send the last known value
-                    if error_count >= 5 && last_successful_fetch.elapsed() > StdDuration::from_secs(60) {
-                        tracing::warn!("L1 head SSE: Using cached value due to persistent database errors");
-                        yield Ok(Event::default().data(last.to_string()));
-                    }
-                }
-                Err(_timeout) => {
-                    error_count += 1;
-                    tracing::error!("Timeout fetching L1 head block (attempt {})", error_count);
-
-                    // On timeout, send cached value to keep connection alive
-                    if error_count >= 3 {
-                        yield Ok(Event::default().data(last.to_string()));
-                    }
-                }
-            }
-
-            // Adaptive sleep interval based on error state
-            let sleep_duration = if error_count > 0 {
-                // Back off when there are errors
-                StdDuration::from_secs((error_count as u64).min(10))
-            } else {
-                StdDuration::from_secs(1)
-            };
-
-            tokio::time::sleep(sleep_duration).await;
-        }
-    };
-
-    // More aggressive keep-alive settings to prevent proxy timeouts
-    let keep_alive = KeepAlive::new().interval(StdDuration::from_secs(15)).text("keepalive");
-
-    Sse::new(stream).keep_alive(keep_alive)
+    sse_head_with(state, |c| c.get_last_l1_block_number(), "L1").await
 }
 
 #[utoipa::path(


### PR DESCRIPTION
## Summary
- factor out common SSE code used by l1/l2 head streams

## Testing
- `just ci` *(fails: failed to download Swagger UI)*

------
https://chatgpt.com/codex/tasks/task_b_683eb1693dd88328b8bd18d52dadbf25