### PR TITLE
Fix NaN brush values

### DIFF
--- a/dashboard/components/BatchProcessChart.tsx
+++ b/dashboard/components/BatchProcessChart.tsx
@@ -53,7 +53,13 @@ const BatchProcessChartComponent: React.FC<BatchProcessChartProps> = ({
     startIndex?: number;
     endIndex?: number;
   }) => {
-    if (range.startIndex == null || range.endIndex == null) return;
+    if (
+      range.startIndex == null ||
+      range.endIndex == null ||
+      !Number.isFinite(range.startIndex) ||
+      !Number.isFinite(range.endIndex)
+    )
+      return;
     const maxRange = 500;
     if (range.endIndex - range.startIndex > maxRange) {
       setBrushRange({

--- a/dashboard/components/BlobsPerBatchChart.tsx
+++ b/dashboard/components/BlobsPerBatchChart.tsx
@@ -44,7 +44,13 @@ const BlobsPerBatchChartComponent: React.FC<BlobsPerBatchChartProps> = ({
     startIndex?: number;
     endIndex?: number;
   }) => {
-    if (range.startIndex == null || range.endIndex == null) return;
+    if (
+      range.startIndex == null ||
+      range.endIndex == null ||
+      !Number.isFinite(range.startIndex) ||
+      !Number.isFinite(range.endIndex)
+    )
+      return;
     const maxRange = 500;
     if (range.endIndex - range.startIndex > maxRange) {
       setBrushRange({

--- a/dashboard/components/BlockTimeChart.tsx
+++ b/dashboard/components/BlockTimeChart.tsx
@@ -54,7 +54,13 @@ const BlockTimeChartComponent: React.FC<BlockTimeChartProps> = ({
     startIndex?: number;
     endIndex?: number;
   }) => {
-    if (range.startIndex == null || range.endIndex == null) return;
+    if (
+      range.startIndex == null ||
+      range.endIndex == null ||
+      !Number.isFinite(range.startIndex) ||
+      !Number.isFinite(range.endIndex)
+    )
+      return;
     const maxRange = 500;
     if (range.endIndex - range.startIndex > maxRange) {
       setBrushRange({

--- a/dashboard/components/BlockTxChart.tsx
+++ b/dashboard/components/BlockTxChart.tsx
@@ -48,7 +48,13 @@ const BlockTxChartComponent: React.FC<BlockTxChartProps> = ({
     startIndex?: number;
     endIndex?: number;
   }) => {
-    if (range.startIndex == null || range.endIndex == null) return;
+    if (
+      range.startIndex == null ||
+      range.endIndex == null ||
+      !Number.isFinite(range.startIndex) ||
+      !Number.isFinite(range.endIndex)
+    )
+      return;
     const maxRange = 500;
     if (range.endIndex - range.startIndex > maxRange) {
       setBrushRange({

--- a/dashboard/components/GasUsedChart.tsx
+++ b/dashboard/components/GasUsedChart.tsx
@@ -44,7 +44,13 @@ const GasUsedChartComponent: React.FC<GasUsedChartProps> = ({
     startIndex?: number;
     endIndex?: number;
   }) => {
-    if (range.startIndex == null || range.endIndex == null) return;
+    if (
+      range.startIndex == null ||
+      range.endIndex == null ||
+      !Number.isFinite(range.startIndex) ||
+      !Number.isFinite(range.endIndex)
+    )
+      return;
     const maxRange = 500;
     if (range.endIndex - range.startIndex > maxRange) {
       setBrushRange({

--- a/dashboard/components/MissedBlockChart.tsx
+++ b/dashboard/components/MissedBlockChart.tsx
@@ -45,7 +45,13 @@ const MissedBlockChartComponent: React.FC<MissedBlockChartProps> = ({
     startIndex?: number;
     endIndex?: number;
   }) => {
-    if (range.startIndex == null || range.endIndex == null) return;
+    if (
+      range.startIndex == null ||
+      range.endIndex == null ||
+      !Number.isFinite(range.startIndex) ||
+      !Number.isFinite(range.endIndex)
+    )
+      return;
     const maxRange = 500;
     if (range.endIndex - range.startIndex > maxRange) {
       setBrushRange({

--- a/dashboard/components/ReorgDepthChart.tsx
+++ b/dashboard/components/ReorgDepthChart.tsx
@@ -41,7 +41,13 @@ const ReorgDepthChartComponent: React.FC<ReorgDepthChartProps> = ({ data }) => {
     startIndex?: number;
     endIndex?: number;
   }) => {
-    if (range.startIndex == null || range.endIndex == null) return;
+    if (
+      range.startIndex == null ||
+      range.endIndex == null ||
+      !Number.isFinite(range.startIndex) ||
+      !Number.isFinite(range.endIndex)
+    )
+      return;
     const maxRange = 500;
     if (range.endIndex - range.startIndex > maxRange) {
       setBrushRange({


### PR DESCRIPTION
## Summary
- guard against NaN values in chart brush change handlers

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_684084fe2fc883289ec2d53d14e4fe2a