### PR TITLE
Add sequencer details page

### DIFF
--- a/dashboard/components/DashboardHeader.tsx
+++ b/dashboard/components/DashboardHeader.tsx
@@ -10,9 +10,11 @@ interface DashboardHeaderProps {
   onRefreshRateChange: (rate: number) => void;
   lastRefresh: number;
   onManualRefresh: () => void;
-  sequencers: string[];
-  selectedSequencer: string | null;
-  onSequencerChange: (seq: string | null) => void;
+  isSequencerPage: boolean;
+  onNavigate: () => void;
+  sequencers?: string[];
+  selectedSequencer?: string | null;
+  onSequencerChange?: (seq: string | null) => void;
 }
 
 export const DashboardHeader: React.FC<DashboardHeaderProps> = ({
@@ -22,6 +24,8 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({
   onRefreshRateChange,
   lastRefresh,
   onManualRefresh,
+  isSequencerPage,
+  onNavigate,
   sequencers,
   selectedSequencer,
   onSequencerChange,
@@ -58,11 +62,20 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({
           lastRefresh={lastRefresh}
           onRefresh={onManualRefresh}
         />
-        <SequencerSelector
-          sequencers={sequencers}
-          value={selectedSequencer}
-          onChange={onSequencerChange}
-        />
+        {isSequencerPage && sequencers && onSequencerChange ? (
+          <SequencerSelector
+            sequencers={sequencers}
+            value={selectedSequencer ?? null}
+            onChange={onSequencerChange}
+          />
+        ) : null}
+        <button
+          className="text-sm hover:underline"
+          style={{ color: TAIKO_PINK }}
+          onClick={onNavigate}
+        >
+          {isSequencerPage ? 'Dashboard' : 'Sequencer Details'}
+        </button>
         {/* Export button removed as per request */}
       </div>
     </header>

--- a/dashboard/tests/dashboardHeader.test.ts
+++ b/dashboard/tests/dashboardHeader.test.ts
@@ -13,9 +13,8 @@ describe('DashboardHeader', () => {
         onRefreshRateChange: () => {},
         lastRefresh: Date.now(),
         onManualRefresh: () => {},
-        sequencers: ['seq1', 'seq2'],
-        selectedSequencer: null,
-        onSequencerChange: () => {},
+        isSequencerPage: false,
+        onNavigate: () => {},
       }),
     );
     expect(html.includes('Taiko Masaya Testnet')).toBe(true);
@@ -24,5 +23,6 @@ describe('DashboardHeader', () => {
     expect(html.includes('7D')).toBe(true);
     expect(html.includes('Refresh')).toBe(true);
     expect(html.includes('Status')).toBe(true);
+    expect(html.includes('Sequencer Details')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- remove sequencer filter from main dashboard header
- allow navigating to a sequencer details page
- hide Active Sequencers and Next Sequencer metrics on that page
- update DashboardHeader tests

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_683eef86f96c83289a988a1563423e46