### PR TITLE
Move status page link before time range selector

### DIFF
--- a/dashboard/components/DashboardHeader.tsx
+++ b/dashboard/components/DashboardHeader.tsx
@@ -34,6 +34,8 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({
           {/* Updated Taiko Pink */}
           Taiko Masaya Testnet
         </h1>
+      </div>
+      <div className="flex items-center space-x-2 mt-4 md:mt-0">
         <a
           href="https://taikoscope.instatus.com/"
           target="_blank"
@@ -43,8 +45,6 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({
         >
           Status Page
         </a>
-      </div>
-      <div className="flex items-center space-x-2 mt-4 md:mt-0">
         <TimeRangeSelector
           currentTimeRange={timeRange}
           onTimeRangeChange={onTimeRangeChange}


### PR DESCRIPTION
## Summary
- reposition status page link so it's before the time range selector in the dashboard header

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_683ef0720104832895cc12dd35f468f1