### PR TITLE
Fix dashboard navigation path handling

### DIFF
--- a/dashboard/tests/navigationUtils.test.ts
+++ b/dashboard/tests/navigationUtils.test.ts
@@ -43,7 +43,7 @@ describe('navigationUtils', () => {
   describe('sanitizeUrl', () => {
     it('should preserve same-origin URLs', () => {
       const url = 'https://example.com/dashboard?view=table';
-      expect(sanitizeUrl(url)).toBe(url);
+      expect(sanitizeUrl(url)).toBe('/dashboard?view=table');
     });
 
     it('should reject different-origin URLs', () => {
@@ -58,7 +58,7 @@ describe('navigationUtils', () => {
 
     it('should remove invalid search parameters', () => {
       const url = 'https://example.com/dashboard?view=table&page=-1&bad=1';
-      expect(sanitizeUrl(url)).toBe('https://example.com/dashboard?view=table');
+      expect(sanitizeUrl(url)).toBe('/dashboard?view=table');
     });
   });
 
@@ -172,10 +172,9 @@ describe('navigationUtils', () => {
     it('cleans search params', () => {
       const nav = vi.fn();
       safeNavigate(nav, '/dashboard?page=-1&view=table');
-      expect(nav).toHaveBeenCalledWith(
-        'https://example.com/dashboard?view=table',
-        { replace: false },
-      );
+      expect(nav).toHaveBeenCalledWith('/dashboard?view=table', {
+        replace: false,
+      });
     });
   });
 });

--- a/dashboard/utils/navigationUtils.ts
+++ b/dashboard/utils/navigationUtils.ts
@@ -61,7 +61,8 @@ export const sanitizeUrl = (url: string | URL): string => {
     urlObj.search = cleanSearchParams(urlObj.searchParams).toString();
     urlObj.hash = '';
 
-    return urlObj.toString();
+    // Return relative path for SPA navigation
+    return urlObj.pathname + urlObj.search;
   } catch (err) {
     console.error('Failed to sanitize URL:', err);
     return window.location.pathname;


### PR DESCRIPTION
## Summary
- sanitize URLs to return relative paths for SPA routing
- update navigation utils tests for new behaviour

## Testing
- `just lint-dashboard`
- `just check-dashboard`
- `just test-dashboard`
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_684088323d948328ba06143e875beb62