### PR TITLE
Fix chart brush labels

### DIFF
--- a/dashboard/components/BatchProcessChart.tsx
+++ b/dashboard/components/BatchProcessChart.tsx
@@ -69,7 +69,7 @@ export const BatchProcessChart: React.FC<BatchProcessChartProps> = ({
     <ResponsiveContainer width="100%" height="100%">
       <LineChart
         data={data}
-        margin={{ top: 5, right: 30, left: 20, bottom: 40 }}
+        margin={{ top: 5, right: 50, left: 20, bottom: 40 }}
       >
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis

--- a/dashboard/components/BlobsPerBatchChart.tsx
+++ b/dashboard/components/BlobsPerBatchChart.tsx
@@ -60,7 +60,7 @@ export const BlobsPerBatchChart: React.FC<BlobsPerBatchChartProps> = ({
     <ResponsiveContainer width="100%" height="100%">
       <BarChart
         data={data}
-        margin={{ top: 5, right: 30, left: 20, bottom: 40 }}
+        margin={{ top: 5, right: 50, left: 20, bottom: 40 }}
       >
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis

--- a/dashboard/components/BlockTimeChart.tsx
+++ b/dashboard/components/BlockTimeChart.tsx
@@ -60,7 +60,7 @@ export const BlockTimeChart: React.FC<BlockTimeChartProps> = ({
     <ResponsiveContainer width="100%" height="100%">
       <LineChart
         data={data}
-        margin={{ top: 5, right: 30, left: 20, bottom: 40 }}
+        margin={{ top: 5, right: 50, left: 20, bottom: 40 }}
       >
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis

--- a/dashboard/components/BlockTxChart.tsx
+++ b/dashboard/components/BlockTxChart.tsx
@@ -63,7 +63,7 @@ export const BlockTxChart: React.FC<BlockTxChartProps> = ({
     <ResponsiveContainer width="100%" height="100%">
       <BarChart
         data={sortedData}
-        margin={{ top: 5, right: 30, left: 20, bottom: 40 }}
+        margin={{ top: 5, right: 50, left: 20, bottom: 40 }}
       >
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis

--- a/dashboard/components/GasUsedChart.tsx
+++ b/dashboard/components/GasUsedChart.tsx
@@ -59,7 +59,7 @@ export const GasUsedChart: React.FC<GasUsedChartProps> = ({
     <ResponsiveContainer width="100%" height="100%">
       <LineChart
         data={data}
-        margin={{ top: 5, right: 30, left: 20, bottom: 40 }}
+        margin={{ top: 5, right: 50, left: 20, bottom: 40 }}
       >
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis

--- a/dashboard/components/ReorgDepthChart.tsx
+++ b/dashboard/components/ReorgDepthChart.tsx
@@ -57,7 +57,7 @@ export const ReorgDepthChart: React.FC<ReorgDepthChartProps> = ({ data }) => {
     <ResponsiveContainer width="100%" height="100%">
       <BarChart
         data={data}
-        margin={{ top: 5, right: 30, left: 20, bottom: 40 }}
+        margin={{ top: 5, right: 50, left: 20, bottom: 40 }}
       >
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis

--- a/dashboard/components/TpsChart.tsx
+++ b/dashboard/components/TpsChart.tsx
@@ -31,7 +31,7 @@ export const TpsChart: React.FC<TpsChartProps> = ({ data, lineColor }) => {
     <ResponsiveContainer width="100%" height="100%">
       <LineChart
         data={data}
-        margin={{ top: 5, right: 30, left: 20, bottom: 40 }}
+        margin={{ top: 5, right: 50, left: 20, bottom: 40 }}
       >
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis


### PR DESCRIPTION
## Summary
- widen right margin for dashboard charts so brush labels stay visible

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_683eff8255d883289bdca06324131f60