### PR TITLE
Fix block number formatting

### DIFF
--- a/dashboard/helpers.tsx
+++ b/dashboard/helpers.tsx
@@ -108,12 +108,14 @@ export const createMetrics = (data: MetricInputData): MetricData[] => [
   },
   {
     title: 'L2 Block',
-    value: data.l2Block != null ? data.l2Block.toString() : 'N/A',
+    value:
+      data.l2Block != null ? data.l2Block.toLocaleString() : 'N/A',
     group: 'Block Information',
   },
   {
     title: 'L1 Block',
-    value: data.l1Block != null ? data.l1Block.toString() : 'N/A',
+    value:
+      data.l1Block != null ? data.l1Block.toLocaleString() : 'N/A',
     group: 'Block Information',
   },
 ];


### PR DESCRIPTION
## Summary
- display thousands separators for L1 and L2 block numbers

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68402c90caa083289f8775b49e05713f