### PR TITLE
Ensure dropdown sequencers sorted with all option first

### DIFF
--- a/dashboard/components/DashboardHeader.tsx
+++ b/dashboard/components/DashboardHeader.tsx
@@ -200,6 +200,14 @@ export const SequencerSelector: React.FC<SequencerSelectorProps> = ({
   value,
   onChange,
 }) => {
+  const sorted = React.useMemo(
+    () =>
+      [...sequencers]
+        .filter((s) => s.toLowerCase() !== 'all sequencers')
+        .sort(),
+    [sequencers],
+  );
+
   return (
     <select
       value={value ?? ''}
@@ -207,7 +215,7 @@ export const SequencerSelector: React.FC<SequencerSelectorProps> = ({
       className="p-1 border rounded-md text-sm"
     >
       <option value="">All Sequencers</option>
-      {[...sequencers].sort().map((s) => (
+      {sorted.map((s) => (
         <option key={s} value={s}>
           {s}
         </option>

--- a/dashboard/tests/dataTable.test.ts
+++ b/dashboard/tests/dataTable.test.ts
@@ -111,6 +111,24 @@ describe('DataTable', () => {
     expect(options).toEqual(['All Sequencers', 'a', 'b']);
   });
 
+  it('handles sequencer list containing All Sequencers entry', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(DataTable, {
+        title: 'Seq',
+        columns: [{ key: 'v', label: 'V' }],
+        rows: [{ v: 1 }],
+        onBack: () => {},
+        sequencers: ['b', 'All Sequencers', 'a'],
+        selectedSequencer: null,
+        onSequencerChange: () => {},
+      }),
+    );
+    const options = Array.from(html.matchAll(/<option[^>]*>(.*?)<\/option>/g)).map(
+      (m) => m[1],
+    );
+    expect(options).toEqual(['All Sequencers', 'a', 'b']);
+  });
+
   it('paginates rows when more than 50 items', () => {
     const rows = Array.from({ length: 55 }, (_, i) => ({ a: String(i) }));
     const html = renderToStaticMarkup(


### PR DESCRIPTION
## Summary
- keep `All Sequencers` at the top of dropdown
- filter and sort sequencer list for selector
- verify behaviour via new unit test

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68404c0cb50c8328ac2a5a1b5783e672