### PR TITLE
Improve brush labels for graphs

### DIFF
--- a/dashboard/components/BlockTimeChart.tsx
+++ b/dashboard/components/BlockTimeChart.tsx
@@ -10,7 +10,7 @@ import {
   Brush,
 } from 'recharts';
 import { TimeSeriesData } from '../types';
-import { formatDecimal, formatInterval, shouldShowMinutes } from '../utils';
+import { formatDecimal, formatInterval, shouldShowMinutes, formatTime } from '../utils';
 
 interface BlockTimeChartProps {
   data: TimeSeriesData[];
@@ -120,7 +120,7 @@ export const BlockTimeChart: React.FC<BlockTimeChartProps> = ({
           startIndex={brushRange.startIndex}
           endIndex={brushRange.endIndex}
           onChange={handleBrushChange}
-          tickFormatter={(v: number) => formatInterval(v, showMinutes)}
+          tickFormatter={(v: number) => formatTime(v)}
         />
       </LineChart>
     </ResponsiveContainer>

--- a/dashboard/components/GasUsedChart.tsx
+++ b/dashboard/components/GasUsedChart.tsx
@@ -10,7 +10,7 @@ import {
   Brush,
 } from 'recharts';
 import { TimeSeriesData } from '../types';
-import { formatLargeNumber } from '../utils';
+import { formatLargeNumber, formatTime } from '../utils';
 
 interface GasUsedChartProps {
   data: TimeSeriesData[];
@@ -115,7 +115,7 @@ export const GasUsedChart: React.FC<GasUsedChartProps> = ({
           startIndex={brushRange.startIndex}
           endIndex={brushRange.endIndex}
           onChange={handleBrushChange}
-          tickFormatter={(v: number) => v.toLocaleString()}
+          tickFormatter={(v: number) => formatTime(v)}
         />
       </LineChart>
     </ResponsiveContainer>

--- a/dashboard/utils.ts
+++ b/dashboard/utils.ts
@@ -23,6 +23,14 @@ export const formatLargeNumber = (value: number): string => {
   return value.toLocaleString();
 };
 
+export const formatTime = (ms: number): string =>
+  new Date(ms).toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  });
+
 export const formatInterval = (ms: number, showMinutes: boolean): string => {
   return showMinutes
     ? `${formatDecimal(ms / 60000)} minutes`


### PR DESCRIPTION
## Summary
- show human readable time in brush tick labels
- expose a helper `formatTime`

## Testing
- `just ci` *(fails: couldn't download Swagger UI)*
- `npm --prefix dashboard run check`

------
https://chatgpt.com/codex/tasks/task_b_683ec3b9fbfc8328802ba2534d1a0554