### PR TITLE
Update L2 block time chart

### DIFF
--- a/dashboard/App.tsx
+++ b/dashboard/App.tsx
@@ -681,6 +681,7 @@ const App: React.FC = () => {
               key={timeRange}
               data={l2BlockTimeData}
               lineColor="#FAA43A"
+              histogram
             />
           </ChartCard>
           <ChartCard

--- a/dashboard/components/BlockTimeChart.tsx
+++ b/dashboard/components/BlockTimeChart.tsx
@@ -2,6 +2,8 @@ import React, { useState, useEffect } from 'react';
 import {
   LineChart,
   Line,
+  BarChart,
+  Bar,
   XAxis,
   YAxis,
   CartesianGrid,
@@ -20,11 +22,13 @@ import {
 interface BlockTimeChartProps {
   data: TimeSeriesData[];
   lineColor: string;
+  histogram?: boolean;
 }
 
 export const BlockTimeChart: React.FC<BlockTimeChartProps> = ({
   data,
   lineColor,
+  histogram = false,
 }) => {
   if (!data || data.length === 0) {
     return (
@@ -61,9 +65,10 @@ export const BlockTimeChart: React.FC<BlockTimeChartProps> = ({
       setBrushRange({ startIndex: range.startIndex, endIndex: range.endIndex });
     }
   };
+  const ChartComponent = histogram ? BarChart : LineChart;
   return (
     <ResponsiveContainer width="100%" height="100%">
-      <LineChart
+      <ChartComponent
         data={data}
         margin={{ top: 5, right: 90, left: 20, bottom: 40 }}
       >
@@ -109,15 +114,19 @@ export const BlockTimeChart: React.FC<BlockTimeChartProps> = ({
           }}
           labelStyle={{ color: '#333' }}
         />
-        <Line
-          type="monotone"
-          dataKey="timestamp"
-          stroke={lineColor}
-          strokeWidth={2}
-          dot={false}
-          activeDot={data.length <= 100 ? { r: 6 } : false}
-          name="Time"
-        />
+        {histogram ? (
+          <Bar dataKey="timestamp" fill={lineColor} name="Time" />
+        ) : (
+          <Line
+            type="monotone"
+            dataKey="timestamp"
+            stroke={lineColor}
+            strokeWidth={2}
+            dot={false}
+            activeDot={data.length <= 100 ? { r: 6 } : false}
+            name="Time"
+          />
+        )}
         <Brush
           dataKey="timestamp"
           height={20}
@@ -127,7 +136,7 @@ export const BlockTimeChart: React.FC<BlockTimeChartProps> = ({
           onChange={handleBrushChange}
           tickFormatter={(v: number) => formatTime(v)}
         />
-      </LineChart>
+      </ChartComponent>
     </ResponsiveContainer>
   );
 };

--- a/dashboard/config/tableConfig.ts
+++ b/dashboard/config/tableConfig.ts
@@ -226,6 +226,7 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
       return React.createElement(BlockTimeChart, {
         data,
         lineColor: '#FAA43A',
+        histogram: true,
       });
     },
     urlKey: 'l2-block-times',


### PR DESCRIPTION
## Summary
- update `BlockTimeChart` to optionally render a histogram
- show histogram for L2 block times
- update generic table to render histogram for L2 block times

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6840124eabf483289b2d08f63dea3e7c