### PR TITLE
Improve dashboard error boundary

### DIFF
--- a/dashboard/components/ErrorBoundary.tsx
+++ b/dashboard/components/ErrorBoundary.tsx
@@ -2,10 +2,17 @@ import React from 'react';
 
 interface ErrorBoundaryProps {
   fallback?: React.ReactNode;
+  /**
+   * Optional function invoked when an error is caught. Can be used to
+   * send the error to an external reporting service.
+   */
+  reportError?: (error: Error, info: React.ErrorInfo) => void;
 }
 
 interface ErrorBoundaryState {
   hasError: boolean;
+  error?: Error;
+  info?: React.ErrorInfo;
 }
 
 export class ErrorBoundary extends React.Component<
@@ -14,7 +21,7 @@ export class ErrorBoundary extends React.Component<
 > {
   constructor(props: React.PropsWithChildren<ErrorBoundaryProps>) {
     super(props);
-    this.state = { hasError: false };
+    this.state = { hasError: false, error: undefined, info: undefined };
   }
 
   static getDerivedStateFromError(): ErrorBoundaryState {
@@ -24,14 +31,29 @@ export class ErrorBoundary extends React.Component<
   componentDidCatch(error: Error, info: React.ErrorInfo) {
     // eslint-disable-next-line no-console
     console.error('Error boundary caught an error:', error, info);
+    this.setState({ error, info });
+    if (this.props.reportError) {
+      try {
+        this.props.reportError(error, info);
+      } catch (reportError) {
+        // eslint-disable-next-line no-console
+        console.error('Failed to report error', reportError);
+      }
+    }
   }
 
   render() {
     if (this.state.hasError) {
       return (
         this.props.fallback || (
-          <div className="p-4 bg-red-50 border border-red-200 rounded text-red-700">
-            Something went wrong.
+          <div className="p-4 bg-red-50 border border-red-200 rounded text-red-700 space-y-2">
+            <div>Oops! Something went wrong. Please reload the page.</div>
+            <button
+              onClick={() => window.location.reload()}
+              className="text-sm bg-red-600 text-white px-2 py-1 rounded hover:bg-red-700"
+            >
+              Reload
+            </button>
           </div>
         )
       );

--- a/dashboard/tests/errorBoundary.test.ts
+++ b/dashboard/tests/errorBoundary.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { ErrorBoundary } from '../components/ErrorBoundary';
@@ -21,5 +21,14 @@ describe('ErrorBoundary', () => {
       ),
     );
     expect(html).toContain('oops');
+  });
+
+  it('calls reportError when provided', () => {
+    const report = vi.fn();
+    const boundary = new ErrorBoundary({ reportError: report });
+    const error = new Error('boom');
+    const info = { componentStack: 'stack' } as React.ErrorInfo;
+    boundary.componentDidCatch(error, info);
+    expect(report).toHaveBeenCalledWith(error, info);
   });
 });


### PR DESCRIPTION
## Summary
- augment ErrorBoundary to store caught errors
- add optional reporting hook and better fallback UI
- verify ErrorBoundary reports when enabled

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68405c4ef2d88328ac339155dffa6df7