### PR TITLE
Persist sequencer filter in dashboard URL

### DIFF
--- a/dashboard/App.tsx
+++ b/dashboard/App.tsx
@@ -76,9 +76,10 @@ import {
 } from './services/apiService';
 
 const App: React.FC = () => {
+  const searchParams = useSearchParams();
   const [timeRange, setTimeRange] = useState<TimeRange>('1h');
   const [selectedSequencer, setSelectedSequencer] = useState<string | null>(
-    null,
+    searchParams.get('sequencer'),
   );
   const [metrics, setMetrics] = useState<MetricData[]>([]);
   const [loadingMetrics, setLoadingMetrics] = useState(true);
@@ -121,6 +122,25 @@ const App: React.FC = () => {
     selectedSequencer,
     blockTxData,
     l2BlockTimeData,
+  );
+
+  useEffect(() => {
+    const seq = searchParams.get('sequencer');
+    setSelectedSequencer(seq ?? null);
+  }, [searchParams]);
+
+  const handleSequencerChange = useCallback(
+    (seq: string | null) => {
+      setSelectedSequencer(seq);
+      const url = new URL(window.location.href);
+      if (seq) {
+        url.searchParams.set('sequencer', seq);
+      } else {
+        url.searchParams.delete('sequencer');
+      }
+      window.history.pushState(null, '', url);
+    },
+    [],
   );
 
   useEffect(() => {
@@ -406,8 +426,6 @@ const App: React.FC = () => {
     [selectedSequencer],
   );
 
-  const searchParams = useSearchParams();
-
   const handleRouteChange = useCallback(() => {
     const params = searchParams;
     if (params.get('view') !== 'table') {
@@ -497,7 +515,7 @@ const App: React.FC = () => {
         onManualRefresh={handleManualRefresh}
         sequencers={sequencerList}
         selectedSequencer={selectedSequencer}
-        onSequencerChange={setSelectedSequencer}
+        onSequencerChange={handleSequencerChange}
       />
 
       {errorMessage && (


### PR DESCRIPTION
## Summary
- keep current sequencer selection in URL
- sync selected sequencer with query parameter when navigating

## Testing
- `npm run check`
- `npm run test`
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_683efb12fcf88328abb40ba00b733a9c