### PR TITLE
Add dashboard utility tests

### DIFF
--- a/dashboard/tests/dataFetcher.test.ts
+++ b/dashboard/tests/dataFetcher.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  fetchMainDashboardData,
+  fetchEconomicsData,
+} from '../utils/dataFetcher';
+import * as api from '../services/apiService.ts';
+
+type Res<T> = { data: T; badRequest: boolean; error: null };
+const ok = <T>(data: T): Res<T> => ({ data, badRequest: false, error: null });
+
+// helper to set all mocks to return provided data
+function setAll(data: Partial<Record<keyof typeof api, unknown>>) {
+  for (const [key, value] of Object.entries(data)) {
+    // @ts-ignore
+    vi.spyOn(api, key as any).mockResolvedValue(value);
+  }
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('dataFetcher', () => {
+  it('aggregates main dashboard data', async () => {
+    setAll({
+      fetchL2BlockCadence: ok(1),
+      fetchBatchPostingCadence: ok(2),
+      fetchAvgProveTime: ok(3),
+      fetchAvgVerifyTime: ok(4),
+      fetchAvgL2Tps: ok(5),
+      fetchPreconfData: ok({
+        candidates: ['a'],
+        current_operator: 'x',
+        next_operator: 'y',
+      }),
+      fetchL2Reorgs: ok(6),
+      fetchSlashingEventCount: ok(7),
+      fetchForcedInclusionCount: ok(8),
+      fetchMissedProposalCount: ok(9),
+      fetchL2HeadBlock: ok(10),
+      fetchL1HeadBlock: ok(11),
+      fetchProveTimes: ok([{ name: '1', value: 1, timestamp: 0 }]),
+      fetchVerifyTimes: ok([{ name: '2', value: 2, timestamp: 0 }]),
+      fetchL1BlockTimes: ok([{ value: 1, timestamp: 0 }]),
+      fetchL2BlockTimes: ok([{ value: 2, timestamp: 0 }]),
+      fetchL2GasUsed: ok([{ value: 3, timestamp: 0 }]),
+      fetchSequencerDistribution: ok([{ name: 'foo', value: 1 }]),
+      fetchBlockTransactions: ok([{ block: 1, txs: 2, sequencer: 'bar' }]),
+      fetchBatchBlobCounts: ok([{ batch: 1, blobs: 2 }]),
+      fetchL2TxFee: ok(12),
+      fetchCloudCost: ok(13),
+    });
+
+    const res = await fetchMainDashboardData('1h', null);
+    expect(res.avgProve).toBe(3);
+    expect(res.avgVerify).toBe(4);
+    expect(res.sequencerDist[0].name).toBe('foo');
+    expect(res.txPerBlock).toHaveLength(1);
+    expect(res.badRequestResults).toHaveLength(20);
+  });
+
+  it('defaults to empty arrays when service data missing', async () => {
+    setAll({
+      fetchL2BlockCadence: ok(null),
+      fetchBatchPostingCadence: ok(null),
+      fetchAvgProveTime: ok(null),
+      fetchAvgVerifyTime: ok(null),
+      fetchAvgL2Tps: ok(null),
+      fetchPreconfData: ok(null),
+      fetchL2Reorgs: ok(null),
+      fetchSlashingEventCount: ok(null),
+      fetchForcedInclusionCount: ok(null),
+      fetchMissedProposalCount: ok(null),
+      fetchL2HeadBlock: ok(null),
+      fetchL1HeadBlock: ok(null),
+      fetchProveTimes: ok(null),
+      fetchVerifyTimes: ok(null),
+      fetchL1BlockTimes: ok(null),
+      fetchL2BlockTimes: ok(null),
+      fetchL2GasUsed: ok(null),
+      fetchSequencerDistribution: ok(null),
+      fetchBlockTransactions: ok(null),
+      fetchBatchBlobCounts: ok(null),
+      fetchL2TxFee: ok(null),
+      fetchCloudCost: ok(null),
+    });
+
+    const res = await fetchMainDashboardData('1h', null);
+    expect(res.proveTimes).toEqual([]);
+    expect(res.sequencerDist).toEqual([]);
+    expect(res.txPerBlock).toEqual([]);
+    expect(res.blobsPerBatch).toEqual([]);
+  });
+
+  it('fetches economics data', async () => {
+    setAll({
+      fetchL2TxFee: ok(1),
+      fetchL2HeadBlock: ok(2),
+      fetchL1HeadBlock: ok(3),
+    });
+
+    const res = await fetchEconomicsData('1h', null);
+    expect(res.l2TxFee).toBe(1);
+    expect(res.l2Block).toBe(2);
+    expect(res.l1Block).toBe(3);
+    expect(res.badRequestResults).toHaveLength(3);
+  });
+});

--- a/dashboard/tests/metricsCreator.test.ts
+++ b/dashboard/tests/metricsCreator.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import React from 'react';
+import { createMetrics } from '../utils/metricsCreator';
+
+const addressA = '0x00a00800c28f2616360dcfadee02d761d14ad94e';
+const addressB = '0x00b00194cdc219921784ab1eb4eaa9634fe1f1a8';
+
+describe('metricsCreator', () => {
+  it('creates properly formatted metrics', () => {
+    const metrics = createMetrics({
+      avgTps: 1.234,
+      l2Cadence: 60000,
+      batchCadence: 30000,
+      avgProve: 2000,
+      avgVerify: 3000,
+      activeGateways: 2,
+      currentOperator: addressA,
+      nextOperator: addressB,
+      l2Reorgs: 1,
+      slashings: 2,
+      forcedInclusions: 3,
+      missedProposals: 4,
+      l2TxFee: 42e18,
+      cloudCost: 7.89,
+      l2Block: 100,
+      l1Block: 50,
+    });
+
+    expect(metrics).toHaveLength(16);
+    expect(metrics[0].value).toBe('1.23');
+
+    const verifyMetric = metrics.find((m) => React.isValidElement(m.title));
+    expect(verifyMetric).toBeDefined();
+    const link = verifyMetric!.title as React.ReactElement;
+    expect(link.type).toBe('a');
+    expect((link as any).props.href).toContain('block-states');
+    expect((link as any).props.children).toBe('Avg. Verify Time');
+    expect(verifyMetric!.value).toBe('3.00s');
+
+    const current = metrics.find((m) => m.title === 'Current Sequencer');
+    const next = metrics.find((m) => m.title === 'Next Sequencer');
+    expect(current?.value).toBe('Chainbound A');
+    expect(next?.value).toBe('Chainbound B');
+  });
+
+  it('falls back to N/A for missing values', () => {
+    const metrics = createMetrics({
+      avgTps: null,
+      l2Cadence: null,
+      batchCadence: null,
+      avgProve: null,
+      avgVerify: null,
+      activeGateways: null,
+      currentOperator: null,
+      nextOperator: null,
+      l2Reorgs: null,
+      slashings: null,
+      forcedInclusions: null,
+      missedProposals: null,
+      l2TxFee: null,
+      cloudCost: null,
+      l2Block: null,
+      l1Block: null,
+    });
+
+    for (const metric of metrics) {
+      expect(metric.value).toBe('N/A');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add metricsCreator tests to verify formatting and links
- test dataFetcher with success and fallback scenarios

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68408715a3bc8328b1d4379964b2799b