### PR TITLE
Add rate limit toast

### DIFF
--- a/dashboard/components/ToastProvider.tsx
+++ b/dashboard/components/ToastProvider.tsx
@@ -1,0 +1,43 @@
+import React, { useEffect, useState } from 'react';
+import { TOAST_EVENT } from '../utils/toast';
+
+interface Toast {
+  id: number;
+  message: string;
+}
+
+
+export const ToastProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  useEffect(() => {
+    const handler = (event: Event) => {
+      const message = (event as CustomEvent<string>).detail;
+      const id = Date.now() + Math.random();
+      const toast: Toast = { id, message };
+      setToasts((t) => [...t, toast]);
+      setTimeout(() => {
+        setToasts((t) => t.filter((x) => x.id !== id));
+      }, 5000);
+    };
+    window.addEventListener(TOAST_EVENT, handler as EventListener);
+    return () => window.removeEventListener(TOAST_EVENT, handler as EventListener);
+  }, []);
+
+  return (
+    <>
+      {children}
+      <div className="fixed bottom-4 right-4 space-y-2 z-50">
+        {toasts.map((t) => (
+          <div
+            key={t.id}
+            className="bg-gray-800 text-white px-3 py-2 rounded shadow"
+          >
+            {t.message}
+          </div>
+        ))}
+      </div>
+    </>
+  );
+};
+

--- a/dashboard/index.tsx
+++ b/dashboard/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import { ErrorBoundary } from './components/ErrorBoundary';
+import { ToastProvider } from './components/ToastProvider';
 import './index.css';
 
 const rootElement = document.getElementById('root');
@@ -12,8 +13,10 @@ if (!rootElement) {
 const root = ReactDOM.createRoot(rootElement);
 root.render(
   <React.StrictMode>
-    <ErrorBoundary>
-      <App />
-    </ErrorBoundary>
+    <ToastProvider>
+      <ErrorBoundary>
+        <App />
+      </ErrorBoundary>
+    </ToastProvider>
   </React.StrictMode>,
 );

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -3,6 +3,7 @@ export const API_BASE: string =
   (metaEnv.VITE_API_BASE ?? metaEnv.API_BASE ?? '') + '/v1';
 
 import { getSequencerName } from '../sequencerConfig';
+import { showToast } from '../utils/toast';
 
 import type {
   TimeSeriesData,
@@ -24,6 +25,9 @@ const fetchJson = async <T>(url: string): Promise<RequestResult<T>> => {
   try {
     const res = await fetch(url);
     if (!res.ok) {
+      if (res.status === 429) {
+        showToast('Too many requests, please slow down.');
+      }
       let error: ErrorResponse | null = null;
       try {
         error = (await res.json()) as ErrorResponse;

--- a/dashboard/utils/toast.ts
+++ b/dashboard/utils/toast.ts
@@ -1,0 +1,6 @@
+export const TOAST_EVENT = 'toast-event';
+
+export const showToast = (message: string) => {
+  window.dispatchEvent(new CustomEvent(TOAST_EVENT, { detail: message }));
+};
+


### PR DESCRIPTION
## Summary
- add a Toast provider and toast utility
- wrap the dashboard with the new ToastProvider
- show a toast when API calls hit HTTP 429

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68404d3b5c7c83288f07065adae31dad