### PR TITLE
Fix sequencer name truncation

### DIFF
--- a/dashboard/components/MetricCard.tsx
+++ b/dashboard/components/MetricCard.tsx
@@ -18,6 +18,7 @@ export const MetricCard: React.FC<MetricCardProps> = ({
 }) => {
   // Check if value looks like an Ethereum address (0x followed by 40 hex characters)
   const isAddress = /^0x[a-fA-F0-9]{40}$/.test(value);
+  const isShortValue = !isAddress && value.length <= 16;
 
   return (
     <div
@@ -36,7 +37,7 @@ export const MetricCard: React.FC<MetricCardProps> = ({
         )}
       </div>
       <p
-        className={`mt-1 font-semibold text-gray-900 ${isAddress ? 'text-base sm:text-lg break-all' : 'text-3xl whitespace-nowrap overflow-hidden text-ellipsis'}`}
+        className={`mt-1 font-semibold text-gray-900 ${isAddress ? 'text-base sm:text-lg break-all' : `text-3xl${isShortValue ? '' : ' whitespace-nowrap overflow-hidden text-ellipsis'}`}`}
       >
         {value}
       </p>

--- a/dashboard/tests/dataTable.test.ts
+++ b/dashboard/tests/dataTable.test.ts
@@ -17,7 +17,7 @@ describe('DataTable', () => {
           { a: '1', b: '2' },
           { a: '3', b: '4' },
         ],
-        onBack: () => {},
+        onBack: () => { },
       }),
     );
     expect(html.includes('A')).toBe(true);
@@ -33,8 +33,8 @@ describe('DataTable', () => {
         title: 'Main',
         columns: [{ key: 'x', label: 'X' }],
         rows: [{ x: '10' }],
-        onBack: () => {},
-        extraAction: { label: 'More', onClick: () => {} },
+        onBack: () => { },
+        extraAction: { label: 'More', onClick: () => { } },
         extraTable: {
           title: 'Extra',
           columns: [{ key: 'y', label: 'Y' }],
@@ -53,9 +53,9 @@ describe('DataTable', () => {
         title: 'Range',
         columns: [{ key: 'v', label: 'V' }],
         rows: [{ v: 1 }],
-        onBack: () => {},
+        onBack: () => { },
         timeRange: '1h',
-        onTimeRangeChange: () => {},
+        onTimeRangeChange: () => { },
       }),
     );
     expect(html.includes('1H')).toBe(true);
@@ -69,9 +69,9 @@ describe('DataTable', () => {
         title: 'Refresh',
         columns: [{ key: 'v', label: 'V' }],
         rows: [{ v: 1 }],
-        onBack: () => {},
+        onBack: () => { },
         refreshRate: 60000,
-        onRefreshRateChange: () => {},
+        onRefreshRateChange: () => { },
       }),
     );
     expect(html.includes('Refresh')).toBe(true);
@@ -84,7 +84,7 @@ describe('DataTable', () => {
         title: 'Paged',
         columns: [{ key: 'a', label: 'A' }],
         rows,
-        onBack: () => {},
+        onBack: () => { },
       }),
     );
     expect(html.includes('49')).toBe(true);

--- a/dashboard/tests/metricCard.test.ts
+++ b/dashboard/tests/metricCard.test.ts
@@ -25,7 +25,17 @@ describe('MetricCard', () => {
       React.createElement(MetricCard, { title: 'Blocks', value: '42' }),
     );
     expect(htmlNormal.includes('min-w-0 w-full')).toBe(false);
-    expect(htmlNormal.includes('text-3xl whitespace-nowrap overflow-hidden text-ellipsis')).toBe(true);
+    expect(htmlNormal.includes('text-3xl')).toBe(true);
+    expect(htmlNormal.includes('whitespace-nowrap')).toBe(false);
     expect(htmlNormal.includes('42')).toBe(true);
+  });
+
+  it('truncates long values with ellipsis', () => {
+    const longValue = 'Chainbound extremely long name';
+    const html = renderToStaticMarkup(
+      React.createElement(MetricCard, { title: 'Current', value: longValue }),
+    );
+    expect(html.includes('whitespace-nowrap')).toBe(true);
+    expect(html.includes('overflow-hidden')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- avoid truncating short metric values in dashboard cards
- test short and long values

## Testing
- `npm run check`
- `npm run test`
- `just ci` *(fails: failed to download Swagger UI)*

------
https://chatgpt.com/codex/tasks/task_b_683eb2ae8e8483288f13dcf4f4202bc9