### PR TITLE
Add server router tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3801,11 +3801,17 @@ version = "0.1.0"
 dependencies = [
  "api",
  "axum",
+ "chrono",
  "clickhouse 0.1.0",
+ "clickhouse 0.13.3",
  "eyre",
+ "serde",
+ "serde_json",
  "tokio",
+ "tower",
  "tower-http",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -16,3 +16,11 @@ eyre.workspace = true
 
 [lints]
 workspace = true
+
+[dev-dependencies]
+chrono.workspace = true
+clickhouse.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tower.workspace = true
+url.workspace = true

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -62,3 +62,91 @@ pub async fn run(
     axum::serve(listener, app.into_make_service_with_connect_info::<SocketAddr>()).await?;
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use api::{ApiState, DEFAULT_MAX_REQUESTS, DEFAULT_RATE_PERIOD};
+    use axum::{
+        body::{self, Body},
+        http::{Request, StatusCode},
+    };
+    use chrono::Utc;
+    use clickhouse::{
+        Row,
+        test::{Mock, handlers},
+    };
+    use serde::Serialize;
+    use serde_json::{Value, json};
+    use tower::util::ServiceExt;
+    use url::Url;
+
+    #[derive(Serialize, Row)]
+    struct MaxRow {
+        block_ts: u64,
+    }
+
+    fn build_app(mock_url: &str, extra: Vec<String>) -> Router {
+        let url = Url::parse(mock_url).unwrap();
+        let client =
+            ClickhouseReader::new(url, "db".to_owned(), "user".into(), "pass".into()).unwrap();
+        let state = ApiState::new(client, DEFAULT_MAX_REQUESTS, DEFAULT_RATE_PERIOD);
+        router(state, extra)
+    }
+
+    async fn send_request(app: Router, origin: &str) -> (StatusCode, Value, Option<String>) {
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/{API_VERSION}/l2-head"))
+                    .header("Origin", origin)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        let cors = response
+            .headers()
+            .get("access-control-allow-origin")
+            .and_then(|v| v.to_str().ok())
+            .map(ToOwned::to_owned);
+        let bytes = body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body: Value = serde_json::from_slice(&bytes).unwrap();
+        (status, body, cors)
+    }
+
+    #[tokio::test]
+    async fn allows_default_origin() {
+        let mock = Mock::new();
+        mock.add(handlers::provide(vec![MaxRow { block_ts: 1 }]));
+        let app = build_app(mock.url(), vec![]);
+        let (status, body, cors) = send_request(app, "https://taikoscope.xyz").await;
+        let expected = json!({
+            "last_l2_head_time": Utc.timestamp_opt(1, 0).single().unwrap().to_rfc3339()
+        });
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, expected);
+        assert_eq!(cors.as_deref(), Some("https://taikoscope.xyz"));
+    }
+
+    #[tokio::test]
+    async fn allows_extra_origin() {
+        let mock = Mock::new();
+        mock.add(handlers::provide(vec![MaxRow { block_ts: 1 }]));
+        let app = build_app(mock.url(), vec!["https://example.com".to_string()]);
+        let (status, _, cors) = send_request(app, "https://example.com").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(cors.as_deref(), Some("https://example.com"));
+    }
+
+    #[tokio::test]
+    async fn denies_other_origin() {
+        let mock = Mock::new();
+        mock.add(handlers::provide(vec![MaxRow { block_ts: 1 }]));
+        let app = build_app(mock.url(), vec![]);
+        let (status, _, cors) = send_request(app, "https://notallowed.com").await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(cors.is_none());
+    }
+}

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -71,7 +71,7 @@ mod tests {
         body::{self, Body},
         http::{Request, StatusCode},
     };
-    use chrono::Utc;
+    use chrono::{TimeZone, Utc};
     use clickhouse::{
         Row,
         test::{Mock, handlers},
@@ -134,7 +134,7 @@ mod tests {
     async fn allows_extra_origin() {
         let mock = Mock::new();
         mock.add(handlers::provide(vec![MaxRow { block_ts: 1 }]));
-        let app = build_app(mock.url(), vec!["https://example.com".to_string()]);
+        let app = build_app(mock.url(), vec!["https://example.com".to_owned()]);
         let (status, _, cors) = send_request(app, "https://example.com").await;
         assert_eq!(status, StatusCode::OK);
         assert_eq!(cors.as_deref(), Some("https://example.com"));


### PR DESCRIPTION
## Summary
- add integration-style unit tests for server router

## Testing
- `cargo +nightly fmt --all`
- `just ci` *(fails: failed to download Swagger UI during build)*

------
https://chatgpt.com/codex/tasks/task_b_683ebfc5cd808328b04aa4a00d45d605