### PR TITLE
Add trailing whitespace guideline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@
 - Prefer `#[derive(Debug)]` on structs and enums
 - Use trace/debug/info/warn/error logs properly with `tracing` crate
 - Error handling: Prefer `?` operator with contextual error info
+- Avoid lines with trailing whitespace (spaces or tabs)
 
 ## Git
 - Use Conventional Commits for commits

--- a/dashboard/AGENTS.md
+++ b/dashboard/AGENTS.md
@@ -11,6 +11,7 @@
 ## Code Style
 - Use TypeScript and keep components typed.
 - Format using `prettier`.
+- Avoid lines with trailing whitespace (spaces or tabs)
 
 ## Git
 - Use Conventional Commits for commits.


### PR DESCRIPTION
## Summary
- document avoiding trailing whitespace in the repository guidelines
- document avoiding trailing whitespace in dashboard guidelines

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6840426a82388328a81c9672de48f2c1