### PR TITLE
Fix metric button layout

### DIFF
--- a/dashboard/components/MetricCard.tsx
+++ b/dashboard/components/MetricCard.tsx
@@ -24,12 +24,14 @@ export const MetricCard: React.FC<MetricCardProps> = ({
     <div
       className={`bg-white p-4 rounded-lg border border-gray-200 transition-shadow duration-200 ${isAddress ? 'min-w-0 w-full sm:col-span-2 md:col-span-2 lg:col-span-2 xl:col-span-2 2xl:col-span-2' : ''} ${className ?? ''}`.trim()}
     >
-      <div className="flex justify-between items-center">
-        <h3 className="text-sm font-medium text-gray-500 truncate">{title}</h3>
+      <div className="relative">
+        <h3 className="text-sm font-medium text-gray-500 truncate pr-8">
+          {title}
+        </h3>
         {onMore && (
           <button
             onClick={onMore}
-            className="text-gray-500 hover:text-gray-700 text-xl leading-none w-8 h-8 flex items-center justify-center rounded-md"
+            className="absolute top-0 right-0 text-gray-500 hover:text-gray-700 text-xl leading-none w-6 h-6 flex items-center justify-center rounded-md"
             aria-label="View table"
           >
             ⋮


### PR DESCRIPTION
## Summary
- align metric card "more" button with absolute positioning so metrics look consistent

## Testing
- `just ci`
- `npm run check --prefix dashboard`
- `npm run test --prefix dashboard`


------
https://chatgpt.com/codex/tasks/task_b_683f00a9d57c8328b1c8b9dbd2b6e7aa