### PR TITLE
Refactor dashboard routing

### DIFF
--- a/dashboard/App.tsx
+++ b/dashboard/App.tsx
@@ -16,7 +16,6 @@ const App: React.FC = () => {
     chartsData,
     blockData,
     refreshTimer,
-    searchParams,
 
     // Table state
     tableView,
@@ -38,7 +37,7 @@ const App: React.FC = () => {
       <TableView
         tableView={tableView}
         tableLoading={tableLoading}
-        isNavigating={searchParams.navigationState.isNavigating}
+        isNavigating={false}
         refreshTimer={refreshTimer}
         sequencerList={sequencerList}
         selectedSequencer={selectedSequencer}

--- a/dashboard/components/DashboardHeader.tsx
+++ b/dashboard/components/DashboardHeader.tsx
@@ -3,7 +3,7 @@ import { TimeRange } from '../types';
 import { RefreshCountdown } from './RefreshCountdown';
 import { TAIKO_PINK } from '../theme';
 import { isValidRefreshRate } from '../utils';
-import { useSearchParams } from '../hooks/useSearchParams';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 
 const metaEnv = (import.meta as any).env as ImportMetaEnv | undefined;
 const NETWORK_NAME =
@@ -32,7 +32,8 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({
   selectedSequencer,
   onSequencerChange,
 }) => {
-  const searchParams = useSearchParams();
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   return (
     <header className="flex flex-col md:flex-row justify-between items-center pb-4 border-b border-gray-200">
       <div className="flex items-baseline space-x-4">
@@ -41,17 +42,10 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({
           style={{ color: TAIKO_PINK }}
           onClick={() => {
             try {
-              const url = new URL(window.location.href);
-              url.searchParams.delete('view');
-              url.searchParams.delete('table');
-              url.searchParams.delete('address');
-              url.searchParams.delete('page');
-              url.searchParams.delete('start');
-              url.searchParams.delete('end');
-              searchParams.navigate(url);
+              setSearchParams({});
+              navigate('/');
             } catch (err) {
               console.error('Failed to navigate to home:', err);
-              // Fallback: reload page
               window.location.href = window.location.pathname;
             }
           }}
@@ -65,17 +59,16 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({
         <button
           onClick={() => {
             try {
-              const url = new URL(window.location.href);
-              if (url.searchParams.get('view') === 'economics') {
-                url.searchParams.delete('view');
+              const params = new URLSearchParams(searchParams);
+              if (params.get('view') === 'economics') {
+                params.delete('view');
               } else {
-                url.searchParams.set('view', 'economics');
+                params.set('view', 'economics');
               }
-              url.searchParams.delete('table');
-              searchParams.navigate(url);
+              params.delete('table');
+              navigate({ search: params.toString() });
             } catch (err) {
               console.error('Failed to toggle economics view:', err);
-              // Fallback: just reload the page with economics parameter
               const fallbackUrl = new URL(window.location.href);
               try {
                 fallbackUrl.searchParams.set('view', 'economics');

--- a/dashboard/components/layout/ErrorDisplay.tsx
+++ b/dashboard/components/layout/ErrorDisplay.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 interface ErrorDisplayProps {
     errorMessage: string;
     navigationError?: string;
-    errorCount: number;
+    errorCount?: number;
     onResetNavigation: () => void;
     onClearError: () => void;
 }
@@ -16,6 +16,7 @@ export const ErrorDisplay: React.FC<ErrorDisplayProps> = ({
     onClearError,
 }) => {
     const displayError = errorMessage || navigationError;
+    const count = errorCount ?? 0;
 
     if (!displayError) return null;
 
@@ -24,14 +25,14 @@ export const ErrorDisplay: React.FC<ErrorDisplayProps> = ({
             <div className="flex justify-between items-start">
                 <div className="flex-1">
                     {displayError}
-                    {errorCount > 0 && (
+                    {count > 0 && (
                         <div className="text-sm mt-1 text-red-600">
                             Navigation issues detected. Try refreshing the page if problems persist.
                         </div>
                     )}
                 </div>
                 <div className="flex space-x-2 ml-4">
-                    {errorCount > 2 && (
+                    {count > 2 && (
                         <button
                             onClick={onResetNavigation}
                             className="text-sm bg-red-600 text-white px-2 py-1 rounded hover:bg-red-700"

--- a/dashboard/components/views/DashboardView.tsx
+++ b/dashboard/components/views/DashboardView.tsx
@@ -5,7 +5,7 @@ import { MetricsGrid } from '../layout/MetricsGrid';
 import { ChartsGrid } from '../layout/ChartsGrid';
 import { TAIKO_PINK } from '../../theme';
 import { TimeRange, MetricData } from '../../types';
-import { useSearchParams } from '../../hooks/useSearchParams';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 
 interface DashboardViewProps {
     timeRange: TimeRange;
@@ -54,7 +54,8 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
     onOpenTpsTable,
     onOpenSequencerDistributionTable,
 }) => {
-    const searchParams = useSearchParams();
+    const navigate = useNavigate();
+    const [searchParams] = useSearchParams();
     const isEconomicsView = searchParams.get('view') === 'economics';
 
     const visibleMetrics = React.useMemo(
@@ -104,13 +105,9 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
         : groupOrder;
 
     const handleResetNavigation = useCallback(() => {
-        try {
-            searchParams.resetNavigation();
-            metricsData.setErrorMessage('');
-        } catch (err) {
-            console.error('Failed to reset navigation:', err);
-        }
-    }, [searchParams, metricsData]);
+        navigate('/', { replace: true });
+        metricsData.setErrorMessage('');
+    }, [navigate, metricsData]);
 
     const handleClearError = useCallback(() => {
         metricsData.setErrorMessage('');
@@ -148,8 +145,6 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
 
             <ErrorDisplay
                 errorMessage={metricsData.errorMessage}
-                navigationError={searchParams.navigationState.lastError}
-                errorCount={searchParams.navigationState.errorCount}
                 onResetNavigation={handleResetNavigation}
                 onClearError={handleClearError}
             />

--- a/dashboard/hooks/useDashboardController.ts
+++ b/dashboard/hooks/useDashboardController.ts
@@ -9,11 +9,11 @@ import { useNavigationHandler } from './useNavigationHandler';
 import { useDataFetcher } from './useDataFetcher';
 import { useSequencerHandler } from './useSequencerHandler';
 import { useTableActions } from './useTableActions';
-import { useSearchParams } from './useSearchParams';
+import { useSearchParams } from 'react-router-dom';
 
 export const useDashboardController = () => {
     const [timeRange, setTimeRange] = useState<TimeRange>('1h');
-    const searchParams = useSearchParams();
+    const [searchParams] = useSearchParams();
 
     // Data management hooks
     const metricsData = useMetricsData();

--- a/dashboard/hooks/useDataFetcher.ts
+++ b/dashboard/hooks/useDataFetcher.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo } from 'react';
 import useSWR from 'swr';
 import { TimeRange } from '../types';
-import { useSearchParams } from './useSearchParams';
+import { useSearchParams } from 'react-router-dom';
 import { TableViewState } from './useTableActions';
 
 interface UseDataFetcherProps {
@@ -26,7 +26,7 @@ export const useDataFetcher = ({
   refreshRate,
   updateLastRefresh,
 }: UseDataFetcherProps) => {
-  const searchParams = useSearchParams();
+  const [searchParams] = useSearchParams();
 
   // Memoize the specific value we need to prevent infinite re-renders
   const viewParam = searchParams.get('view');

--- a/dashboard/hooks/useMetricsData.ts
+++ b/dashboard/hooks/useMetricsData.ts
@@ -3,14 +3,14 @@ import { MetricData, TimeRange } from '../types';
 import { createMetrics, type MetricInputData } from '../utils/metricsCreator';
 import { hasBadRequest, getErrorMessage } from '../utils/errorHandler';
 import { fetchMainDashboardData, fetchEconomicsData } from '../utils/dataFetcher';
-import { useSearchParams } from './useSearchParams';
+import { useSearchParams } from 'react-router-dom';
 
 export const useMetricsData = () => {
     const [metrics, setMetrics] = useState<MetricData[]>([]);
     const [loadingMetrics, setLoadingMetrics] = useState(true);
     const [errorMessage, setErrorMessage] = useState<string>('');
 
-    const searchParams = useSearchParams();
+    const [searchParams] = useSearchParams();
 
     // Memoize the specific value we need to prevent infinite re-renders
     const viewParam = searchParams.get('view');

--- a/dashboard/hooks/useSearchParams.ts
+++ b/dashboard/hooks/useSearchParams.ts
@@ -3,7 +3,6 @@ import {
   useSearchParams as useRouterSearchParams,
   useNavigate,
 } from 'react-router-dom';
-import { safeNavigate } from '../utils/navigationUtils';
 
 interface NavigationState {
   canGoBack: boolean;
@@ -32,7 +31,8 @@ export const useSearchParams = (): URLSearchParams & {
     (url: string | URL, replace = false) => {
       setNavigationState((prev) => ({ ...prev, isNavigating: true }));
       try {
-        safeNavigate(routerNavigate, url, replace);
+        const to = url instanceof URL ? url.pathname + url.search : url;
+        routerNavigate(to, { replace });
       } catch (err) {
         console.error('Navigation error:', err);
         setNavigationState((prev) => ({
@@ -57,7 +57,7 @@ export const useSearchParams = (): URLSearchParams & {
   }, [routerNavigate]);
 
   const resetNavigation = useCallback(() => {
-    safeNavigate(routerNavigate, '/', true);
+    routerNavigate('/', { replace: true });
   }, [routerNavigate]);
 
   useEffect(() => {

--- a/dashboard/hooks/useSequencerHandler.ts
+++ b/dashboard/hooks/useSequencerHandler.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, useRef } from 'react';
-import { useSearchParams } from './useSearchParams';
+import { useSearchParams } from 'react-router-dom';
 
 interface UseSequencerHandlerProps {
     chartsData: {
@@ -21,7 +21,7 @@ export const useSequencerHandler = ({
     blockData,
     metricsData,
 }: UseSequencerHandlerProps) => {
-    const searchParams = useSearchParams();
+    const [searchParams] = useSearchParams();
     const [selectedSequencer, setSelectedSequencer] = useState<string | null>(
         searchParams.get('sequencer'),
     );

--- a/dashboard/hooks/useTableActions.ts
+++ b/dashboard/hooks/useTableActions.ts
@@ -1,5 +1,5 @@
 import React, { useState, useCallback } from 'react';
-import { useSearchParams } from './useSearchParams';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { TimeRange } from '../types';
 import { TABLE_CONFIGS } from '../config/tableConfig';
 import { getSequencerAddress } from '../sequencerConfig';
@@ -42,7 +42,8 @@ export const useTableActions = (
   l2BlockTimeData: any[],
 ) => {
   const [tableView, setTableView] = useState<TableViewState | null>(null);
-  const searchParams = useSearchParams();
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const [tableLoading, setTableLoading] = useState<boolean>(
     searchParams.get('view') === 'table',
   );
@@ -54,30 +55,24 @@ export const useTableActions = (
       params: Record<string, string | number | undefined> = {},
     ) => {
       try {
-        const url = new URL(window.location.href);
-        url.searchParams.set('view', 'table');
-        url.searchParams.set('table', name);
+        const newParams = new URLSearchParams(searchParams);
+        newParams.set('view', 'table');
+        newParams.set('table', name);
 
-        // remove stale parameters when switching tables
         ['address', 'page', 'start', 'end'].forEach((key) => {
-          url.searchParams.delete(key);
+          newParams.delete(key);
         });
 
         Object.entries(params).forEach(([k, v]) => {
-          if (v !== undefined) url.searchParams.set(k, String(v));
+          if (v !== undefined) newParams.set(k, String(v));
         });
 
-        const newUrl = url.toString();
-        if (newUrl !== window.location.href) {
-          const relative = url.pathname + url.search;
-          searchParams.navigate(relative, false);
-        }
+        navigate({ search: newParams.toString() }, { replace: false });
       } catch (err) {
         console.error('Failed to set table URL:', err);
-        // Don't throw to prevent breaking the table functionality
       }
     },
-    [searchParams],
+    [navigate, searchParams],
   );
 
   const openTable = useCallback(

--- a/dashboard/hooks/useTableRouter.ts
+++ b/dashboard/hooks/useTableRouter.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo } from 'react';
 import { TimeRange } from '../types';
-import { useSearchParams } from './useSearchParams';
+import { useSearchParams } from 'react-router-dom';
 import { TableViewState } from './useTableActions';
 
 interface UseTableRouterProps {
@@ -24,7 +24,7 @@ export const useTableRouter = ({
     openSequencerDistributionTable,
     onError,
 }: UseTableRouterProps) => {
-    const searchParams = useSearchParams();
+    const [searchParams] = useSearchParams();
 
     // Extract specific search param values to avoid unstable object dependencies
     const urlParams = useMemo(() => ({


### PR DESCRIPTION
## Summary
- replace custom navigation handlers with react-router helpers
- simplify dashboard header navigation logic
- use react-router search params in hooks and views
- loosen error display props

## Testing
- `just lint`
- `just lint-dashboard`
- `just check-dashboard`
- `just test`
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_6840883119a88328bb7f1cb62e659876