### PR TITLE
Add filters to dashboard table views

### DIFF
--- a/dashboard/App.tsx
+++ b/dashboard/App.tsx
@@ -129,19 +129,16 @@ const App: React.FC = () => {
     setSelectedSequencer(seq ?? null);
   }, [searchParams]);
 
-  const handleSequencerChange = useCallback(
-    (seq: string | null) => {
-      setSelectedSequencer(seq);
-      const url = new URL(window.location.href);
-      if (seq) {
-        url.searchParams.set('sequencer', seq);
-      } else {
-        url.searchParams.delete('sequencer');
-      }
-      window.history.pushState(null, '', url);
-    },
-    [],
-  );
+  const handleSequencerChange = useCallback((seq: string | null) => {
+    setSelectedSequencer(seq);
+    const url = new URL(window.location.href);
+    if (seq) {
+      url.searchParams.set('sequencer', seq);
+    } else {
+      url.searchParams.delete('sequencer');
+    }
+    window.history.pushState(null, '', url);
+  }, []);
 
   useEffect(() => {
     let pollId: NodeJS.Timeout | null = null;
@@ -502,6 +499,11 @@ const App: React.FC = () => {
         extraTable={tableView.extraTable}
         timeRange={tableView.timeRange}
         onTimeRangeChange={tableView.onTimeRangeChange}
+        refreshRate={refreshRate}
+        onRefreshRateChange={setRefreshRate}
+        sequencers={sequencerList}
+        selectedSequencer={selectedSequencer}
+        onSequencerChange={handleSequencerChange}
         chart={tableView.chart}
       />
     );
@@ -584,8 +586,9 @@ const App: React.FC = () => {
                                 ? () => openGenericTable('gateways')
                                 : typeof m.title === 'string' &&
                                     m.title === 'Batch Posting Cadence'
-                                  ? () => openGenericTable('batch-posting-cadence')
-                                : undefined
+                                  ? () =>
+                                      openGenericTable('batch-posting-cadence')
+                                  : undefined
                     }
                   />
                 ))}

--- a/dashboard/components/DataTable.tsx
+++ b/dashboard/components/DataTable.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { TimeRange } from '../types';
-import { TimeRangeSelector, RefreshRateInput } from './DashboardHeader';
+import {
+  TimeRangeSelector,
+  RefreshRateInput,
+  SequencerSelector,
+} from './DashboardHeader';
 import { TAIKO_PINK } from '../theme';
 
 const DEFAULT_ROWS_PER_PAGE = 50;
@@ -37,6 +41,9 @@ interface DataTableProps {
   onTimeRangeChange?: (range: TimeRange) => void;
   refreshRate?: number;
   onRefreshRateChange?: (rate: number) => void;
+  sequencers?: string[];
+  selectedSequencer?: string | null;
+  onSequencerChange?: (seq: string | null) => void;
   chart?: React.ReactNode;
   rowsPerPage?: number;
 }
@@ -54,6 +61,9 @@ export const DataTable: React.FC<DataTableProps> = ({
   onTimeRangeChange,
   refreshRate,
   onRefreshRateChange,
+  sequencers,
+  selectedSequencer,
+  onSequencerChange,
   chart,
   rowsPerPage = DEFAULT_ROWS_PER_PAGE,
 }) => {
@@ -101,6 +111,13 @@ export const DataTable: React.FC<DataTableProps> = ({
           <RefreshRateInput
             refreshRate={refreshRate}
             onRefreshRateChange={onRefreshRateChange}
+          />
+        )}
+        {sequencers && onSequencerChange && (
+          <SequencerSelector
+            sequencers={sequencers}
+            value={selectedSequencer ?? null}
+            onChange={onSequencerChange}
           />
         )}
       </div>

--- a/dashboard/tests/dataTable.test.ts
+++ b/dashboard/tests/dataTable.test.ts
@@ -77,6 +77,23 @@ describe('DataTable', () => {
     expect(html.includes('Refresh')).toBe(true);
   });
 
+  it('renders sequencer selector', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(DataTable, {
+        title: 'Seq',
+        columns: [{ key: 'v', label: 'V' }],
+        rows: [{ v: 1 }],
+        onBack: () => {},
+        sequencers: ['a', 'b'],
+        selectedSequencer: null,
+        onSequencerChange: () => {},
+      }),
+    );
+    expect(html.includes('All Sequencers')).toBe(true);
+    expect(html.includes('a')).toBe(true);
+    expect(html.includes('b')).toBe(true);
+  });
+
   it('paginates rows when more than 50 items', () => {
     const rows = Array.from({ length: 55 }, (_, i) => ({ a: String(i) }));
     const html = renderToStaticMarkup(


### PR DESCRIPTION
## Summary
- allow selecting sequencer in `DataTable`
- pass refresh and sequencer props from `App`
- test sequencer selector in `DataTable` tests

## Testing
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_683f098b1d48832883d8d8fea385ad33