### PR TITLE
Fix economics link path in dashboard

### DIFF
--- a/dashboard/components/DashboardHeader.tsx
+++ b/dashboard/components/DashboardHeader.tsx
@@ -66,7 +66,7 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({
                 params.set('view', 'economics');
               }
               params.delete('table');
-              navigate({ search: params.toString() });
+              navigate({ pathname: '', search: params.toString() });
             } catch (err) {
               console.error('Failed to toggle economics view:', err);
               const fallbackUrl = new URL(window.location.href);

--- a/dashboard/hooks/useNavigationHandler.ts
+++ b/dashboard/hooks/useNavigationHandler.ts
@@ -3,50 +3,53 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import { TableViewState } from './useTableActions';
 
 interface UseNavigationHandlerProps {
-    setTableView: (view: TableViewState | null) => void;
-    onError: (message: string) => void;
+  setTableView: (view: TableViewState | null) => void;
+  onError: (message: string) => void;
 }
 
 export const useNavigationHandler = ({
-    setTableView,
-    onError,
+  setTableView,
+  onError,
 }: UseNavigationHandlerProps) => {
-    const navigate = useNavigate();
-    const [searchParams, setSearchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
 
-    const handleBack = useCallback(() => {
-        try {
-            if (window.history.length > 1) {
-                navigate(-1);
-            } else {
-                setSearchParams({});
-            }
-            setTableView(null);
-        } catch (err) {
-            console.error('Failed to handle back navigation:', err);
-            // Emergency fallback: just clear the table view
-            setTableView(null);
-            onError('Navigation error occurred.');
+  const handleBack = useCallback(() => {
+    try {
+      if (window.history.length > 1) {
+        navigate(-1);
+      } else {
+        setSearchParams({});
+      }
+      setTableView(null);
+    } catch (err) {
+      console.error('Failed to handle back navigation:', err);
+      // Emergency fallback: just clear the table view
+      setTableView(null);
+      onError('Navigation error occurred.');
+    }
+  }, [navigate, setSearchParams, setTableView, onError]);
+
+  const handleSequencerChange = useCallback(
+    (seq: string | null) => {
+      try {
+        const params = new URLSearchParams(searchParams);
+        if (seq) {
+          params.set('sequencer', seq);
+        } else {
+          params.delete('sequencer');
         }
-    }, [navigate, setSearchParams, setTableView, onError]);
+        navigate({ pathname: '', search: params.toString() });
+      } catch (err) {
+        console.error('Failed to handle sequencer change:', err);
+        onError('Failed to update sequencer selection.');
+      }
+    },
+    [navigate, searchParams, onError],
+  );
 
-    const handleSequencerChange = useCallback((seq: string | null) => {
-        try {
-            const params = new URLSearchParams(searchParams);
-            if (seq) {
-                params.set('sequencer', seq);
-            } else {
-                params.delete('sequencer');
-            }
-            navigate({ search: params.toString() });
-        } catch (err) {
-            console.error('Failed to handle sequencer change:', err);
-            onError('Failed to update sequencer selection.');
-        }
-    }, [navigate, searchParams, onError]);
-
-    return {
-        handleBack,
-        handleSequencerChange,
-    };
+  return {
+    handleBack,
+    handleSequencerChange,
+  };
 };

--- a/dashboard/hooks/useTableActions.ts
+++ b/dashboard/hooks/useTableActions.ts
@@ -67,7 +67,10 @@ export const useTableActions = (
           if (v !== undefined) newParams.set(k, String(v));
         });
 
-        navigate({ search: newParams.toString() }, { replace: false });
+        navigate(
+          { pathname: '', search: newParams.toString() },
+          { replace: false },
+        );
       } catch (err) {
         console.error('Failed to set table URL:', err);
       }
@@ -155,20 +158,30 @@ export const useTableActions = (
             const refreshMappedData = config.mapData
               ? config.mapData(refreshDataResult, extraParams)
               : refreshDataResult;
-            const refreshChart = config.chart ? config.chart(refreshDataResult) : undefined;
+            const refreshChart = config.chart
+              ? config.chart(refreshDataResult)
+              : undefined;
 
-            setTableView(prev => prev ? {
-              ...prev,
-              rows: refreshMappedData,
-              chart: refreshChart,
-            } : null);
+            setTableView((prev) =>
+              prev
+                ? {
+                    ...prev,
+                    rows: refreshMappedData,
+                    chart: refreshChart,
+                  }
+                : null,
+            );
           } catch (error) {
             console.error(`Failed to refresh ${tableKey} table:`, error);
             // Optionally show user-facing error
-            setTableView(prev => prev ? {
-              ...prev,
-              rows: [], // Clear data on error to prevent stale data
-            } : null);
+            setTableView((prev) =>
+              prev
+                ? {
+                    ...prev,
+                    rows: [], // Clear data on error to prevent stale data
+                  }
+                : null,
+            );
           }
         };
 
@@ -181,9 +194,9 @@ export const useTableActions = (
           mappedData,
           tableKey === 'sequencer-dist'
             ? (row) =>
-              openGenericTable('sequencer-blocks', range, {
-                address: row.name,
-              })
+                openGenericTable('sequencer-blocks', range, {
+                  address: row.name,
+                })
             : undefined,
           undefined,
           undefined,
@@ -197,7 +210,14 @@ export const useTableActions = (
         setTableLoading(false);
       }
     },
-    [timeRange, setTimeRange, selectedSequencer, openTable, setTableUrl, setTableView],
+    [
+      timeRange,
+      setTimeRange,
+      selectedSequencer,
+      openTable,
+      setTableUrl,
+      setTableView,
+    ],
   );
 
   const openTpsTable = useCallback(() => {
@@ -294,25 +314,46 @@ export const useTableActions = (
             ),
           ]);
 
-          setTableView(prev => prev ? {
-            ...prev,
-            rows: (refreshDistRes.data || []) as unknown as Record<string, string | number>[],
-            extraTable: prev.extraTable ? {
-              ...prev.extraTable,
-              rows: (refreshTxRes.data || []) as unknown as Record<string, string | number>[],
-            } : undefined,
-          } : null);
+          setTableView((prev) =>
+            prev
+              ? {
+                  ...prev,
+                  rows: (refreshDistRes.data || []) as unknown as Record<
+                    string,
+                    string | number
+                  >[],
+                  extraTable: prev.extraTable
+                    ? {
+                        ...prev.extraTable,
+                        rows: (refreshTxRes.data || []) as unknown as Record<
+                          string,
+                          string | number
+                        >[],
+                      }
+                    : undefined,
+                }
+              : null,
+          );
         } catch (error) {
-          console.error('Failed to refresh sequencer distribution table:', error);
+          console.error(
+            'Failed to refresh sequencer distribution table:',
+            error,
+          );
           // Clear data on error to prevent showing stale information
-          setTableView(prev => prev ? {
-            ...prev,
-            rows: [],
-            extraTable: prev.extraTable ? {
-              ...prev.extraTable,
-              rows: [],
-            } : undefined,
-          } : null);
+          setTableView((prev) =>
+            prev
+              ? {
+                  ...prev,
+                  rows: [],
+                  extraTable: prev.extraTable
+                    ? {
+                        ...prev.extraTable,
+                        rows: [],
+                      }
+                    : undefined,
+                }
+              : null,
+          );
         }
       };
 


### PR DESCRIPTION
## Summary
- keep same pathname when toggling Economics view
- preserve pathname for sequencer navigation
- maintain pathname for table navigation

## Testing
- `just check-dashboard`
- `npm run lint:whitespace` in dashboard
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_68414b916ef88328917a787d0bf8dae4