### PR TITLE
Add coverage for dashboard utilities

### DIFF
--- a/dashboard/tests/errorHandler.test.ts
+++ b/dashboard/tests/errorHandler.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { getErrorMessage } from '../utils/errorHandler';
+
+describe('errorHandler', () => {
+  it('returns warning message when bad request detected', () => {
+    expect(getErrorMessage(true)).toBe(
+      'Invalid parameters provided. Some data may not be available.'
+    );
+  });
+
+  it('returns empty string when no bad request', () => {
+    expect(getErrorMessage(false)).toBe('');
+  });
+});

--- a/dashboard/tests/toast.test.ts
+++ b/dashboard/tests/toast.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { showToast, TOAST_EVENT } from '../utils/toast';
+
+describe('toast', () => {
+  beforeEach(() => {
+    vi.stubGlobal('window', {
+      dispatchEvent: vi.fn(),
+    });
+  });
+
+  it('dispatches a custom event with the message', () => {
+    const spy = vi.spyOn(window, 'dispatchEvent');
+    showToast('hello');
+    expect(spy).toHaveBeenCalledTimes(1);
+    const event = spy.mock.calls[0][0] as CustomEvent;
+    expect(event.type).toBe(TOAST_EVENT);
+    expect(event.detail).toBe('hello');
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for toast event dispatch
- add tests for error handler message

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_684076a414448328b6e227831e714b39