### PR TITLE
Fix L2 Block Times graph

### DIFF
--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -338,7 +338,7 @@ export const fetchL2BlockTimes = async (
     return { data: null, badRequest: res.badRequest, error: res.error };
   }
 
-  const data = res.data.blocks.slice(1).map(
+  const data = res.data.blocks.map(
     (b): TimeSeriesData => ({
       value: b.l2_block_number,
       timestamp: b.ms_since_prev_block,

--- a/dashboard/tests/apiService.test.ts
+++ b/dashboard/tests/apiService.test.ts
@@ -63,7 +63,10 @@ describe('apiService', () => {
     });
     const blockTimes = await fetchL2BlockTimes('1h');
     expect(blockTimes.error).toBeNull();
-    expect(blockTimes.data).toStrictEqual([{ value: 2, timestamp: 20 }]);
+    expect(blockTimes.data).toStrictEqual([
+      { value: 1, timestamp: 10 },
+      { value: 2, timestamp: 20 },
+    ]);
   });
 
   it('transforms block transactions', async () => {


### PR DESCRIPTION
## Summary
- include all data in `fetchL2BlockTimes`
- update tests for new behavior

## Testing
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_68401653a2748328a3f6c40aae0e6f6d