### PR TITLE
Add L2 base fee inclusion in tx fee metric

### DIFF
--- a/crates/clickhouse/migrations/001_create_tables.sql
+++ b/crates/clickhouse/migrations/001_create_tables.sql
@@ -23,6 +23,7 @@ CREATE TABLE IF NOT EXISTS ${DB}.l2_head_events (
     sum_gas_used UInt128,
     sum_tx UInt32,
     sum_priority_fee UInt128,
+    sum_base_fee UInt128,
     sequencer FixedString(20),
     inserted_at DateTime64(3) DEFAULT now64()
 ) ENGINE = MergeTree()

--- a/crates/clickhouse/src/models.rs
+++ b/crates/clickhouse/src/models.rs
@@ -47,6 +47,8 @@ pub struct L2HeadEvent {
     pub sum_tx: u32,
     /// Sum of priority fees paid
     pub sum_priority_fee: u128,
+    /// Sum of base fees paid
+    pub sum_base_fee: u128,
     /// Sequencer sequencing the block
     pub sequencer: AddressBytes,
 }

--- a/crates/clickhouse/src/reader.rs
+++ b/crates/clickhouse/src/reader.rs
@@ -1518,7 +1518,7 @@ impl ClickhouseReader {
         }
 
         let mut query = format!(
-            "SELECT sum(sum_priority_fee) AS total \
+            "SELECT sum(sum_priority_fee + sum_base_fee * 3 / 4) AS total \
              FROM {db}.l2_head_events \
              WHERE block_ts >= toUnixTimestamp(now64() - INTERVAL {interval})",
             interval = range.interval(),

--- a/crates/clickhouse/src/schema.rs
+++ b/crates/clickhouse/src/schema.rs
@@ -52,6 +52,7 @@ pub const TABLE_SCHEMAS: &[TableSchema] = &[
                  sum_gas_used UInt128,
                  sum_tx UInt32,
                  sum_priority_fee UInt128,
+                 sum_base_fee UInt128,
                  sequencer FixedString(20),
                  inserted_at DateTime64(3) DEFAULT now64()",
         order_by: "l2_block_number",

--- a/crates/clickhouse/src/writer.rs
+++ b/crates/clickhouse/src/writer.rs
@@ -489,6 +489,7 @@ mod tests {
             sum_gas_used: 20,
             sum_tx: 3,
             sum_priority_fee: 30,
+            sum_base_fee: 40,
             sequencer: AddressBytes::from([5u8; 20]),
         };
 

--- a/crates/driver/src/lib.rs
+++ b/crates/driver/src/lib.rs
@@ -443,6 +443,8 @@ impl Driver {
         } else {
             match self.extractor.get_l2_block_stats(header.number, header.base_fee_per_gas).await {
                 Ok((sum_gas_used, sum_tx, sum_priority_fee)) => {
+                    let sum_base_fee =
+                        sum_gas_used.saturating_mul(header.base_fee_per_gas.unwrap_or(0) as u128);
                     let event = clickhouse::L2HeadEvent {
                         l2_block_number: header.number,
                         block_hash: HashBytes(*header.hash),
@@ -450,6 +452,7 @@ impl Driver {
                         sum_gas_used,
                         sum_tx,
                         sum_priority_fee,
+                        sum_base_fee,
                         sequencer: AddressBytes(header.beneficiary.into_array()),
                     };
 


### PR DESCRIPTION
## Summary
- include aggregated L2 base fee in `l2_head_events`
- store the value from headers in the driver
- select 75% of base fee plus priority fee in tx fee query
- update migration and tests

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68400b89fc1c8328bcab22cc9857deda