### PR TITLE
Update active sequencers data source

### DIFF
--- a/dashboard/config/tableConfig.ts
+++ b/dashboard/config/tableConfig.ts
@@ -9,7 +9,7 @@ import {
   fetchL2ReorgEvents,
   fetchSlashingEvents,
   fetchForcedInclusionEvents,
-  fetchActiveGatewayAddresses,
+  fetchActiveSequencerAddresses,
   fetchBatchBlobCounts,
   fetchBatchPostingTimes,
   fetchProveTimes,
@@ -106,7 +106,7 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
 
   gateways: {
     title: 'Active Sequencers',
-    fetcher: fetchActiveGatewayAddresses,
+    fetcher: fetchActiveSequencerAddresses,
     columns: [{ key: 'address', label: 'Address' }],
     mapData: (data) => data.map((g) => ({ address: g })),
     urlKey: 'gateways',

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -92,25 +92,12 @@ export const fetchBatchPostingCadence = async (
   };
 };
 
-export const fetchActiveGateways = async (
-  range: '1h' | '24h' | '7d',
-): Promise<RequestResult<number>> => {
-  const url = `${API_BASE}/active-gateways?range=${range}`;
-  const res = await fetchJson<{ gateways: string[] }>(url);
-  return {
-    data: res.data ? res.data.gateways.length : null,
-    badRequest: res.badRequest,
-    error: res.error,
-  };
-};
-
-export const fetchActiveGatewayAddresses = async (
-  range: '1h' | '24h' | '7d',
+export const fetchActiveSequencerAddresses = async (
+  _range: '1h' | '24h' | '7d',
 ): Promise<RequestResult<string[]>> => {
-  const url = `${API_BASE}/active-gateways?range=${range}`;
-  const res = await fetchJson<{ gateways: string[] }>(url);
+  const res = await fetchPreconfData();
   return {
-    data: res.data?.gateways ?? null,
+    data: res.data?.candidates ?? null,
     badRequest: res.badRequest,
     error: res.error,
   };

--- a/dashboard/tests/apiService.test.ts
+++ b/dashboard/tests/apiService.test.ts
@@ -2,8 +2,7 @@ import { describe, it, expect, afterEach } from 'vitest';
 
 import {
   fetchAvgProveTime,
-  fetchActiveGateways,
-  fetchActiveGatewayAddresses,
+  fetchActiveSequencerAddresses,
   fetchL2BlockTimes,
   fetchBlockTransactions,
   fetchAvgL2Tps,
@@ -42,15 +41,9 @@ describe('apiService', () => {
     expect(badProve.data).toBeNull();
   });
 
-  it('transforms active gateways', async () => {
-    globalThis.fetch = mockFetch({ gateways: ['a', 'b'] });
-    const gateways = await fetchActiveGateways('1h');
-    expect(gateways.data).toBe(2);
-  });
-
-  it('fetches active gateway addresses', async () => {
-    globalThis.fetch = mockFetch({ gateways: ['a', 'b'] });
-    const gateways = await fetchActiveGatewayAddresses('1h');
+  it('fetches active sequencer addresses from preconf', async () => {
+    globalThis.fetch = mockFetch({ candidates: ['a', 'b'] });
+    const gateways = await fetchActiveSequencerAddresses('1h');
     expect(gateways.data).toStrictEqual(['a', 'b']);
   });
 


### PR DESCRIPTION
## Summary
- pull active sequencer addresses from `/preconf-data`
- remove unused active gateways fetch logic
- update tests

## Testing
- `just lint`
- `just test`
- `just check-dashboard`
- `just test-dashboard`
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_684023e0cef88328a4da7758f20c8da8