### PR TITLE
Fix ErrorBoundary reload

### DIFF
--- a/dashboard/components/ErrorBoundary.tsx
+++ b/dashboard/components/ErrorBoundary.tsx
@@ -42,17 +42,21 @@ export class ErrorBoundary extends React.Component<
     }
   }
 
+  private resetError() {
+    this.setState({ hasError: false, error: undefined, info: undefined });
+  }
+
   render() {
     if (this.state.hasError) {
       return (
         this.props.fallback || (
           <div className="p-4 bg-red-50 border border-red-200 rounded text-red-700 space-y-2">
-            <div>Oops! Something went wrong. Please reload the page.</div>
+            <div>Oops! Something went wrong.</div>
             <button
-              onClick={() => window.location.reload()}
+              onClick={() => this.resetError()}
               className="text-sm bg-red-600 text-white px-2 py-1 rounded hover:bg-red-700"
             >
-              Reload
+              Retry
             </button>
           </div>
         )

--- a/dashboard/tests/errorBoundary.test.ts
+++ b/dashboard/tests/errorBoundary.test.ts
@@ -31,4 +31,12 @@ describe('ErrorBoundary', () => {
     boundary.componentDidCatch(error, info);
     expect(report).toHaveBeenCalledWith(error, info);
   });
+
+  it('resetError clears error state', () => {
+    const boundary = new ErrorBoundary({});
+    boundary.setState({ hasError: true, error: new Error('oops'), info: undefined });
+    (boundary as any).resetError();
+    expect(boundary.state.hasError).toBe(false);
+    expect(boundary.state.error).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary
- add resetError method and Retry button to ErrorBoundary
- test clearing error state

## Testing
- `npm run check`
- `npm run test`
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_6840656ac960832893e170a3e6faf2e2