### PR TITLE
Fix disabled state for pagination

### DIFF
--- a/dashboard/components/DataTable.tsx
+++ b/dashboard/components/DataTable.tsx
@@ -152,7 +152,7 @@ export const DataTable: React.FC<DataTableProps> = ({
             onClick={() => setPage((p) => p - 1)}
             disabled={disablePrev}
             className="disabled:text-gray-400"
-            style={{ color: TAIKO_PINK }}
+            style={disablePrev ? undefined : { color: TAIKO_PINK }}
           >
             Prev
           </button>
@@ -161,7 +161,7 @@ export const DataTable: React.FC<DataTableProps> = ({
             onClick={() => setPage((p) => p + 1)}
             disabled={disableNext}
             className="disabled:text-gray-400"
-            style={{ color: TAIKO_PINK }}
+            style={disableNext ? undefined : { color: TAIKO_PINK }}
           >
             Next
           </button>
@@ -220,7 +220,11 @@ export const DataTable: React.FC<DataTableProps> = ({
                 onClick={extraTable.pagination.onPrev}
                 disabled={extraTable.pagination.disablePrev}
                 className="disabled:text-gray-400"
-                style={{ color: TAIKO_PINK }}
+                style={
+                  extraTable.pagination.disablePrev
+                    ? undefined
+                    : { color: TAIKO_PINK }
+                }
               >
                 Prev
               </button>
@@ -229,7 +233,11 @@ export const DataTable: React.FC<DataTableProps> = ({
                 onClick={extraTable.pagination.onNext}
                 disabled={extraTable.pagination.disableNext}
                 className="disabled:text-gray-400"
-                style={{ color: TAIKO_PINK }}
+                style={
+                  extraTable.pagination.disableNext
+                    ? undefined
+                    : { color: TAIKO_PINK }
+                }
               >
                 Next
               </button>

--- a/dashboard/index.css
+++ b/dashboard/index.css
@@ -20,6 +20,10 @@ button:hover {
   cursor: pointer;
 }
 
+button:disabled {
+  cursor: not-allowed;
+}
+
 select:hover {
   cursor: pointer;
 }

--- a/dashboard/tests/dataTable.test.ts
+++ b/dashboard/tests/dataTable.test.ts
@@ -17,7 +17,7 @@ describe('DataTable', () => {
           { a: '1', b: '2' },
           { a: '3', b: '4' },
         ],
-        onBack: () => { },
+        onBack: () => {},
       }),
     );
     expect(html.includes('A')).toBe(true);
@@ -33,8 +33,8 @@ describe('DataTable', () => {
         title: 'Main',
         columns: [{ key: 'x', label: 'X' }],
         rows: [{ x: '10' }],
-        onBack: () => { },
-        extraAction: { label: 'More', onClick: () => { } },
+        onBack: () => {},
+        extraAction: { label: 'More', onClick: () => {} },
         extraTable: {
           title: 'Extra',
           columns: [{ key: 'y', label: 'Y' }],
@@ -53,9 +53,9 @@ describe('DataTable', () => {
         title: 'Range',
         columns: [{ key: 'v', label: 'V' }],
         rows: [{ v: 1 }],
-        onBack: () => { },
+        onBack: () => {},
         timeRange: '1h',
-        onTimeRangeChange: () => { },
+        onTimeRangeChange: () => {},
       }),
     );
     expect(html.includes('1H')).toBe(true);
@@ -69,9 +69,9 @@ describe('DataTable', () => {
         title: 'Refresh',
         columns: [{ key: 'v', label: 'V' }],
         rows: [{ v: 1 }],
-        onBack: () => { },
+        onBack: () => {},
         refreshRate: 60000,
-        onRefreshRateChange: () => { },
+        onRefreshRateChange: () => {},
       }),
     );
     expect(html.includes('Refresh')).toBe(true);
@@ -84,7 +84,7 @@ describe('DataTable', () => {
         title: 'Paged',
         columns: [{ key: 'a', label: 'A' }],
         rows,
-        onBack: () => { },
+        onBack: () => {},
       }),
     );
     expect(html.includes('49')).toBe(true);
@@ -99,7 +99,7 @@ describe('DataTable', () => {
         title: 'Custom',
         columns: [{ key: 'a', label: 'A' }],
         rows,
-        onBack: () => { },
+        onBack: () => {},
         rowsPerPage: 5,
       }),
     );
@@ -107,5 +107,18 @@ describe('DataTable', () => {
     expect(html.includes('>4<')).toBe(true);
     expect(html.includes('>5<')).toBe(false);
     expect(html.includes('Next')).toBe(true);
+  });
+
+  it('disables pagination buttons when not clickable', () => {
+    const rows = [{ a: '1' }, { a: '2' }];
+    const html = renderToStaticMarkup(
+      React.createElement(DataTable, {
+        title: 'Disabled',
+        columns: [{ key: 'a', label: 'A' }],
+        rows,
+        onBack: () => {},
+      }),
+    );
+    expect(html.includes('disabled')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- disable pagination buttons when table navigation is unavailable
- add CSS rule to show disabled cursor
- test that pagination buttons render disabled

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_b_683f04be01148328a083fa1f082c69c7