### PR TITLE
Add per-client rate limiting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -733,6 +733,7 @@ dependencies = [
  "chrono",
  "clickhouse 0.1.0",
  "clickhouse 0.13.3",
+ "dashmap",
  "eyre",
  "futures",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ tracing-subscriber = { version = "0.3.19", features = ["env-filter", "fmt"] }
 url = { version = "2.5.4", features = ["serde"] }
 tower-http = { version = "0.5.2", features = ["cors", "trace"] }
 tower = "0.5.2"
+dashmap = "6.1"
 utoipa = { version = "5.3", features = ["axum_extras"] }
 utoipa-swagger-ui = { version = "8.1", features = ["axum"] }
 

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -21,6 +21,7 @@ serde.workspace = true
 serde_json.workspace = true
 tower-http.workspace = true
 futures.workspace = true
+dashmap.workspace = true
 utoipa.workspace = true
 utoipa-swagger-ui.workspace = true
 

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -16,6 +16,7 @@ use chrono::{Duration as ChronoDuration, Utc};
 #[cfg(test)]
 use clickhouse_lib::HashBytes;
 use clickhouse_lib::{AddressBytes, ClickhouseReader};
+use dashmap::DashMap;
 use futures::stream::Stream;
 use hex::encode;
 use runtime::rate_limiter::RateLimiter;
@@ -115,16 +116,35 @@ pub const DEFAULT_RATE_PERIOD: StdDuration = StdDuration::from_secs(60);
 pub struct ApiDoc;
 
 /// Shared state for API handlers.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct ApiState {
     client: ClickhouseReader,
-    limiter: RateLimiter,
+    limiters: std::sync::Arc<DashMap<std::net::IpAddr, RateLimiter>>,
+    max_requests: u64,
+    rate_period: StdDuration,
+}
+
+impl std::fmt::Debug for ApiState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiState")
+            .field("max_requests", &self.max_requests)
+            .field("rate_period", &self.rate_period)
+            .finish_non_exhaustive()
+    }
 }
 
 impl ApiState {
     /// Create a new [`ApiState`].
     pub fn new(client: ClickhouseReader, max_requests: u64, rate_period: StdDuration) -> Self {
-        Self { client, limiter: RateLimiter::new(max_requests, rate_period) }
+        Self { client, limiters: std::sync::Arc::new(DashMap::new()), max_requests, rate_period }
+    }
+
+    fn try_acquire(&self, ip: std::net::IpAddr) -> bool {
+        self.limiters
+            .entry(ip)
+            .or_insert_with(|| RateLimiter::new(self.max_requests, self.rate_period))
+            .value_mut()
+            .try_acquire()
     }
 }
 
@@ -1069,7 +1089,16 @@ async fn rate_limit(
     req: axum::http::Request<axum::body::Body>,
     next: middleware::Next,
 ) -> axum::response::Response {
-    if state.limiter.try_acquire() {
+    use axum::extract::connect_info::ConnectInfo;
+    use std::net::{IpAddr, Ipv4Addr};
+
+    let ip = req
+        .extensions()
+        .get::<ConnectInfo<std::net::SocketAddr>>()
+        .map(|c| c.0.ip())
+        .unwrap_or(IpAddr::V4(Ipv4Addr::UNSPECIFIED));
+
+    if state.try_acquire(ip) {
         next.run(req).await
     } else {
         axum::http::StatusCode::TOO_MANY_REQUESTS.into_response()

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -59,6 +59,6 @@ pub async fn run(
 
     info!("Starting API server on {}", addr);
     let listener = tokio::net::TcpListener::bind(addr).await?;
-    axum::serve(listener, app).await?;
+    axum::serve(listener, app.into_make_service_with_connect_info::<SocketAddr>()).await?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- store per-client limiters in `ApiState`
- use client IP when applying rate limits
- expose connection info when serving API
- adjust API integration test harness
- include dashmap dependency

## Testing
- `SWAGGER_UI_DOWNLOAD_URL=file://$(pwd)/dummy_swagger.zip just ci`

------
https://chatgpt.com/codex/tasks/task_b_683eb15fcb008328b93a64d02fafdfc7