### PR TITLE
Fix bad refresh rate value

### DIFF
--- a/dashboard/tests/utils.test.ts
+++ b/dashboard/tests/utils.test.ts
@@ -109,11 +109,11 @@ describe('utils', () => {
     saveRefreshRate(60000);
     expect(store.refreshRate).toBe('60000');
     store.refreshRate = '2000';
-    expect(loadRefreshRate()).toBe(2000);
+    expect(loadRefreshRate()).toBe(60000);
   });
 
   it('validates refresh rate', () => {
-    expect(isValidRefreshRate(1000)).toBe(true);
+    expect(isValidRefreshRate(1000)).toBe(false);
     expect(isValidRefreshRate(-1)).toBe(false);
     expect(isValidRefreshRate(NaN)).toBe(false);
   });

--- a/dashboard/utils.ts
+++ b/dashboard/utils.ts
@@ -90,7 +90,11 @@ export const loadRefreshRate = (): number => {
   if (typeof localStorage === 'undefined') return 60000;
   const stored = localStorage.getItem('refreshRate');
   const value = stored ? parseInt(stored, 10) : NaN;
-  return Number.isFinite(value) && value > 0 ? value : 60000;
+  if (!Number.isFinite(value) || value < 60000) {
+    localStorage.removeItem('refreshRate');
+    return 60000;
+  }
+  return value;
 };
 
 export const saveRefreshRate = (rate: number): void => {
@@ -99,4 +103,4 @@ export const saveRefreshRate = (rate: number): void => {
 };
 
 export const isValidRefreshRate = (rate: number): boolean =>
-  Number.isFinite(rate) && rate > 0;
+  Number.isFinite(rate) && rate >= 60000;


### PR DESCRIPTION
## Summary
- validate refresh rate value from localStorage
- require refresh rate >= 60s in utils and tests

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6840658219c88328a6073b9b6174d4c8