### PR TITLE
Fix reorg table navigation loop

### DIFF
--- a/dashboard/hooks/useTableActions.ts
+++ b/dashboard/hooks/useTableActions.ts
@@ -67,8 +67,9 @@ export const useTableActions = (
       });
 
       const newUrl = url.toString();
-      const shouldReplace = newUrl === window.location.href;
-      searchParams.navigate(url, shouldReplace);
+      if (newUrl !== window.location.href) {
+        searchParams.navigate(url, false);
+      }
     },
     [searchParams],
   );


### PR DESCRIPTION
## Summary
- avoid redundant navigation calls when opening table views

## Testing
- `npm run check`
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_68404486b5f88328b7406fdb5c65f87f