### PR TITLE
Add flexible time ranges

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -17,7 +17,7 @@ use axum::{
 use chrono::{Duration as ChronoDuration, Utc};
 #[cfg(test)]
 use clickhouse_lib::HashBytes;
-use clickhouse_lib::{AddressBytes, ClickhouseReader};
+use clickhouse_lib::{AddressBytes, ClickhouseReader, TimeRange};
 use dashmap::DashMap;
 use futures::stream::Stream;
 use hex::encode;
@@ -714,13 +714,7 @@ async fn avg_prove_time(
     State(state): State<ApiState>,
 ) -> Result<Json<AvgProveTimeResponse>, ErrorResponse> {
     let duration = range_duration(&params.range);
-    let avg = match if duration.num_hours() <= 1 {
-        state.client.get_avg_prove_time_last_hour().await
-    } else if duration.num_hours() <= 24 {
-        state.client.get_avg_prove_time_last_24_hours().await
-    } else {
-        state.client.get_avg_prove_time_last_7_days().await
-    } {
+    let avg = match state.client.get_avg_prove_time(TimeRange::from_duration(duration)).await {
         Ok(val) => val,
         Err(e) => {
             tracing::error!(error = %e, "Failed to get avg prove time");
@@ -753,13 +747,7 @@ async fn avg_verify_time(
     State(state): State<ApiState>,
 ) -> Result<Json<AvgVerifyTimeResponse>, ErrorResponse> {
     let duration = range_duration(&params.range);
-    let avg = match if duration.num_hours() <= 1 {
-        state.client.get_avg_verify_time_last_hour().await
-    } else if duration.num_hours() <= 24 {
-        state.client.get_avg_verify_time_last_24_hours().await
-    } else {
-        state.client.get_avg_verify_time_last_7_days().await
-    } {
+    let avg = match state.client.get_avg_verify_time(TimeRange::from_duration(duration)).await {
         Ok(val) => val,
         Err(e) => {
             tracing::error!(error = %e, "Failed to get avg verify time");

--- a/crates/clickhouse/src/lib.rs
+++ b/crates/clickhouse/src/lib.rs
@@ -24,7 +24,7 @@ pub mod types;
 pub mod writer;
 
 // Re-export main types for convenience
-pub use reader::ClickhouseReader;
+pub use reader::{ClickhouseReader, TimeRange};
 pub use writer::ClickhouseWriter;
 
 // Re-export all models for backward compatibility and ease of use


### PR DESCRIPTION
## Summary
- allow custom time ranges for metrics up to 7 days
- re-export `TimeRange` for API usage
- use new range handling in avg metrics endpoints

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6840897920488328a84bf28e1ae4c2fe