### PR TITLE
Improve selected sequencer view

### DIFF
--- a/dashboard/App.tsx
+++ b/dashboard/App.tsx
@@ -37,6 +37,11 @@ const BlobsPerBatchChart = lazy(() =>
     default: m.BlobsPerBatchChart,
   })),
 );
+const SequencerBlockTable = lazy(() =>
+  import('./components/SequencerBlockTable').then((m) => ({
+    default: m.SequencerBlockTable,
+  })),
+);
 import {
   TimeRange,
   TimeSeriesData,
@@ -561,13 +566,21 @@ const App: React.FC = () => {
 
         {/* Charts Grid - Reordered: Sequencer Pie Chart first */}
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 md:gap-6 mt-6">
-          {!selectedSequencer && (
+          {!selectedSequencer ? (
             <ChartCard
               title="Sequencer Distribution"
               onMore={() => openSequencerDistributionTable(timeRange, 0)}
               loading={loadingMetrics}
             >
               <SequencerPieChart key={timeRange} data={sequencerDistribution} />
+            </ChartCard>
+          ) : (
+            <ChartCard
+              title={`Blocks by ${selectedSequencer}`}
+              onMore={() => openSequencerDistributionTable(timeRange, 0)}
+              loading={loadingMetrics}
+            >
+              <SequencerBlockTable key={timeRange} data={blockTxData} />
             </ChartCard>
           )}
           <ChartCard

--- a/dashboard/components/SequencerBlockTable.tsx
+++ b/dashboard/components/SequencerBlockTable.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import type { BlockTransaction } from '../services/apiService';
+
+interface SequencerBlockTableProps {
+  data: BlockTransaction[];
+}
+
+export const SequencerBlockTable: React.FC<SequencerBlockTableProps> = ({ data }) => {
+  if (!data || data.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-full text-gray-500">
+        No data available
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto h-full">
+      <table className="min-w-full border divide-y divide-gray-200 text-sm">
+        <thead>
+          <tr>
+            <th className="px-2 py-1 text-left">Block Number</th>
+            <th className="px-2 py-1 text-left">Tx Count</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((row, idx) => (
+            <tr key={idx} className="border-t">
+              <td className="px-2 py-1">{row.block}</td>
+              <td className="px-2 py-1">{row.txs}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};

--- a/dashboard/tests/sequencerBlockTable.test.ts
+++ b/dashboard/tests/sequencerBlockTable.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { SequencerBlockTable } from '../components/SequencerBlockTable';
+
+describe('SequencerBlockTable', () => {
+  it('renders rows', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(SequencerBlockTable, {
+        data: [
+          { block: 1, txs: 2, sequencer: '0xabc' },
+          { block: 2, txs: 3, sequencer: '0xabc' },
+        ],
+      }),
+    );
+    expect(html.includes('Block Number')).toBe(true);
+    expect(html.includes('Tx Count')).toBe(true);
+    expect(html.includes('>1<')).toBe(true);
+    expect(html.includes('>3<')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- show the blocks proposed by the selected sequencer in a chart card
- add SequencerBlockTable component for compact table display
- test new SequencerBlockTable

## Testing
- `just check-dashboard`
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_683efb4a67a08328bfec1b35f1f4723a