### PR TITLE
Fix chart label spacing

### DIFF
--- a/dashboard/components/BlockTimeChart.tsx
+++ b/dashboard/components/BlockTimeChart.tsx
@@ -10,7 +10,12 @@ import {
   Brush,
 } from 'recharts';
 import { TimeSeriesData } from '../types';
-import { formatDecimal, formatInterval, shouldShowMinutes, formatTime } from '../utils';
+import {
+  formatDecimal,
+  formatInterval,
+  shouldShowMinutes,
+  formatTime,
+} from '../utils';
 
 interface BlockTimeChartProps {
   data: TimeSeriesData[];
@@ -60,7 +65,7 @@ export const BlockTimeChart: React.FC<BlockTimeChartProps> = ({
     <ResponsiveContainer width="100%" height="100%">
       <LineChart
         data={data}
-        margin={{ top: 5, right: 70, left: 20, bottom: 40 }}
+        margin={{ top: 5, right: 90, left: 20, bottom: 40 }}
       >
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis


### PR DESCRIPTION
## Summary
- bump the right margin on BlockTimeChart so the brush label fits

## Testing
- `just ci` *(fails: unused import in crates/api/src/lib.rs)*
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_b_683f03bf02c883288cc3c750d8567cae