### PR TITLE
Optimize dashboard charts re-renders

### DIFF
--- a/dashboard/components/BatchProcessChart.tsx
+++ b/dashboard/components/BatchProcessChart.tsx
@@ -21,7 +21,7 @@ interface BatchProcessChartProps {
   lineColor: string;
 }
 
-export const BatchProcessChart: React.FC<BatchProcessChartProps> = ({
+const BatchProcessChartComponent: React.FC<BatchProcessChartProps> = ({
   data,
   lineColor,
 }) => {
@@ -135,3 +135,5 @@ export const BatchProcessChart: React.FC<BatchProcessChartProps> = ({
     </ResponsiveContainer>
   );
 };
+
+export const BatchProcessChart = React.memo(BatchProcessChartComponent);

--- a/dashboard/components/BlobsPerBatchChart.tsx
+++ b/dashboard/components/BlobsPerBatchChart.tsx
@@ -16,7 +16,7 @@ interface BlobsPerBatchChartProps {
   barColor: string;
 }
 
-export const BlobsPerBatchChart: React.FC<BlobsPerBatchChartProps> = ({
+const BlobsPerBatchChartComponent: React.FC<BlobsPerBatchChartProps> = ({
   data,
   barColor,
 }) => {
@@ -114,3 +114,5 @@ export const BlobsPerBatchChart: React.FC<BlobsPerBatchChartProps> = ({
     </ResponsiveContainer>
   );
 };
+
+export const BlobsPerBatchChart = React.memo(BlobsPerBatchChartComponent);

--- a/dashboard/components/BlockTimeChart.tsx
+++ b/dashboard/components/BlockTimeChart.tsx
@@ -25,7 +25,7 @@ interface BlockTimeChartProps {
   histogram?: boolean;
 }
 
-export const BlockTimeChart: React.FC<BlockTimeChartProps> = ({
+const BlockTimeChartComponent: React.FC<BlockTimeChartProps> = ({
   data,
   lineColor,
   histogram = false,
@@ -140,3 +140,5 @@ export const BlockTimeChart: React.FC<BlockTimeChartProps> = ({
     </ResponsiveContainer>
   );
 };
+
+export const BlockTimeChart = React.memo(BlockTimeChartComponent);

--- a/dashboard/components/BlockTxChart.tsx
+++ b/dashboard/components/BlockTxChart.tsx
@@ -16,7 +16,7 @@ interface BlockTxChartProps {
   barColor: string;
 }
 
-export const BlockTxChart: React.FC<BlockTxChartProps> = ({
+const BlockTxChartComponent: React.FC<BlockTxChartProps> = ({
   data,
   barColor,
 }) => {
@@ -117,3 +117,5 @@ export const BlockTxChart: React.FC<BlockTxChartProps> = ({
     </ResponsiveContainer>
   );
 };
+
+export const BlockTxChart = React.memo(BlockTxChartComponent);

--- a/dashboard/components/GasUsedChart.tsx
+++ b/dashboard/components/GasUsedChart.tsx
@@ -17,7 +17,7 @@ interface GasUsedChartProps {
   lineColor: string;
 }
 
-export const GasUsedChart: React.FC<GasUsedChartProps> = ({
+const GasUsedChartComponent: React.FC<GasUsedChartProps> = ({
   data,
   lineColor,
 }) => {
@@ -121,3 +121,5 @@ export const GasUsedChart: React.FC<GasUsedChartProps> = ({
     </ResponsiveContainer>
   );
 };
+
+export const GasUsedChart = React.memo(GasUsedChartComponent);

--- a/dashboard/components/MissedBlockChart.tsx
+++ b/dashboard/components/MissedBlockChart.tsx
@@ -16,7 +16,9 @@ interface MissedBlockChartProps {
   data: MissedBlockProposal[];
 }
 
-export const MissedBlockChart: React.FC<MissedBlockChartProps> = ({ data }) => {
+const MissedBlockChartComponent: React.FC<MissedBlockChartProps> = ({
+  data,
+}) => {
   if (!data || data.length === 0) {
     return (
       <div className="flex items-center justify-center h-full text-gray-500">
@@ -39,11 +41,17 @@ export const MissedBlockChart: React.FC<MissedBlockChartProps> = ({ data }) => {
     setBrushRange({ startIndex: 0, endIndex: sortedData.length - 1 });
   }, [sortedData]);
 
-  const handleBrushChange = (range: { startIndex?: number; endIndex?: number }) => {
+  const handleBrushChange = (range: {
+    startIndex?: number;
+    endIndex?: number;
+  }) => {
     if (range.startIndex == null || range.endIndex == null) return;
     const maxRange = 500;
     if (range.endIndex - range.startIndex > maxRange) {
-      setBrushRange({ startIndex: range.endIndex - maxRange, endIndex: range.endIndex });
+      setBrushRange({
+        startIndex: range.endIndex - maxRange,
+        endIndex: range.endIndex,
+      });
     } else {
       setBrushRange({ startIndex: range.startIndex, endIndex: range.endIndex });
     }
@@ -51,7 +59,10 @@ export const MissedBlockChart: React.FC<MissedBlockChartProps> = ({ data }) => {
 
   return (
     <ResponsiveContainer width="100%" height="100%">
-      <BarChart data={sortedData} margin={{ top: 5, right: 70, left: 20, bottom: 40 }}>
+      <BarChart
+        data={sortedData}
+        margin={{ top: 5, right: 70, left: 20, bottom: 40 }}
+      >
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis
           dataKey="slot"
@@ -84,7 +95,10 @@ export const MissedBlockChart: React.FC<MissedBlockChartProps> = ({ data }) => {
         <Tooltip
           labelFormatter={(label: number) => `Slot ${label.toLocaleString()}`}
           formatter={() => [1, 'missed']}
-          contentStyle={{ backgroundColor: 'rgba(255, 255, 255, 0.8)', borderColor: TAIKO_PINK }}
+          contentStyle={{
+            backgroundColor: 'rgba(255, 255, 255, 0.8)',
+            borderColor: TAIKO_PINK,
+          }}
           labelStyle={{ color: '#333' }}
         />
         <Bar dataKey={() => 1} fill={TAIKO_PINK} name="Missed" />
@@ -100,3 +114,5 @@ export const MissedBlockChart: React.FC<MissedBlockChartProps> = ({ data }) => {
     </ResponsiveContainer>
   );
 };
+
+export const MissedBlockChart = React.memo(MissedBlockChartComponent);

--- a/dashboard/components/ReorgDepthChart.tsx
+++ b/dashboard/components/ReorgDepthChart.tsx
@@ -16,7 +16,7 @@ interface ReorgDepthChartProps {
   data: L2ReorgEvent[];
 }
 
-export const ReorgDepthChart: React.FC<ReorgDepthChartProps> = ({ data }) => {
+const ReorgDepthChartComponent: React.FC<ReorgDepthChartProps> = ({ data }) => {
   if (!data || data.length === 0) {
     return (
       <div className="flex items-center justify-center h-full text-gray-500">
@@ -109,3 +109,5 @@ export const ReorgDepthChart: React.FC<ReorgDepthChartProps> = ({ data }) => {
     </ResponsiveContainer>
   );
 };
+
+export const ReorgDepthChart = React.memo(ReorgDepthChartComponent);

--- a/dashboard/components/SequencerPieChart.tsx
+++ b/dashboard/components/SequencerPieChart.tsx
@@ -29,7 +29,7 @@ const FALLBACK_COLORS = [
   '#F15854',
 ];
 
-export const SequencerPieChart: React.FC<SequencerPieChartProps> = ({
+const SequencerPieChartComponent: React.FC<SequencerPieChartProps> = ({
   data,
 }) => {
   if (!data || data.length === 0) {
@@ -69,3 +69,5 @@ export const SequencerPieChart: React.FC<SequencerPieChartProps> = ({
     </ResponsiveContainer>
   );
 };
+
+export const SequencerPieChart = React.memo(SequencerPieChartComponent);

--- a/dashboard/components/TpsChart.tsx
+++ b/dashboard/components/TpsChart.tsx
@@ -19,7 +19,7 @@ interface TpsChartProps {
   lineColor: string;
 }
 
-export const TpsChart: React.FC<TpsChartProps> = ({ data, lineColor }) => {
+const TpsChartComponent: React.FC<TpsChartProps> = ({ data, lineColor }) => {
   if (!data || data.length === 0) {
     return (
       <div className="flex items-center justify-center h-full text-gray-500">
@@ -83,3 +83,5 @@ export const TpsChart: React.FC<TpsChartProps> = ({ data, lineColor }) => {
     </ResponsiveContainer>
   );
 };
+
+export const TpsChart = React.memo(TpsChartComponent);


### PR DESCRIPTION
## Summary
- memoize heavy chart components used across the dashboard

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68405c654524832894e918f777c4ae68