### PR TITLE
Fix NaN errors when changing dashboard range

### DIFF
--- a/dashboard/components/BatchProcessChart.tsx
+++ b/dashboard/components/BatchProcessChart.tsx
@@ -49,6 +49,14 @@ const BatchProcessChartComponent: React.FC<BatchProcessChartProps> = ({
     });
   }, [data]);
 
+  const clampedRange = React.useMemo(
+    () => ({
+      startIndex: Math.max(0, Math.min(brushRange.startIndex, data.length - 1)),
+      endIndex: Math.max(0, Math.min(brushRange.endIndex, data.length - 1)),
+    }),
+    [brushRange, data.length],
+  );
+
   const handleBrushChange = (range: {
     startIndex?: number;
     endIndex?: number;
@@ -133,8 +141,8 @@ const BatchProcessChartComponent: React.FC<BatchProcessChartProps> = ({
           dataKey="name"
           height={20}
           stroke={lineColor}
-          startIndex={brushRange.startIndex}
-          endIndex={brushRange.endIndex}
+          startIndex={clampedRange.startIndex}
+          endIndex={clampedRange.endIndex}
           onChange={handleBrushChange}
         />
       </LineChart>

--- a/dashboard/components/BlobsPerBatchChart.tsx
+++ b/dashboard/components/BlobsPerBatchChart.tsx
@@ -40,6 +40,14 @@ const BlobsPerBatchChartComponent: React.FC<BlobsPerBatchChartProps> = ({
     });
   }, [data]);
 
+  const clampedRange = React.useMemo(
+    () => ({
+      startIndex: Math.max(0, Math.min(brushRange.startIndex, data.length - 1)),
+      endIndex: Math.max(0, Math.min(brushRange.endIndex, data.length - 1)),
+    }),
+    [brushRange, data.length],
+  );
+
   const handleBrushChange = (range: {
     startIndex?: number;
     endIndex?: number;
@@ -112,8 +120,8 @@ const BlobsPerBatchChartComponent: React.FC<BlobsPerBatchChartProps> = ({
           dataKey="batch"
           height={20}
           stroke={barColor}
-          startIndex={brushRange.startIndex}
-          endIndex={brushRange.endIndex}
+          startIndex={clampedRange.startIndex}
+          endIndex={clampedRange.endIndex}
           onChange={handleBrushChange}
         />
       </BarChart>

--- a/dashboard/components/BlockTimeChart.tsx
+++ b/dashboard/components/BlockTimeChart.tsx
@@ -50,6 +50,14 @@ const BlockTimeChartComponent: React.FC<BlockTimeChartProps> = ({
     });
   }, [data]);
 
+  const clampedRange = React.useMemo(
+    () => ({
+      startIndex: Math.max(0, Math.min(brushRange.startIndex, data.length - 1)),
+      endIndex: Math.max(0, Math.min(brushRange.endIndex, data.length - 1)),
+    }),
+    [brushRange, data.length],
+  );
+
   const handleBrushChange = (range: {
     startIndex?: number;
     endIndex?: number;
@@ -137,8 +145,8 @@ const BlockTimeChartComponent: React.FC<BlockTimeChartProps> = ({
           dataKey="timestamp"
           height={20}
           stroke={lineColor}
-          startIndex={brushRange.startIndex}
-          endIndex={brushRange.endIndex}
+          startIndex={clampedRange.startIndex}
+          endIndex={clampedRange.endIndex}
           onChange={handleBrushChange}
           tickFormatter={(v: number) => formatTime(v)}
         />

--- a/dashboard/components/BlockTxChart.tsx
+++ b/dashboard/components/BlockTxChart.tsx
@@ -44,6 +44,20 @@ const BlockTxChartComponent: React.FC<BlockTxChartProps> = ({
     });
   }, [sortedData]);
 
+  const clampedRange = React.useMemo(
+    () => ({
+      startIndex: Math.max(
+        0,
+        Math.min(brushRange.startIndex, sortedData.length - 1),
+      ),
+      endIndex: Math.max(
+        0,
+        Math.min(brushRange.endIndex, sortedData.length - 1),
+      ),
+    }),
+    [brushRange, sortedData.length],
+  );
+
   const handleBrushChange = (range: {
     startIndex?: number;
     endIndex?: number;
@@ -115,8 +129,8 @@ const BlockTxChartComponent: React.FC<BlockTxChartProps> = ({
           dataKey="block"
           height={20}
           stroke={barColor}
-          startIndex={brushRange.startIndex}
-          endIndex={brushRange.endIndex}
+          startIndex={clampedRange.startIndex}
+          endIndex={clampedRange.endIndex}
           onChange={handleBrushChange}
         />
       </BarChart>

--- a/dashboard/components/GasUsedChart.tsx
+++ b/dashboard/components/GasUsedChart.tsx
@@ -40,6 +40,14 @@ const GasUsedChartComponent: React.FC<GasUsedChartProps> = ({
     });
   }, [data]);
 
+  const clampedRange = React.useMemo(
+    () => ({
+      startIndex: Math.max(0, Math.min(brushRange.startIndex, data.length - 1)),
+      endIndex: Math.max(0, Math.min(brushRange.endIndex, data.length - 1)),
+    }),
+    [brushRange, data.length],
+  );
+
   const handleBrushChange = (range: {
     startIndex?: number;
     endIndex?: number;
@@ -118,8 +126,8 @@ const GasUsedChartComponent: React.FC<GasUsedChartProps> = ({
           dataKey="timestamp"
           height={20}
           stroke={lineColor}
-          startIndex={brushRange.startIndex}
-          endIndex={brushRange.endIndex}
+          startIndex={clampedRange.startIndex}
+          endIndex={clampedRange.endIndex}
           onChange={handleBrushChange}
           tickFormatter={(v: number) => formatTime(v)}
         />

--- a/dashboard/components/MissedBlockChart.tsx
+++ b/dashboard/components/MissedBlockChart.tsx
@@ -41,6 +41,20 @@ const MissedBlockChartComponent: React.FC<MissedBlockChartProps> = ({
     setBrushRange({ startIndex: 0, endIndex: sortedData.length - 1 });
   }, [sortedData]);
 
+  const clampedRange = React.useMemo(
+    () => ({
+      startIndex: Math.max(
+        0,
+        Math.min(brushRange.startIndex, sortedData.length - 1),
+      ),
+      endIndex: Math.max(
+        0,
+        Math.min(brushRange.endIndex, sortedData.length - 1),
+      ),
+    }),
+    [brushRange, sortedData.length],
+  );
+
   const handleBrushChange = (range: {
     startIndex?: number;
     endIndex?: number;
@@ -112,8 +126,8 @@ const MissedBlockChartComponent: React.FC<MissedBlockChartProps> = ({
           dataKey="slot"
           height={20}
           stroke={TAIKO_PINK}
-          startIndex={brushRange.startIndex}
-          endIndex={brushRange.endIndex}
+          startIndex={clampedRange.startIndex}
+          endIndex={clampedRange.endIndex}
           onChange={handleBrushChange}
         />
       </BarChart>

--- a/dashboard/components/ReorgDepthChart.tsx
+++ b/dashboard/components/ReorgDepthChart.tsx
@@ -37,6 +37,14 @@ const ReorgDepthChartComponent: React.FC<ReorgDepthChartProps> = ({ data }) => {
     });
   }, [data]);
 
+  const clampedRange = React.useMemo(
+    () => ({
+      startIndex: Math.max(0, Math.min(brushRange.startIndex, data.length - 1)),
+      endIndex: Math.max(0, Math.min(brushRange.endIndex, data.length - 1)),
+    }),
+    [brushRange, data.length],
+  );
+
   const handleBrushChange = (range: {
     startIndex?: number;
     endIndex?: number;
@@ -107,8 +115,8 @@ const ReorgDepthChartComponent: React.FC<ReorgDepthChartProps> = ({ data }) => {
           dataKey="timestamp"
           height={20}
           stroke={TAIKO_PINK}
-          startIndex={brushRange.startIndex}
-          endIndex={brushRange.endIndex}
+          startIndex={clampedRange.startIndex}
+          endIndex={clampedRange.endIndex}
           onChange={handleBrushChange}
         />
       </BarChart>


### PR DESCRIPTION
## Summary
- clamp brush indices to data length to avoid NaN rendering errors in charts

## Testing
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_68414bdab2188328a424a0251c1b30ed