### PR TITLE
Fix reorg view refresh requests

### DIFF
--- a/dashboard/App.tsx
+++ b/dashboard/App.tsx
@@ -381,11 +381,11 @@ const App: React.FC = () => {
   }, [refreshRate]);
 
   useEffect(() => {
-    if (tableView) return;
+    if (tableView || searchParams.get('view') === 'table') return;
     fetchData();
     const interval = setInterval(fetchData, Math.max(refreshRate, 60000));
     return () => clearInterval(interval);
-  }, [timeRange, fetchData, refreshRate, tableView]);
+  }, [timeRange, fetchData, refreshRate, tableView, searchParams]);
 
   const visibleMetrics = React.useMemo(
     () =>


### PR DESCRIPTION
## Summary
- avoid triggering main dashboard fetch when loading the L2 Reorgs table

## Testing
- `npm run check`
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_684013a1c99883288bd47d7a407c82bd