### PR TITLE
Sort sequencer selector options

### DIFF
--- a/dashboard/App.tsx
+++ b/dashboard/App.tsx
@@ -98,7 +98,7 @@ const App: React.FC = () => {
     PieChartDataItem[]
   >([]);
   const sequencerList = React.useMemo(
-    () => sequencerDistribution.map((s) => s.name),
+    () => sequencerDistribution.map((s) => s.name).sort(),
     [sequencerDistribution],
   );
   const [l2HeadBlock, setL2HeadBlock] = useState<string>('0');

--- a/dashboard/components/DashboardHeader.tsx
+++ b/dashboard/components/DashboardHeader.tsx
@@ -189,7 +189,7 @@ export const SequencerSelector: React.FC<SequencerSelectorProps> = ({
       className="p-1 border rounded-md text-sm"
     >
       <option value="">All Sequencers</option>
-      {sequencers.map((s) => (
+      {[...sequencers].sort().map((s) => (
         <option key={s} value={s}>
           {s}
         </option>

--- a/dashboard/tests/dataTable.test.ts
+++ b/dashboard/tests/dataTable.test.ts
@@ -100,14 +100,15 @@ describe('DataTable', () => {
         columns: [{ key: 'v', label: 'V' }],
         rows: [{ v: 1 }],
         onBack: () => {},
-        sequencers: ['a', 'b'],
+        sequencers: ['b', 'a'],
         selectedSequencer: null,
         onSequencerChange: () => {},
       }),
     );
-    expect(html.includes('All Sequencers')).toBe(true);
-    expect(html.includes('a')).toBe(true);
-    expect(html.includes('b')).toBe(true);
+    const options = Array.from(html.matchAll(/<option[^>]*>(.*?)<\/option>/g)).map(
+      (m) => m[1],
+    );
+    expect(options).toEqual(['All Sequencers', 'a', 'b']);
   });
 
   it('paginates rows when more than 50 items', () => {


### PR DESCRIPTION
## Summary
- sort sequencer list in `App` so dropdown isn't random
- always display sequencers alphabetically in `SequencerSelector`
- update table test to expect sorted options

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_684049b3e3d883288e6b80c795803b8d