### PR TITLE
Add missed block proposal tracking

### DIFF
--- a/crates/clickhouse/migrations/001_create_tables.sql
+++ b/crates/clickhouse/migrations/001_create_tables.sql
@@ -78,3 +78,11 @@ CREATE TABLE IF NOT EXISTS ${DB}.slashing_events (
     inserted_at DateTime64(3) DEFAULT now64()
 ) ENGINE = MergeTree()
 ORDER BY (l1_block_number, validator_addr);
+
+CREATE TABLE IF NOT EXISTS ${DB}.missed_block_proposals (
+    slot UInt64,
+    sequencer FixedString(20),
+    l2_block_number UInt64,
+    inserted_at DateTime64(3) DEFAULT now64()
+) ENGINE = MergeTree()
+ORDER BY (slot, l2_block_number);

--- a/crates/clickhouse/src/models.rs
+++ b/crates/clickhouse/src/models.rs
@@ -220,3 +220,14 @@ pub struct BatchPostingTimeRow {
     /// Milliseconds since the previous batch
     pub ms_since_prev_batch: Option<u64>,
 }
+
+/// Row representing a missed block proposal for a slot
+#[derive(Debug, Row, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+pub struct MissedBlockProposalRow {
+    /// Slot number when the proposal was missed
+    pub slot: u64,
+    /// Sequencer that produced the unproposed block
+    pub sequencer: AddressBytes,
+    /// L2 block number that should have been proposed
+    pub l2_block_number: u64,
+}

--- a/crates/clickhouse/src/schema.rs
+++ b/crates/clickhouse/src/schema.rs
@@ -22,6 +22,7 @@ pub const TABLES: &[&str] = &[
     "forced_inclusion_processed",
     "verified_batches",
     "slashing_events",
+    "missed_block_proposals",
 ];
 
 /// Schema definitions for tables
@@ -106,5 +107,13 @@ pub const TABLE_SCHEMAS: &[TableSchema] = &[
                  validator_addr FixedString(20),
                  inserted_at DateTime64(3) DEFAULT now64()",
         order_by: "l1_block_number, validator_addr",
+    },
+    TableSchema {
+        name: "missed_block_proposals",
+        columns: "slot UInt64,
+                 sequencer FixedString(20),
+                 l2_block_number UInt64,
+                 inserted_at DateTime64(3) DEFAULT now64()",
+        order_by: "slot, l2_block_number",
     },
 ];

--- a/crates/driver/src/lib.rs
+++ b/crates/driver/src/lib.rs
@@ -2,6 +2,7 @@
 
 use std::time::Duration;
 
+use alloy_primitives::Address;
 use eyre::Result;
 use tokio_stream::StreamExt;
 use tracing::info;


### PR DESCRIPTION
## Summary
- add table and model for missed block proposals
- write helper for inserting missed block proposal events
- track last L2 header and last proposed block in driver
- detect missed proposals when processing L1 headers
- fix unused import

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_683f054448fc83289439ad05acbc700b