### PR TITLE
Fix dashboard fetch loop

### DIFF
--- a/dashboard/hooks/useChartsData.ts
+++ b/dashboard/hooks/useChartsData.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import { TimeSeriesData, PieChartDataItem } from '../types';
 import type { BlockTransaction, BatchBlobCount } from '../services/apiService';
 
@@ -12,7 +12,7 @@ export const useChartsData = () => {
     const [batchBlobCounts, setBatchBlobCounts] = useState<BatchBlobCount[]>([]);
     const [sequencerDistribution, setSequencerDistribution] = useState<PieChartDataItem[]>([]);
 
-    const updateChartsData = (data: {
+    const updateChartsData = useCallback((data: {
         proveTimes: TimeSeriesData[];
         verifyTimes: TimeSeriesData[];
         l2Times: TimeSeriesData[];
@@ -30,17 +30,30 @@ export const useChartsData = () => {
         setBlockTxData(data.txPerBlock);
         setBatchBlobCounts(data.blobsPerBatch);
         setSequencerDistribution(data.sequencerDist);
-    };
+    }, []);
 
-    return {
-        secondsToProveData,
-        secondsToVerifyData,
-        l2BlockTimeData,
-        l2GasUsedData,
-        l1BlockTimeData,
-        blockTxData,
-        batchBlobCounts,
-        sequencerDistribution,
-        updateChartsData,
-    };
+    return useMemo(
+        () => ({
+            secondsToProveData,
+            secondsToVerifyData,
+            l2BlockTimeData,
+            l2GasUsedData,
+            l1BlockTimeData,
+            blockTxData,
+            batchBlobCounts,
+            sequencerDistribution,
+            updateChartsData,
+        }),
+        [
+            secondsToProveData,
+            secondsToVerifyData,
+            l2BlockTimeData,
+            l2GasUsedData,
+            l1BlockTimeData,
+            blockTxData,
+            batchBlobCounts,
+            sequencerDistribution,
+            updateChartsData,
+        ],
+    );
 };

--- a/dashboard/hooks/useDashboardController.ts
+++ b/dashboard/hooks/useDashboardController.ts
@@ -50,9 +50,10 @@ export const useDashboardController = () => {
         timeRange,
         selectedSequencer,
         tableView,
-        metricsData,
-        chartsData,
-        refreshTimer,
+        fetchMetricsData: metricsData.fetchMetricsData,
+        updateChartsData: chartsData.updateChartsData,
+        refreshRate: refreshTimer.refreshRate,
+        updateLastRefresh: refreshTimer.updateLastRefresh,
     });
 
     // Navigation handling

--- a/dashboard/hooks/useMetricsData.ts
+++ b/dashboard/hooks/useMetricsData.ts
@@ -103,12 +103,15 @@ export const useMetricsData = () => {
         [isEconomicsView],
     );
 
-    return {
-        metrics,
-        setMetrics,
-        loadingMetrics,
-        errorMessage,
-        setErrorMessage,
-        fetchMetricsData,
-    };
+    return useMemo(
+        () => ({
+            metrics,
+            setMetrics,
+            loadingMetrics,
+            errorMessage,
+            setErrorMessage,
+            fetchMetricsData,
+        }),
+        [metrics, loadingMetrics, errorMessage, fetchMetricsData],
+    );
 };


### PR DESCRIPTION
## Summary
- memoize chart data hook and metrics hook results
- pass stable callbacks to data fetcher
- make data fetcher depend only on stable props

## Testing
- `just check-dashboard`
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_684072cbda9083288f4934ba868822f5