### PR TITLE
Expand brush on dashboard time range change

### DIFF
--- a/dashboard/components/BatchProcessChart.tsx
+++ b/dashboard/components/BatchProcessChart.tsx
@@ -38,13 +38,13 @@ export const BatchProcessChart: React.FC<BatchProcessChartProps> = ({
     formatBatchDuration(value, showHours, showMinutes);
 
   const [brushRange, setBrushRange] = useState({
-    startIndex: Math.max(0, data.length - 50),
+    startIndex: 0,
     endIndex: data.length - 1,
   });
 
   useEffect(() => {
     setBrushRange({
-      startIndex: Math.max(0, data.length - 50),
+      startIndex: 0,
       endIndex: data.length - 1,
     });
   }, [data]);

--- a/dashboard/components/BlobsPerBatchChart.tsx
+++ b/dashboard/components/BlobsPerBatchChart.tsx
@@ -29,13 +29,13 @@ export const BlobsPerBatchChart: React.FC<BlobsPerBatchChartProps> = ({
   }
 
   const [brushRange, setBrushRange] = useState({
-    startIndex: Math.max(0, data.length - 50),
+    startIndex: 0,
     endIndex: data.length - 1,
   });
 
   useEffect(() => {
     setBrushRange({
-      startIndex: Math.max(0, data.length - 50),
+      startIndex: 0,
       endIndex: data.length - 1,
     });
   }, [data]);

--- a/dashboard/components/BlockTimeChart.tsx
+++ b/dashboard/components/BlockTimeChart.tsx
@@ -30,13 +30,13 @@ export const BlockTimeChart: React.FC<BlockTimeChartProps> = ({
   }
   const showMinutes = shouldShowMinutes(data);
   const [brushRange, setBrushRange] = useState({
-    startIndex: Math.max(0, data.length - 50),
+    startIndex: 0,
     endIndex: data.length - 1,
   });
 
   useEffect(() => {
     setBrushRange({
-      startIndex: Math.max(0, data.length - 50),
+      startIndex: 0,
       endIndex: data.length - 1,
     });
   }, [data]);

--- a/dashboard/components/BlockTxChart.tsx
+++ b/dashboard/components/BlockTxChart.tsx
@@ -33,13 +33,13 @@ export const BlockTxChart: React.FC<BlockTxChartProps> = ({
   );
 
   const [brushRange, setBrushRange] = useState({
-    startIndex: Math.max(0, sortedData.length - 50),
+    startIndex: 0,
     endIndex: sortedData.length - 1,
   });
 
   useEffect(() => {
     setBrushRange({
-      startIndex: Math.max(0, sortedData.length - 50),
+      startIndex: 0,
       endIndex: sortedData.length - 1,
     });
   }, [sortedData]);

--- a/dashboard/components/GasUsedChart.tsx
+++ b/dashboard/components/GasUsedChart.tsx
@@ -29,13 +29,13 @@ export const GasUsedChart: React.FC<GasUsedChartProps> = ({
     );
   }
   const [brushRange, setBrushRange] = useState({
-    startIndex: Math.max(0, data.length - 50),
+    startIndex: 0,
     endIndex: data.length - 1,
   });
 
   useEffect(() => {
     setBrushRange({
-      startIndex: Math.max(0, data.length - 50),
+      startIndex: 0,
       endIndex: data.length - 1,
     });
   }, [data]);

--- a/dashboard/components/ReorgDepthChart.tsx
+++ b/dashboard/components/ReorgDepthChart.tsx
@@ -16,7 +16,6 @@ interface ReorgDepthChartProps {
   data: L2ReorgEvent[];
 }
 
-
 export const ReorgDepthChart: React.FC<ReorgDepthChartProps> = ({ data }) => {
   if (!data || data.length === 0) {
     return (
@@ -27,13 +26,13 @@ export const ReorgDepthChart: React.FC<ReorgDepthChartProps> = ({ data }) => {
   }
 
   const [brushRange, setBrushRange] = useState({
-    startIndex: Math.max(0, data.length - 50),
+    startIndex: 0,
     endIndex: data.length - 1,
   });
 
   useEffect(() => {
     setBrushRange({
-      startIndex: Math.max(0, data.length - 50),
+      startIndex: 0,
       endIndex: data.length - 1,
     });
   }, [data]);


### PR DESCRIPTION
## Summary
- reset brush state to full range when chart data updates so changing the time range leaves the brush fully expanded

## Testing
- `just ci` *(fails: failed to download Swagger UI)*

------
https://chatgpt.com/codex/tasks/task_b_683ec0750e2c83289e8264e07bbc819b