### PR TITLE
Add test for short sequencer names

### DIFF
--- a/dashboard/tests/metricCard.test.ts
+++ b/dashboard/tests/metricCard.test.ts
@@ -38,4 +38,15 @@ describe('MetricCard', () => {
     expect(html.includes('whitespace-nowrap')).toBe(true);
     expect(html.includes('overflow-hidden')).toBe(true);
   });
+
+  it('does not truncate short sequencer names', () => {
+    const names = ['Nethermind A', 'Chainbound B', 'Gattaca C'];
+    for (const name of names) {
+      const html = renderToStaticMarkup(
+        React.createElement(MetricCard, { title: 'Current', value: name }),
+      );
+      expect(html.includes('whitespace-nowrap')).toBe(false);
+      expect(html.includes('overflow-hidden')).toBe(false);
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- add test case to ensure sequencer names under 16 chars are not truncated

## Testing
- `just ci` *(fails: failed to download Swagger UI)*

------
https://chatgpt.com/codex/tasks/task_b_683ebe308f808328aaa7a7802e717ed9