### PR TITLE
Integrate API error type in dashboard

### DIFF
--- a/dashboard/tests/apiService.test.ts
+++ b/dashboard/tests/apiService.test.ts
@@ -30,6 +30,7 @@ describe('apiService', () => {
     globalThis.fetch = mockFetch({ avg_prove_time_ms: 42 });
     const prove = await fetchAvgProveTime('1h');
     expect(prove.badRequest).toBe(false);
+    expect(prove.error).toBeNull();
     expect(prove.data).toBe(42);
   });
 
@@ -37,6 +38,7 @@ describe('apiService', () => {
     globalThis.fetch = mockFetch({}, 400, false);
     const badProve = await fetchAvgProveTime('1h');
     expect(badProve.badRequest).toBe(true);
+    expect(badProve.error).toStrictEqual({});
     expect(badProve.data).toBeNull();
   });
 
@@ -60,6 +62,7 @@ describe('apiService', () => {
       ],
     });
     const blockTimes = await fetchL2BlockTimes('1h');
+    expect(blockTimes.error).toBeNull();
     expect(blockTimes.data).toStrictEqual([{ value: 2, timestamp: 20 }]);
   });
 
@@ -68,6 +71,7 @@ describe('apiService', () => {
       blocks: [{ block: 1, txs: 3, sequencer: '0xabc' }],
     });
     const txs = await fetchBlockTransactions('1h');
+    expect(txs.error).toBeNull();
     expect(txs.data).toStrictEqual([{ block: 1, txs: 3, sequencer: '0xabc' }]);
   });
 
@@ -75,6 +79,7 @@ describe('apiService', () => {
     globalThis.fetch = mockFetch({ avg_tps: 1.5 });
     const res = await fetchAvgL2Tps('1h');
     expect(res.badRequest).toBe(false);
+    expect(res.error).toBeNull();
     expect(res.data).toBe(1.5);
   });
 
@@ -82,6 +87,7 @@ describe('apiService', () => {
     globalThis.fetch = mockFetch({}, 400, false);
     const res = await fetchAvgL2Tps('1h');
     expect(res.badRequest).toBe(true);
+    expect(res.error).toStrictEqual({});
     expect(res.data).toBeNull();
   });
 });

--- a/dashboard/tests/helpers.test.ts
+++ b/dashboard/tests/helpers.test.ts
@@ -18,8 +18,8 @@ const metrics = createMetrics({
 });
 
 const results = [
-  { badRequest: false, data: null },
-  { badRequest: true, data: null },
+  { badRequest: false, data: null, error: null },
+  { badRequest: true, data: null, error: null },
 ];
 
 const metricsAllNull = createMetrics({
@@ -70,7 +70,9 @@ describe('helpers', () => {
 
   it('detects bad requests', () => {
     expect(hasBadRequest(results)).toBe(true);
-    expect(hasBadRequest([{ badRequest: false, data: null }])).toBe(false);
+    expect(
+      hasBadRequest([{ badRequest: false, data: null, error: null }]),
+    ).toBe(false);
   });
 
   it('handles null metrics', () => {
@@ -95,8 +97,8 @@ describe('helpers', () => {
   it('handles all successful requests', () => {
     expect(
       hasBadRequest([
-        { badRequest: false, data: null },
-        { badRequest: false, data: null },
+        { badRequest: false, data: null, error: null },
+        { badRequest: false, data: null, error: null },
       ]),
     ).toBe(false);
   });

--- a/dashboard/types.ts
+++ b/dashboard/types.ts
@@ -35,3 +35,10 @@ export interface SlashingEvent {
 export interface ForcedInclusionEvent {
   blob_hash: number[];
 }
+
+export interface ErrorResponse {
+  type: string;
+  title: string;
+  status: number;
+  detail: string;
+}


### PR DESCRIPTION
## Summary
- expose `ErrorResponse` type in dashboard
- parse API error responses in `fetchJson`
- return parsed error info from service helpers
- adjust dashboard tests for new structure

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_683ee22a7c0483289b61bc8f29149f87