### PR TITLE
Add detailed batch posting cadence view

### DIFF
--- a/crates/api-types/src/lib.rs
+++ b/crates/api-types/src/lib.rs
@@ -5,8 +5,9 @@
 //! depend on them without pulling in the rest of the server implementation.
 
 use clickhouse_lib::{
-    BatchBlobCountRow, BatchProveTimeRow, BatchVerifyTimeRow, ForcedInclusionProcessedRow,
-    L1BlockTimeRow, L2BlockTimeRow, L2GasUsedRow, L2ReorgRow, SlashingEventRow,
+    BatchBlobCountRow, BatchPostingTimeRow, BatchProveTimeRow, BatchVerifyTimeRow,
+    ForcedInclusionProcessedRow, L1BlockTimeRow, L2BlockTimeRow, L2GasUsedRow, L2ReorgRow,
+    SlashingEventRow,
 };
 
 use axum::{Json, http::StatusCode, response::IntoResponse};
@@ -243,6 +244,13 @@ pub struct BatchBlobsResponse {
 pub struct AvgBlobsPerBatchResponse {
     /// Average number of blobs per batch.
     pub avg_blobs: Option<f64>,
+}
+
+/// Interval between consecutive batch postings.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct BatchPostingTimesResponse {
+    /// Interval data for each batch.
+    pub batches: Vec<BatchPostingTimeRow>,
 }
 
 /// Number of the most recent L2 block.

--- a/crates/clickhouse/src/models.rs
+++ b/crates/clickhouse/src/models.rs
@@ -205,3 +205,14 @@ pub struct BatchBlobCountRow {
     /// Number of blobs in the batch
     pub blob_count: u8,
 }
+
+/// Row representing the interval between consecutive batch proposals
+#[derive(Debug, Row, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+pub struct BatchPostingTimeRow {
+    /// Batch ID
+    pub batch_id: u64,
+    /// Time the batch was inserted
+    pub inserted_at: DateTime<Utc>,
+    /// Milliseconds since the previous batch
+    pub ms_since_prev_batch: Option<u64>,
+}

--- a/dashboard/App.tsx
+++ b/dashboard/App.tsx
@@ -550,6 +550,9 @@ const App: React.FC = () => {
                               : typeof m.title === 'string' &&
                                   m.title === 'Active Sequencers'
                                 ? () => openGenericTable('gateways')
+                                : typeof m.title === 'string' &&
+                                    m.title === 'Batch Posting Cadence'
+                                  ? () => openGenericTable('batch-posting-cadence')
                                 : undefined
                     }
                   />

--- a/dashboard/config/tableConfig.ts
+++ b/dashboard/config/tableConfig.ts
@@ -6,6 +6,7 @@ import {
   fetchForcedInclusionEvents,
   fetchActiveGatewayAddresses,
   fetchBatchBlobCounts,
+  fetchBatchPostingTimes,
   fetchProveTimes,
   fetchVerifyTimes,
   fetchBlockTransactions,
@@ -102,6 +103,23 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
     ],
     mapData: (data) => data as Record<string, string | number>[],
     urlKey: 'blobs-per-batch'
+  },
+
+  'batch-posting-cadence': {
+    title: 'Batch Posting Cadence',
+    fetcher: fetchBatchPostingTimes,
+    columns: [
+      { key: 'value', label: 'Batch' },
+      { key: 'timestamp', label: 'Interval (ms)' }
+    ],
+    mapData: (data) => data as Record<string, string | number>[],
+    chart: (data) => {
+      const BlockTimeChart = React.lazy(() =>
+        import('../components/BlockTimeChart').then(m => ({ default: m.BlockTimeChart }))
+      );
+      return React.createElement(BlockTimeChart, { data, lineColor: '#FF9DA7' });
+    },
+    urlKey: 'batch-posting-cadence'
   },
 
   'prove-time': {

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -349,6 +349,25 @@ export const fetchL2BlockTimes = async (
   return { data, badRequest: res.badRequest, error: res.error };
 };
 
+export const fetchBatchPostingTimes = async (
+  range: '1h' | '24h' | '7d',
+): Promise<RequestResult<TimeSeriesData[]>> => {
+  const url = `${API_BASE}/batch-posting-times?range=${range}`;
+  const res = await fetchJson<{
+    batches: { batch_id: number; ms_since_prev_batch: number }[];
+  }>(url);
+  if (!res.data) {
+    return { data: null, badRequest: res.badRequest, error: res.error };
+  }
+  const data = res.data.batches.map(
+    (b): TimeSeriesData => ({
+      value: b.batch_id,
+      timestamp: b.ms_since_prev_batch,
+    }),
+  );
+  return { data, badRequest: res.badRequest, error: res.error };
+};
+
 export const fetchL2GasUsed = async (
   range: '1h' | '24h' | '7d',
   address?: string,


### PR DESCRIPTION
## Summary
- support batch posting times in clickhouse reader and API
- expose `/batch-posting-times` endpoint
- fetch batch posting times from dashboard
- add table config for Batch Posting Cadence chart
- link metric to detailed view

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_683efb709650832888aa9276afd452ac