### PR TITLE
Format L2 transaction fee in dashboard

### DIFF
--- a/dashboard/helpers.tsx
+++ b/dashboard/helpers.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { type MetricData } from './types';
-import { formatSeconds, formatDecimal } from './utils';
+import { formatSeconds, formatDecimal, formatEth } from './utils';
 import { getSequencerName } from './sequencerConfig';
 import type { RequestResult } from './services/apiService';
 
@@ -103,7 +103,7 @@ export const createMetrics = (data: MetricInputData): MetricData[] => [
   },
   {
     title: 'L2 Transaction Fee',
-    value: data.l2TxFee != null ? formatDecimal(data.l2TxFee) : 'N/A',
+    value: data.l2TxFee != null ? formatEth(data.l2TxFee) : 'N/A',
     group: 'Network Economics',
   },
   {

--- a/dashboard/tests/helpers.test.ts
+++ b/dashboard/tests/helpers.test.ts
@@ -15,7 +15,7 @@ const metrics = createMetrics({
   forcedInclusions: 0,
   l2Block: 100,
   l1Block: 50,
-  l2TxFee: 42,
+  l2TxFee: 42e18,
 });
 
 const results = [
@@ -64,7 +64,7 @@ describe('helpers', () => {
     expect(metrics[9].group).toBe('Network Health');
     expect(metrics[10].value).toBe('0');
     expect(metrics[10].group).toBe('Network Health');
-    expect(metrics[11].value).toBe('42.0');
+    expect(metrics[11].value).toBe('42.0 ETH');
     expect(metrics[11].group).toBe('Network Economics');
     expect(metrics[12].value).toBe('100');
     expect(metrics[12].group).toBe('Block Information');

--- a/dashboard/tests/utils.test.ts
+++ b/dashboard/tests/utils.test.ts
@@ -9,6 +9,7 @@ import {
   findMetricValue,
   formatSequencerTooltip,
   formatLargeNumber,
+  formatEth,
   bytesToHex,
   loadRefreshRate,
   saveRefreshRate,
@@ -80,6 +81,10 @@ describe('utils', () => {
     expect(formatLargeNumber(1500)).toBe('1.5K');
     expect(formatLargeNumber(15_000_000)).toBe('15M');
     expect(formatLargeNumber(50)).toBe('50');
+  });
+
+  it('formats ETH amounts', () => {
+    expect(formatEth(42e18)).toBe('42.0 ETH');
   });
 
   it('converts bytes to hex', () => {

--- a/dashboard/utils.ts
+++ b/dashboard/utils.ts
@@ -23,6 +23,9 @@ export const formatLargeNumber = (value: number): string => {
   return value.toLocaleString();
 };
 
+export const formatEth = (wei: number): string =>
+  `${formatDecimal(wei / 1e18)} ETH`;
+
 export const formatTime = (ms: number): string =>
   new Date(ms).toLocaleTimeString([], {
     hour: '2-digit',


### PR DESCRIPTION
## Summary
- show L2 transaction fee in ETH
- add formatEth helper
- update tests for the new formatting

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_684011d88254832894df8c9f70fddc3d