### PR TITLE
Fix reorgs navigation url

### DIFF
--- a/dashboard/hooks/useNavigationHandler.ts
+++ b/dashboard/hooks/useNavigationHandler.ts
@@ -26,7 +26,8 @@ export const useNavigationHandler = ({
                 url.searchParams.delete('page');
                 url.searchParams.delete('start');
                 url.searchParams.delete('end');
-                searchParams.navigate(url, true);
+                const relative = url.pathname + url.search;
+                searchParams.navigate(relative, true);
             }
             setTableView(null);
         } catch (err) {
@@ -45,7 +46,8 @@ export const useNavigationHandler = ({
             } else {
                 url.searchParams.delete('sequencer');
             }
-            searchParams.navigate(url);
+            const relative = url.pathname + url.search;
+            searchParams.navigate(relative);
         } catch (err) {
             console.error('Failed to handle sequencer change:', err);
             onError('Failed to update sequencer selection.');

--- a/dashboard/hooks/useTableActions.ts
+++ b/dashboard/hooks/useTableActions.ts
@@ -69,7 +69,8 @@ export const useTableActions = (
 
         const newUrl = url.toString();
         if (newUrl !== window.location.href) {
-          searchParams.navigate(url, false);
+          const relative = url.pathname + url.search;
+          searchParams.navigate(relative, false);
         }
       } catch (err) {
         console.error('Failed to set table URL:', err);


### PR DESCRIPTION
## Summary
- navigate using path and search only for same-origin URLs

## Testing
- `npm run check --prefix dashboard`
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68407629e6d48328998a5f621cae8b78