### PR TITLE
Update sequencer metric styling

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -12,7 +12,6 @@ use axum::{
         sse::{Event, KeepAlive, Sse},
     },
     routing::get,
-    http::HeaderMap,
 };
 use chrono::{Duration as ChronoDuration, Utc};
 #[cfg(test)]

--- a/dashboard/App.tsx
+++ b/dashboard/App.tsx
@@ -568,6 +568,13 @@ const App: React.FC = () => {
                     key={`${group}-${idx}`}
                     title={m.title}
                     value={m.value}
+                    valueClassName={
+                      typeof m.title === 'string' &&
+                      (m.title === 'Current Sequencer' ||
+                        m.title === 'Next Sequencer')
+                        ? 'text-2xl'
+                        : undefined
+                    }
                     onMore={
                       typeof m.title === 'string' && m.title === 'Avg. L2 TPS'
                         ? () => openTpsTable()

--- a/dashboard/components/MetricCard.tsx
+++ b/dashboard/components/MetricCard.tsx
@@ -6,6 +6,7 @@ interface MetricCardProps {
   unit?: string; // Unit is passed but not displayed in the title directly as (unit)
   description?: React.ReactNode;
   className?: string;
+  valueClassName?: string;
   onMore?: () => void;
 }
 
@@ -14,6 +15,7 @@ export const MetricCard: React.FC<MetricCardProps> = ({
   value,
   description,
   className,
+  valueClassName,
   onMore,
 }) => {
   // Check if value looks like an Ethereum address (0x followed by 40 hex characters)
@@ -37,7 +39,7 @@ export const MetricCard: React.FC<MetricCardProps> = ({
         )}
       </div>
       <p
-        className={`mt-1 font-semibold text-gray-900 ${isAddress ? 'text-base sm:text-lg break-all' : `text-3xl${isShortValue ? '' : ' whitespace-nowrap overflow-hidden text-ellipsis'}`}`}
+        className={`mt-1 font-semibold text-gray-900 ${isAddress ? 'text-base sm:text-lg break-all' : `text-3xl${isShortValue ? '' : ' whitespace-nowrap overflow-hidden text-ellipsis'}`} ${valueClassName ?? ''}`}
       >
         {value}
       </p>

--- a/dashboard/tests/metricCard.test.ts
+++ b/dashboard/tests/metricCard.test.ts
@@ -49,4 +49,15 @@ describe('MetricCard', () => {
       expect(html.includes('overflow-hidden')).toBe(false);
     }
   });
+
+  it('allows overriding value class', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(MetricCard, {
+        title: 'Current',
+        value: '42',
+        valueClassName: 'text-2xl',
+      }),
+    );
+    expect(html.includes('text-2xl')).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- allow overriding metric value style in `MetricCard`
- show smaller font for `Current Sequencer` and `Next Sequencer`
- test the new prop
- clean up unused import to satisfy lint

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_683f044589a4832893b81904abc55361