### PR TITLE
Parameterize network name in dashboard

### DIFF
--- a/dashboard/components/DashboardHeader.tsx
+++ b/dashboard/components/DashboardHeader.tsx
@@ -3,6 +3,10 @@ import { TimeRange } from '../types';
 import { RefreshCountdown } from './RefreshCountdown';
 import { TAIKO_PINK } from '../theme';
 
+const metaEnv = (import.meta as any).env as ImportMetaEnv | undefined;
+const NETWORK_NAME =
+  metaEnv?.VITE_NETWORK_NAME ?? metaEnv?.NETWORK_NAME ?? 'Taiko Masaya Testnet';
+
 interface DashboardHeaderProps {
   timeRange: TimeRange;
   onTimeRangeChange: (range: TimeRange) => void;
@@ -45,7 +49,7 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({
         >
           {' '}
           {/* Updated Taiko Pink */}
-          Taiko Masaya Testnet
+          {NETWORK_NAME}
         </h1>
       </div>
       <div className="flex items-center space-x-2 mt-4 md:mt-0">

--- a/dashboard/custom.d.ts
+++ b/dashboard/custom.d.ts
@@ -5,6 +5,8 @@ declare module '*.css';
 interface ImportMetaEnv {
   readonly VITE_API_BASE?: string;
   readonly API_BASE?: string;
+  readonly VITE_NETWORK_NAME?: string;
+  readonly NETWORK_NAME?: string;
 }
 
 interface ImportMeta {

--- a/dashboard/metadata.json
+++ b/dashboard/metadata.json
@@ -1,5 +1,5 @@
 {
   "name": "Taikoscope",
-  "description": "A dashboard to display key metrics and charts for the Taiko Masaya Testnet, providing insights into network activity, block production, and batch processing.",
+  "description": "A dashboard to display key metrics and charts for the Taiko network, providing insights into network activity, block production, and batch processing.",
   "requestFramePermissions": []
 }


### PR DESCRIPTION
## Summary
- expose `NETWORK_NAME` via `ImportMetaEnv`
- show the configured network name in `DashboardHeader`
- generalize dashboard metadata description

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6840416119f08328926517284e6bb51a