### PR TITLE
Add refresh button to table views

### DIFF
--- a/dashboard/App.tsx
+++ b/dashboard/App.tsx
@@ -514,6 +514,8 @@ const App: React.FC = () => {
         onTimeRangeChange={tableView.onTimeRangeChange}
         refreshRate={refreshRate}
         onRefreshRateChange={setRefreshRate}
+        lastRefresh={lastRefresh}
+        onManualRefresh={handleManualRefresh}
         sequencers={sequencerList}
         selectedSequencer={selectedSequencer}
         onSequencerChange={handleSequencerChange}

--- a/dashboard/components/DataTable.tsx
+++ b/dashboard/components/DataTable.tsx
@@ -5,6 +5,7 @@ import {
   RefreshRateInput,
   SequencerSelector,
 } from './DashboardHeader';
+import { RefreshCountdown } from './RefreshCountdown';
 import { TAIKO_PINK } from '../theme';
 
 const DEFAULT_ROWS_PER_PAGE = 50;
@@ -41,6 +42,8 @@ interface DataTableProps {
   onTimeRangeChange?: (range: TimeRange) => void;
   refreshRate?: number;
   onRefreshRateChange?: (rate: number) => void;
+  lastRefresh?: number;
+  onManualRefresh?: () => void;
   sequencers?: string[];
   selectedSequencer?: string | null;
   onSequencerChange?: (seq: string | null) => void;
@@ -61,6 +64,8 @@ export const DataTable: React.FC<DataTableProps> = ({
   onTimeRangeChange,
   refreshRate,
   onRefreshRateChange,
+  lastRefresh,
+  onManualRefresh,
   sequencers,
   selectedSequencer,
   onSequencerChange,
@@ -113,6 +118,15 @@ export const DataTable: React.FC<DataTableProps> = ({
             onRefreshRateChange={onRefreshRateChange}
           />
         )}
+        {refreshRate !== undefined &&
+          lastRefresh !== undefined &&
+          onManualRefresh && (
+            <RefreshCountdown
+              refreshRate={refreshRate}
+              lastRefresh={lastRefresh}
+              onRefresh={onManualRefresh}
+            />
+          )}
         {sequencers && onSequencerChange && (
           <SequencerSelector
             sequencers={sequencers}

--- a/dashboard/tests/dataTable.test.ts
+++ b/dashboard/tests/dataTable.test.ts
@@ -77,6 +77,22 @@ describe('DataTable', () => {
     expect(html.includes('Refresh')).toBe(true);
   });
 
+  it('renders refresh countdown when props provided', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(DataTable, {
+        title: 'Countdown',
+        columns: [{ key: 'v', label: 'V' }],
+        rows: [{ v: 1 }],
+        onBack: () => {},
+        refreshRate: 60000,
+        onRefreshRateChange: () => {},
+        lastRefresh: Date.now(),
+        onManualRefresh: () => {},
+      }),
+    );
+    expect(html.includes('Refresh now')).toBe(true);
+  });
+
   it('renders sequencer selector', () => {
     const html = renderToStaticMarkup(
       React.createElement(DataTable, {


### PR DESCRIPTION
## Summary
- show refresh countdown in DataTable component
- expose refresh props from App when table view is active
- test countdown rendering

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_684016e207448328a6e2be4501136e78