### PR TITLE
Implement reorg timestamp display

### DIFF
--- a/crates/clickhouse/src/models.rs
+++ b/crates/clickhouse/src/models.rs
@@ -92,6 +92,8 @@ pub struct L2ReorgRow {
     pub l2_block_number: u64,
     /// Depth
     pub depth: u16,
+    /// Time the reorg was recorded
+    pub inserted_at: DateTime<Utc>,
 }
 
 /// Forced inclusion processed row

--- a/dashboard/components/ReorgDepthChart.tsx
+++ b/dashboard/components/ReorgDepthChart.tsx
@@ -61,12 +61,12 @@ export const ReorgDepthChart: React.FC<ReorgDepthChartProps> = ({ data }) => {
       >
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis
-          dataKey="l2_block_number"
-          tickFormatter={(v: number) => v.toLocaleString()}
+          dataKey="timestamp"
+          tickFormatter={(v: number) => new Date(v).toLocaleString()}
           stroke="#666666"
           fontSize={12}
           label={{
-            value: 'Block Number',
+            value: 'Time',
             position: 'insideBottom',
             offset: -35,
             fontSize: 10,
@@ -88,7 +88,7 @@ export const ReorgDepthChart: React.FC<ReorgDepthChartProps> = ({ data }) => {
           }}
         />
         <Tooltip
-          labelFormatter={(label: number) => `Block ${label.toLocaleString()}`}
+          labelFormatter={(label: number) => new Date(label).toLocaleString()}
           formatter={(value: number) => [value.toString(), 'depth']}
           contentStyle={{
             backgroundColor: 'rgba(255, 255, 255, 0.8)',
@@ -98,7 +98,7 @@ export const ReorgDepthChart: React.FC<ReorgDepthChartProps> = ({ data }) => {
         />
         <Bar dataKey="depth" fill={TAIKO_PINK} name="Depth" />
         <Brush
-          dataKey="l2_block_number"
+          dataKey="timestamp"
           height={20}
           stroke={TAIKO_PINK}
           startIndex={brushRange.startIndex}

--- a/dashboard/config/tableConfig.ts
+++ b/dashboard/config/tableConfig.ts
@@ -1,7 +1,12 @@
-import { TimeRange, L2ReorgEvent, SlashingEvent, ForcedInclusionEvent } from '../types';
-import { 
+import {
+  TimeRange,
+  L2ReorgEvent,
+  SlashingEvent,
+  ForcedInclusionEvent,
+} from '../types';
+import {
   fetchSequencerBlocks,
-  fetchL2ReorgEvents, 
+  fetchL2ReorgEvents,
   fetchSlashingEvents,
   fetchForcedInclusionEvents,
   fetchActiveGatewayAddresses,
@@ -12,7 +17,7 @@ import {
   fetchBlockTransactions,
   fetchL2BlockTimes,
   fetchL1BlockTimes,
-  fetchSequencerDistribution
+  fetchSequencerDistribution,
 } from '../services/apiService';
 import { getSequencerName } from '../sequencerConfig';
 import { bytesToHex } from '../utils';
@@ -28,7 +33,10 @@ export interface TableConfig {
   title: string | ((params: Record<string, any>) => string);
   fetcher: (range: TimeRange, ...args: any[]) => Promise<any>;
   columns: TableColumn[];
-  mapData?: (data: any[], params?: Record<string, any>) => Record<string, string | number>[];
+  mapData?: (
+    data: any[],
+    params?: Record<string, any>,
+  ) => Record<string, string | number>[];
   chart?: (data: any[]) => React.ReactNode;
   supportsPagination?: boolean;
   urlKey: string;
@@ -40,39 +48,49 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
     fetcher: fetchSequencerBlocks,
     columns: [{ key: 'block', label: 'Block Number' }],
     mapData: (data) => data.map((b) => ({ block: b })),
-    urlKey: 'sequencer-blocks'
+    urlKey: 'sequencer-blocks',
   },
 
-  'reorgs': {
+  reorgs: {
     title: 'L2 Reorgs',
     fetcher: fetchL2ReorgEvents,
     columns: [
+      { key: 'timestamp', label: 'Time' },
       { key: 'l2_block_number', label: 'Block Number' },
-      { key: 'depth', label: 'Depth' }
+      { key: 'depth', label: 'Depth' },
     ],
-    mapData: (data) => data as Record<string, string | number>[],
+    mapData: (data) =>
+      (data as L2ReorgEvent[]).map((e) => ({
+        timestamp: new Date(e.timestamp).toLocaleString(),
+        l2_block_number: e.l2_block_number,
+        depth: e.depth,
+      })),
     chart: (data) => {
-      const ReorgDepthChart = React.lazy(() => 
-        import('../components/ReorgDepthChart').then(m => ({ default: m.ReorgDepthChart }))
+      const ReorgDepthChart = React.lazy(() =>
+        import('../components/ReorgDepthChart').then((m) => ({
+          default: m.ReorgDepthChart,
+        })),
       );
-      return React.createElement(ReorgDepthChart, { data: data as L2ReorgEvent[] });
+      return React.createElement(ReorgDepthChart, {
+        data: data as L2ReorgEvent[],
+      });
     },
-    urlKey: 'reorgs'
+    urlKey: 'reorgs',
   },
 
-  'slashings': {
+  slashings: {
     title: 'Slashing Events',
     fetcher: fetchSlashingEvents,
     columns: [
       { key: 'l1_block_number', label: 'L1 Block' },
-      { key: 'validator_addr', label: 'Validator' }
+      { key: 'validator_addr', label: 'Validator' },
     ],
-    mapData: (data) => 
+    mapData: (data) =>
       (data as SlashingEvent[]).map((e) => ({
         l1_block_number: e.l1_block_number,
-        validator_addr: bytesToHex(e.validator_addr)
+        validator_addr: bytesToHex(e.validator_addr),
       })),
-    urlKey: 'slashings'
+    urlKey: 'slashings',
   },
 
   'forced-inclusions': {
@@ -81,17 +99,17 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
     columns: [{ key: 'blob_hash', label: 'Blob Hash' }],
     mapData: (data) =>
       (data as ForcedInclusionEvent[]).map((e) => ({
-        blob_hash: bytesToHex(e.blob_hash)
+        blob_hash: bytesToHex(e.blob_hash),
       })),
-    urlKey: 'forced-inclusions'
+    urlKey: 'forced-inclusions',
   },
 
-  'gateways': {
+  gateways: {
     title: 'Active Sequencers',
     fetcher: fetchActiveGatewayAddresses,
     columns: [{ key: 'address', label: 'Address' }],
     mapData: (data) => data.map((g) => ({ address: g })),
-    urlKey: 'gateways'
+    urlKey: 'gateways',
   },
 
   'blobs-per-batch': {
@@ -99,10 +117,10 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
     fetcher: fetchBatchBlobCounts,
     columns: [
       { key: 'batch', label: 'Batch' },
-      { key: 'blobs', label: 'Blobs' }
+      { key: 'blobs', label: 'Blobs' },
     ],
     mapData: (data) => data as Record<string, string | number>[],
-    urlKey: 'blobs-per-batch'
+    urlKey: 'blobs-per-batch',
   },
 
   'batch-posting-cadence': {
@@ -110,16 +128,21 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
     fetcher: fetchBatchPostingTimes,
     columns: [
       { key: 'value', label: 'Batch' },
-      { key: 'timestamp', label: 'Interval (ms)' }
+      { key: 'timestamp', label: 'Interval (ms)' },
     ],
     mapData: (data) => data as Record<string, string | number>[],
     chart: (data) => {
       const BlockTimeChart = React.lazy(() =>
-        import('../components/BlockTimeChart').then(m => ({ default: m.BlockTimeChart }))
+        import('../components/BlockTimeChart').then((m) => ({
+          default: m.BlockTimeChart,
+        })),
       );
-      return React.createElement(BlockTimeChart, { data, lineColor: '#FF9DA7' });
+      return React.createElement(BlockTimeChart, {
+        data,
+        lineColor: '#FF9DA7',
+      });
     },
-    urlKey: 'batch-posting-cadence'
+    urlKey: 'batch-posting-cadence',
   },
 
   'prove-time': {
@@ -127,16 +150,21 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
     fetcher: fetchProveTimes,
     columns: [
       { key: 'name', label: 'Batch' },
-      { key: 'value', label: 'Seconds' }
+      { key: 'value', label: 'Seconds' },
     ],
     mapData: (data) => data as Record<string, string | number>[],
     chart: (data) => {
       const BatchProcessChart = React.lazy(() =>
-        import('../components/BatchProcessChart').then(m => ({ default: m.BatchProcessChart }))
+        import('../components/BatchProcessChart').then((m) => ({
+          default: m.BatchProcessChart,
+        })),
       );
-      return React.createElement(BatchProcessChart, { data, lineColor: TAIKO_PINK });
+      return React.createElement(BatchProcessChart, {
+        data,
+        lineColor: TAIKO_PINK,
+      });
     },
-    urlKey: 'prove-time'
+    urlKey: 'prove-time',
   },
 
   'verify-time': {
@@ -144,16 +172,21 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
     fetcher: fetchVerifyTimes,
     columns: [
       { key: 'name', label: 'Batch' },
-      { key: 'value', label: 'Seconds' }
+      { key: 'value', label: 'Seconds' },
     ],
     mapData: (data) => data as Record<string, string | number>[],
     chart: (data) => {
       const BatchProcessChart = React.lazy(() =>
-        import('../components/BatchProcessChart').then(m => ({ default: m.BatchProcessChart }))
+        import('../components/BatchProcessChart').then((m) => ({
+          default: m.BatchProcessChart,
+        })),
       );
-      return React.createElement(BatchProcessChart, { data, lineColor: '#5DA5DA' });
+      return React.createElement(BatchProcessChart, {
+        data,
+        lineColor: '#5DA5DA',
+      });
     },
-    urlKey: 'verify-time'
+    urlKey: 'verify-time',
   },
 
   'block-tx': {
@@ -162,16 +195,18 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
     columns: [
       { key: 'block', label: 'Block Number' },
       { key: 'txs', label: 'Tx Count' },
-      { key: 'sequencer', label: 'Sequencer' }
+      { key: 'sequencer', label: 'Sequencer' },
     ],
     mapData: (data) => data as Record<string, string | number>[],
     chart: (data) => {
       const BlockTxChart = React.lazy(() =>
-        import('../components/BlockTxChart').then(m => ({ default: m.BlockTxChart }))
+        import('../components/BlockTxChart').then((m) => ({
+          default: m.BlockTxChart,
+        })),
       );
       return React.createElement(BlockTxChart, { data, barColor: '#4E79A7' });
     },
-    urlKey: 'block-tx'
+    urlKey: 'block-tx',
   },
 
   'l2-block-times': {
@@ -179,16 +214,21 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
     fetcher: fetchL2BlockTimes,
     columns: [
       { key: 'value', label: 'Block Number' },
-      { key: 'timestamp', label: 'Interval (ms)' }
+      { key: 'timestamp', label: 'Interval (ms)' },
     ],
     mapData: (data) => data as Record<string, string | number>[],
     chart: (data) => {
       const BlockTimeChart = React.lazy(() =>
-        import('../components/BlockTimeChart').then(m => ({ default: m.BlockTimeChart }))
+        import('../components/BlockTimeChart').then((m) => ({
+          default: m.BlockTimeChart,
+        })),
       );
-      return React.createElement(BlockTimeChart, { data, lineColor: '#FAA43A' });
+      return React.createElement(BlockTimeChart, {
+        data,
+        lineColor: '#FAA43A',
+      });
     },
-    urlKey: 'l2-block-times'
+    urlKey: 'l2-block-times',
   },
 
   'l1-block-times': {
@@ -196,16 +236,21 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
     fetcher: fetchL1BlockTimes,
     columns: [
       { key: 'value', label: 'Block Number' },
-      { key: 'timestamp', label: 'Interval (ms)' }
+      { key: 'timestamp', label: 'Interval (ms)' },
     ],
     mapData: (data) => data as Record<string, string | number>[],
     chart: (data) => {
       const BlockTimeChart = React.lazy(() =>
-        import('../components/BlockTimeChart').then(m => ({ default: m.BlockTimeChart }))
+        import('../components/BlockTimeChart').then((m) => ({
+          default: m.BlockTimeChart,
+        })),
       );
-      return React.createElement(BlockTimeChart, { data, lineColor: '#60BD68' });
+      return React.createElement(BlockTimeChart, {
+        data,
+        lineColor: '#60BD68',
+      });
     },
-    urlKey: 'l1-block-times'
+    urlKey: 'l1-block-times',
   },
 
   'sequencer-dist': {
@@ -213,10 +258,10 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
     fetcher: fetchSequencerDistribution,
     columns: [
       { key: 'name', label: 'Sequencer' },
-      { key: 'value', label: 'Blocks' }
+      { key: 'value', label: 'Blocks' },
     ],
     mapData: (data) => data as Record<string, string | number>[],
     supportsPagination: true,
-    urlKey: 'sequencer-dist'
-  }
+    urlKey: 'sequencer-dist',
+  },
 };

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -132,9 +132,17 @@ export const fetchL2ReorgEvents = async (
   range: '1h' | '24h' | '7d',
 ): Promise<RequestResult<L2ReorgEvent[]>> => {
   const url = `${API_BASE}/reorgs?range=${range}`;
-  const res = await fetchJson<{ events: L2ReorgEvent[] }>(url);
+  const res = await fetchJson<{
+    events: { l2_block_number: number; depth: number; inserted_at: string }[];
+  }>(url);
   return {
-    data: res.data ? res.data.events : null,
+    data: res.data
+      ? res.data.events.map((e) => ({
+          l2_block_number: e.l2_block_number,
+          depth: e.depth,
+          timestamp: Date.parse(e.inserted_at),
+        }))
+      : null,
     badRequest: res.badRequest,
     error: res.error,
   };
@@ -212,14 +220,15 @@ export const fetchL1HeadBlock = async (
   return { data: value, badRequest: res.badRequest, error: res.error };
 };
 
-
 export interface PreconfData {
   candidates: string[];
   current_operator?: string;
   next_operator?: string;
 }
 
-export const fetchPreconfData = async (): Promise<RequestResult<PreconfData>> => {
+export const fetchPreconfData = async (): Promise<
+  RequestResult<PreconfData>
+> => {
   const url = `${API_BASE}/preconf-data`;
   return fetchJson<PreconfData>(url);
 };

--- a/dashboard/tests/app.integration.test.ts
+++ b/dashboard/tests/app.integration.test.ts
@@ -60,7 +60,11 @@ const responses: Record<string, Record<string, unknown>> = {
     current_operator: '0xaaa',
     next_operator: '0xbbb',
   },
-  '/v1/reorgs?range=1h': { events: [{ l2_block_number: 10, depth: 1 }] },
+  '/v1/reorgs?range=1h': {
+    events: [
+      { l2_block_number: 10, depth: 1, inserted_at: '1970-01-01T00:00:00Z' },
+    ],
+  },
   '/v1/slashings?range=1h': {
     events: [{ l1_block_number: 5, validator_addr: [1, 2] }],
   },

--- a/dashboard/types.ts
+++ b/dashboard/types.ts
@@ -25,6 +25,7 @@ export interface MetricData {
 export interface L2ReorgEvent {
   l2_block_number: number;
   depth: number;
+  timestamp: number;
 }
 
 export interface SlashingEvent {


### PR DESCRIPTION
## Summary
- include `inserted_at` in `L2ReorgRow`
- expose timestamp when fetching reorg events
- show human time on the `L2 Reorgs` graph
- display time column in the reorg events table
- adjust dashboard tests

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68400bf1b6748328bd2012cb3d4c41ff