### PR TITLE
Show UTC time on chart brushes

### DIFF
--- a/dashboard/utils.ts
+++ b/dashboard/utils.ts
@@ -29,6 +29,7 @@ export const formatTime = (ms: number): string =>
     minute: '2-digit',
     second: '2-digit',
     hour12: false,
+    timeZone: 'UTC',
   });
 
 export const formatInterval = (ms: number, showMinutes: boolean): string => {


### PR DESCRIPTION
## Summary
- ensure chart brush tick labels display UTC time

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_683efe9543188328859594330febabce