### PR TITLE
Fix economics page navigation

### DIFF
--- a/dashboard/hooks/useSearchParams.ts
+++ b/dashboard/hooks/useSearchParams.ts
@@ -11,7 +11,28 @@ export const useSearchParams = (): URLSearchParams => {
   useEffect(() => {
     const handleChange = () => setParams(getParams());
     window.addEventListener('popstate', handleChange);
-    return () => window.removeEventListener('popstate', handleChange);
+
+    const { pushState, replaceState } = window.history;
+
+    window.history.pushState = (
+      ...args: Parameters<History['pushState']>
+    ): void => {
+      pushState.apply(window.history, args);
+      window.dispatchEvent(new Event('popstate'));
+    };
+
+    window.history.replaceState = (
+      ...args: Parameters<History['replaceState']>
+    ): void => {
+      replaceState.apply(window.history, args);
+      window.dispatchEvent(new Event('popstate'));
+    };
+
+    return () => {
+      window.removeEventListener('popstate', handleChange);
+      window.history.pushState = pushState;
+      window.history.replaceState = replaceState;
+    };
   }, [getParams]);
 
   return params;


### PR DESCRIPTION
## Summary
- update the search param hook to listen for pushState/replaceState

## Testing
- `just check-dashboard`
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_684019b3bbf083289089f3091fff6650