### PR TITLE
Fix missed proposals table action

### DIFF
--- a/dashboard/tests/navigationUtils.test.ts
+++ b/dashboard/tests/navigationUtils.test.ts
@@ -114,6 +114,14 @@ describe('navigationUtils', () => {
       const invalid = new URLSearchParams('sort=up&filter=<bad>');
       expect(validateSearchParams(invalid)).toBe(false);
     });
+
+    it('should validate table parameters', () => {
+      const params = new URLSearchParams('table=missed-proposals');
+      expect(validateSearchParams(params)).toBe(true);
+
+      const invalid = new URLSearchParams('table=../../etc');
+      expect(validateSearchParams(invalid)).toBe(false);
+    });
   });
 
   describe('cleanSearchParams', () => {
@@ -159,6 +167,14 @@ describe('navigationUtils', () => {
 
       expect(cleaned.get('sort')).toBeNull();
       expect(cleaned.get('filter')).toBeNull();
+    });
+
+    it('should keep valid table parameter', () => {
+      const params = new URLSearchParams('table=missed-proposals&bad=1');
+      const cleaned = cleanSearchParams(params);
+
+      expect(cleaned.get('table')).toBe('missed-proposals');
+      expect(cleaned.get('bad')).toBeNull();
     });
   });
 

--- a/dashboard/utils/navigationUtils.ts
+++ b/dashboard/utils/navigationUtils.ts
@@ -98,6 +98,12 @@ export const validateSearchParams = (params: URLSearchParams): boolean => {
       return false;
     }
 
+    const table = params.get('table');
+    if (table && !/^[a-zA-Z0-9_-]+$/.test(table)) {
+      console.warn('Invalid table parameter:', table);
+      return false;
+    }
+
     const sort = params.get('sort');
     if (sort && !['asc', 'desc'].includes(sort)) {
       console.warn('Invalid sort parameter:', sort);
@@ -128,6 +134,7 @@ export const cleanSearchParams = (params: URLSearchParams): URLSearchParams => {
       range: (v) => ['1h', '24h', '7d'].includes(v),
       sequencer: (v) => /^[0-9a-zA-Z]+$/.test(v),
       address: (v) => /^[0-9a-zA-Z]+$/.test(v),
+      table: (v) => /^[a-zA-Z0-9_-]+$/.test(v),
       sort: (v) => ['asc', 'desc'].includes(v),
       filter: (v) => /^[a-zA-Z0-9_-]+$/.test(v),
     };


### PR DESCRIPTION
## Summary
- keep `table` search parameter in URL sanitization logic
- validate `table` param so we don't drop it
- test navigation utils with table parameter

## Testing
- `just lint-dashboard`
- `just check-dashboard`
- `just test-dashboard`
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_684088cb9c9c83288c989cc32d1dd3c2