### PR TITLE
Fix localStorage error handling in dashboard

### DIFF
--- a/dashboard/utils.ts
+++ b/dashboard/utils.ts
@@ -88,18 +88,27 @@ export const bytesToHex = (bytes: number[]): string =>
 
 export const loadRefreshRate = (): number => {
   if (typeof localStorage === 'undefined') return 60000;
-  const stored = localStorage.getItem('refreshRate');
-  const value = stored ? parseInt(stored, 10) : NaN;
-  if (!Number.isFinite(value) || value < 60000) {
-    localStorage.removeItem('refreshRate');
+  try {
+    const stored = localStorage.getItem('refreshRate');
+    const value = stored ? parseInt(stored, 10) : NaN;
+    if (!Number.isFinite(value) || value < 60000) {
+      localStorage.removeItem('refreshRate');
+      return 60000;
+    }
+    return value;
+  } catch (err) {
+    console.error('Failed to access localStorage:', err);
     return 60000;
   }
-  return value;
 };
 
 export const saveRefreshRate = (rate: number): void => {
   if (typeof localStorage === 'undefined') return;
-  localStorage.setItem('refreshRate', String(rate));
+  try {
+    localStorage.setItem('refreshRate', String(rate));
+  } catch (err) {
+    console.error('Failed to save refresh rate:', err);
+  }
 };
 
 export const isValidRefreshRate = (rate: number): boolean =>


### PR DESCRIPTION
## Summary
- handle `localStorage` access errors in `loadRefreshRate` and `saveRefreshRate`

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_684148267f988328a277229f65799150