### PR TITLE
Validate refresh interval

### DIFF
--- a/dashboard/components/DashboardHeader.tsx
+++ b/dashboard/components/DashboardHeader.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { TimeRange } from '../types';
 import { RefreshCountdown } from './RefreshCountdown';
 import { TAIKO_PINK } from '../theme';
+import { isValidRefreshRate } from '../utils';
 
 const metaEnv = (import.meta as any).env as ImportMetaEnv | undefined;
 const NETWORK_NAME =
@@ -165,7 +166,9 @@ export const RefreshRateInput: React.FC<RefreshRateInputProps> = ({
 
   const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const value = Number(e.target.value);
-    onRefreshRateChange(value);
+    if (isValidRefreshRate(value)) {
+      onRefreshRateChange(value);
+    }
   };
 
   return (

--- a/dashboard/hooks/useRefreshTimer.ts
+++ b/dashboard/hooks/useRefreshTimer.ts
@@ -1,22 +1,30 @@
 import { useState, useEffect, useCallback } from 'react';
-import { loadRefreshRate, saveRefreshRate } from '../utils';
+import { loadRefreshRate, saveRefreshRate, isValidRefreshRate } from '../utils';
 
 export const useRefreshTimer = () => {
-    const [refreshRate, setRefreshRate] = useState<number>(() => loadRefreshRate());
-    const [lastRefresh, setLastRefresh] = useState<number>(Date.now());
+  const [refreshRate, setRefreshRateState] = useState<number>(() =>
+    loadRefreshRate(),
+  );
+  const [lastRefresh, setLastRefresh] = useState<number>(Date.now());
 
-    useEffect(() => {
-        saveRefreshRate(refreshRate);
-    }, [refreshRate]);
+  const setRefreshRate = useCallback((rate: number) => {
+    if (isValidRefreshRate(rate)) {
+      setRefreshRateState(rate);
+    }
+  }, []);
 
-    const updateLastRefresh = useCallback(() => {
-        setLastRefresh(Date.now());
-    }, []);
+  useEffect(() => {
+    saveRefreshRate(refreshRate);
+  }, [refreshRate]);
 
-    return {
-        refreshRate,
-        setRefreshRate,
-        lastRefresh,
-        updateLastRefresh,
-    };
+  const updateLastRefresh = useCallback(() => {
+    setLastRefresh(Date.now());
+  }, []);
+
+  return {
+    refreshRate,
+    setRefreshRate,
+    lastRefresh,
+    updateLastRefresh,
+  };
 };

--- a/dashboard/tests/utils.test.ts
+++ b/dashboard/tests/utils.test.ts
@@ -13,6 +13,7 @@ import {
   bytesToHex,
   loadRefreshRate,
   saveRefreshRate,
+  isValidRefreshRate,
 } from '../utils';
 
 describe('utils', () => {
@@ -109,5 +110,11 @@ describe('utils', () => {
     expect(store.refreshRate).toBe('60000');
     store.refreshRate = '2000';
     expect(loadRefreshRate()).toBe(2000);
+  });
+
+  it('validates refresh rate', () => {
+    expect(isValidRefreshRate(1000)).toBe(true);
+    expect(isValidRefreshRate(-1)).toBe(false);
+    expect(isValidRefreshRate(NaN)).toBe(false);
   });
 });

--- a/dashboard/utils.ts
+++ b/dashboard/utils.ts
@@ -97,3 +97,6 @@ export const saveRefreshRate = (rate: number): void => {
   if (typeof localStorage === 'undefined') return;
   localStorage.setItem('refreshRate', String(rate));
 };
+
+export const isValidRefreshRate = (rate: number): boolean =>
+  Number.isFinite(rate) && rate > 0;


### PR DESCRIPTION
## Summary
- validate refreshRate with `isValidRefreshRate`
- apply validation in `useRefreshTimer` and `RefreshRateInput`
- add tests for refresh rate validation

## Testing
- `npm --prefix dashboard run check`
- `npm --prefix dashboard run test`
- `cargo nextest run --workspace --all-targets`
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6840618294b88328b0bb2428199768c1