### PR TITLE
Fix economics view navigation

### DIFF
--- a/dashboard/components/DashboardHeader.tsx
+++ b/dashboard/components/DashboardHeader.tsx
@@ -3,6 +3,7 @@ import { TimeRange } from '../types';
 import { RefreshCountdown } from './RefreshCountdown';
 import { TAIKO_PINK } from '../theme';
 import { isValidRefreshRate } from '../utils';
+import { useSearchParams } from '../hooks/useSearchParams';
 
 const metaEnv = (import.meta as any).env as ImportMetaEnv | undefined;
 const NETWORK_NAME =
@@ -31,6 +32,7 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({
   selectedSequencer,
   onSequencerChange,
 }) => {
+  const searchParams = useSearchParams();
   return (
     <header className="flex flex-col md:flex-row justify-between items-center pb-4 border-b border-gray-200">
       <div className="flex items-baseline space-x-4">
@@ -46,7 +48,7 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({
               url.searchParams.delete('page');
               url.searchParams.delete('start');
               url.searchParams.delete('end');
-              window.history.pushState(null, '', url.toString());
+              searchParams.navigate(url);
             } catch (err) {
               console.error('Failed to navigate to home:', err);
               // Fallback: reload page
@@ -70,7 +72,7 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({
                 url.searchParams.set('view', 'economics');
               }
               url.searchParams.delete('table');
-              window.history.pushState(null, '', url.toString());
+              searchParams.navigate(url);
             } catch (err) {
               console.error('Failed to toggle economics view:', err);
               // Fallback: just reload the page with economics parameter

--- a/dashboard/hooks/useSearchParams.ts
+++ b/dashboard/hooks/useSearchParams.ts
@@ -21,7 +21,8 @@ export const useSearchParams = (): URLSearchParams & {
   const [params] = useRouterSearchParams();
   const routerNavigate = useNavigate();
   const [navigationState, setNavigationState] = useState<NavigationState>({
-    canGoBack: window.history.length > 1,
+    canGoBack:
+      typeof window !== 'undefined' ? window.history.length > 1 : false,
     isNavigating: false,
     errorCount: 0,
     lastError: undefined,
@@ -43,7 +44,8 @@ export const useSearchParams = (): URLSearchParams & {
         setNavigationState((prev) => ({
           ...prev,
           isNavigating: false,
-          canGoBack: window.history.length > 1,
+          canGoBack:
+            typeof window !== 'undefined' ? window.history.length > 1 : false,
         }));
       }
     },
@@ -59,6 +61,7 @@ export const useSearchParams = (): URLSearchParams & {
   }, [routerNavigate]);
 
   useEffect(() => {
+    if (typeof window === 'undefined') return;
     const handlePop = () => {
       setNavigationState((prev) => ({
         ...prev,

--- a/dashboard/tests/dashboardHeader.test.ts
+++ b/dashboard/tests/dashboardHeader.test.ts
@@ -1,22 +1,27 @@
 import { describe, it, expect } from 'vitest';
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
+import { MemoryRouter } from 'react-router-dom';
 import { DashboardHeader } from '../components/DashboardHeader';
 
 describe('DashboardHeader', () => {
   it('renders time range and refresh controls', () => {
     const html = renderToStaticMarkup(
-      React.createElement(DashboardHeader, {
-        timeRange: '1h',
-        onTimeRangeChange: () => {},
-        refreshRate: 60000,
-        onRefreshRateChange: () => {},
-        lastRefresh: Date.now(),
-        onManualRefresh: () => {},
-        sequencers: ['seq1', 'seq2'],
-        selectedSequencer: null,
-        onSequencerChange: () => {},
-      }),
+      React.createElement(
+        MemoryRouter,
+        null,
+        React.createElement(DashboardHeader, {
+          timeRange: '1h',
+          onTimeRangeChange: () => {},
+          refreshRate: 60000,
+          onRefreshRateChange: () => {},
+          lastRefresh: Date.now(),
+          onManualRefresh: () => {},
+          sequencers: ['seq1', 'seq2'],
+          selectedSequencer: null,
+          onSequencerChange: () => {},
+        }),
+      ),
     );
     expect(html.includes('Taiko Masaya Testnet')).toBe(true);
     expect(html.includes('1H')).toBe(true);


### PR DESCRIPTION
## Summary
- update DashboardHeader to use router search params for navigation
- guard access to `window` in `useSearchParams`
- wrap DashboardHeader test with MemoryRouter

## Testing
- `just check-dashboard`
- `just test-dashboard`
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_684084f7db0c83289b9da479763256c8