### PR TITLE
Fix brush axis for gas used chart

### DIFF
--- a/dashboard/components/GasUsedChart.tsx
+++ b/dashboard/components/GasUsedChart.tsx
@@ -109,7 +109,7 @@ export const GasUsedChart: React.FC<GasUsedChartProps> = ({
           name="Gas Used"
         />
         <Brush
-          dataKey="value"
+          dataKey="timestamp"
           height={20}
           stroke={lineColor}
           startIndex={brushRange.startIndex}


### PR DESCRIPTION
## Summary
- use timestamp data for GasUsedChart brush to filter by time

## Testing
- `just ci` *(fails: failed to download Swagger UI)*

------
https://chatgpt.com/codex/tasks/task_b_683ec20d72f08328a1093edcd690a173