### PR TITLE
Fix table view reload loop

### DIFF
--- a/dashboard/hooks/useTableActions.ts
+++ b/dashboard/hooks/useTableActions.ts
@@ -58,7 +58,11 @@ export const useTableActions = (
       Object.entries(params).forEach(([k, v]) => {
         if (v !== undefined) url.searchParams.set(k, String(v));
       });
-      window.history.pushState(null, '', url);
+
+      const newSearch = url.search;
+      if (window.location.search !== newSearch) {
+        window.history.pushState(null, '', url);
+      }
     },
     [],
   );


### PR DESCRIPTION
## Summary
- prevent `setTableUrl` from pushing duplicate URLs

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6840272b15cc83289e3b406ce2b88e6d