### PR TITLE
Remove L1 block times chart

### DIFF
--- a/dashboard/components/layout/ChartsGrid.tsx
+++ b/dashboard/components/layout/ChartsGrid.tsx
@@ -47,7 +47,6 @@ interface ChartsGridProps {
         blockTxData: BlockTransaction[];
         batchBlobCounts: BatchBlobCount[];
         l2BlockTimeData: TimeSeriesData[];
-        l1BlockTimeData: TimeSeriesData[];
     };
     onOpenTable: (table: string, timeRange?: TimeRange) => void;
     onOpenSequencerDistributionTable: (timeRange: TimeRange, page: number) => void;
@@ -135,17 +134,6 @@ export const ChartsGrid: React.FC<ChartsGridProps> = ({
                     key={timeRange}
                     data={chartsData.l2BlockTimeData}
                     lineColor="#FAA43A"
-                />
-            </ChartCard>
-            <ChartCard
-                title="L1 Block Times"
-                onMore={() => onOpenTable('l1-block-times', timeRange)}
-                loading={isLoading}
-            >
-                <BlockTimeChart
-                    key={timeRange}
-                    data={chartsData.l1BlockTimeData}
-                    lineColor="#60BD68"
                 />
             </ChartCard>
         </div>

--- a/dashboard/config/tableConfig.ts
+++ b/dashboard/config/tableConfig.ts
@@ -18,7 +18,6 @@ import {
   fetchVerifyTimes,
   fetchBlockTransactions,
   fetchL2BlockTimes,
-  fetchL1BlockTimes,
   fetchSequencerDistribution,
 } from '../services/apiService';
 import { getSequencerName } from '../sequencerConfig';
@@ -261,27 +260,6 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
     urlKey: 'l2-block-times',
   },
 
-  'l1-block-times': {
-    title: 'L1 Block Times',
-    fetcher: fetchL1BlockTimes,
-    columns: [
-      { key: 'value', label: 'Block Number' },
-      { key: 'timestamp', label: 'Interval (ms)' },
-    ],
-    mapData: (data) => data as Record<string, string | number>[],
-    chart: (data) => {
-      const BlockTimeChart = React.lazy(() =>
-        import('../components/BlockTimeChart').then((m) => ({
-          default: m.BlockTimeChart,
-        })),
-      );
-      return React.createElement(BlockTimeChart, {
-        data,
-        lineColor: '#60BD68',
-      });
-    },
-    urlKey: 'l1-block-times',
-  },
 
   'sequencer-dist': {
     title: 'Sequencer Distribution',

--- a/dashboard/hooks/useChartsData.ts
+++ b/dashboard/hooks/useChartsData.ts
@@ -7,7 +7,6 @@ export const useChartsData = () => {
     const [secondsToVerifyData, setSecondsToVerifyData] = useState<TimeSeriesData[]>([]);
     const [l2BlockTimeData, setL2BlockTimeData] = useState<TimeSeriesData[]>([]);
     const [l2GasUsedData, setL2GasUsedData] = useState<TimeSeriesData[]>([]);
-    const [l1BlockTimeData, setL1BlockTimeData] = useState<TimeSeriesData[]>([]);
     const [blockTxData, setBlockTxData] = useState<BlockTransaction[]>([]);
     const [batchBlobCounts, setBatchBlobCounts] = useState<BatchBlobCount[]>([]);
     const [sequencerDistribution, setSequencerDistribution] = useState<PieChartDataItem[]>([]);
@@ -17,7 +16,6 @@ export const useChartsData = () => {
         verifyTimes: TimeSeriesData[];
         l2Times: TimeSeriesData[];
         l2Gas: TimeSeriesData[];
-        l1Times: TimeSeriesData[];
         txPerBlock: BlockTransaction[];
         blobsPerBatch: BatchBlobCount[];
         sequencerDist: PieChartDataItem[];
@@ -26,7 +24,6 @@ export const useChartsData = () => {
         setSecondsToVerifyData(data.verifyTimes);
         setL2BlockTimeData(data.l2Times);
         setL2GasUsedData(data.l2Gas);
-        setL1BlockTimeData(data.l1Times);
         setBlockTxData(data.txPerBlock);
         setBatchBlobCounts(data.blobsPerBatch);
         setSequencerDistribution(data.sequencerDist);
@@ -38,7 +35,6 @@ export const useChartsData = () => {
             secondsToVerifyData,
             l2BlockTimeData,
             l2GasUsedData,
-            l1BlockTimeData,
             blockTxData,
             batchBlobCounts,
             sequencerDistribution,
@@ -49,7 +45,6 @@ export const useChartsData = () => {
             secondsToVerifyData,
             l2BlockTimeData,
             l2GasUsedData,
-            l1BlockTimeData,
             blockTxData,
             batchBlobCounts,
             sequencerDistribution,

--- a/dashboard/hooks/useMetricsData.ts
+++ b/dashboard/hooks/useMetricsData.ts
@@ -86,7 +86,6 @@ export const useMetricsData = () => {
                             verifyTimes: data.verifyTimes,
                             l2Times: data.l2Times,
                             l2Gas: data.l2Gas,
-                            l1Times: data.l1Times,
                             txPerBlock: data.txPerBlock,
                             blobsPerBatch: data.blobsPerBatch,
                             sequencerDist: data.sequencerDist,

--- a/dashboard/tests/app.integration.test.ts
+++ b/dashboard/tests/app.integration.test.ts
@@ -17,7 +17,6 @@ import {
   fetchL1HeadNumber,
   fetchProveTimes,
   fetchVerifyTimes,
-  fetchL1BlockTimes,
   fetchL2BlockTimes,
   fetchL2GasUsed,
   fetchSequencerDistribution,
@@ -35,7 +34,6 @@ type State = {
   secondsToVerifyData: unknown[];
   l2BlockTimeData: unknown[];
   l2GasUsedData: unknown[];
-  l1BlockTimeData: unknown[];
   sequencerDistribution: unknown[];
   l2ReorgEvents: unknown[];
   slashingEvents: unknown[];
@@ -205,7 +203,6 @@ async function fetchData(range: TimeRange, state: State, economics = false) {
     l1BlockRes,
     proveTimesRes,
     verifyTimesRes,
-    l1TimesRes,
     l2TimesRes,
     l2GasUsedRes,
     sequencerDistRes,
@@ -227,7 +224,6 @@ async function fetchData(range: TimeRange, state: State, economics = false) {
     fetchL1HeadBlock(range),
     fetchProveTimes(range),
     fetchVerifyTimes(range),
-    fetchL1BlockTimes(range),
     fetchL2BlockTimes(range, undefined),
     fetchL2GasUsed(range, undefined),
     fetchSequencerDistribution(range),
@@ -253,7 +249,6 @@ async function fetchData(range: TimeRange, state: State, economics = false) {
   const l1Block = l1BlockRes.data;
   const proveTimes = proveTimesRes.data || [];
   const verifyTimes = verifyTimesRes.data || [];
-  const l1Times = l1TimesRes.data || [];
   const l2Times = l2TimesRes.data || [];
   const l2Gas = l2GasUsedRes.data || [];
   const sequencerDist = sequencerDistRes.data || [];
@@ -274,7 +269,6 @@ async function fetchData(range: TimeRange, state: State, economics = false) {
     l1BlockRes,
     proveTimesRes,
     verifyTimesRes,
-    l1TimesRes,
     l2TimesRes,
     l2GasUsedRes,
     sequencerDistRes,
@@ -304,7 +298,6 @@ async function fetchData(range: TimeRange, state: State, economics = false) {
   state.secondsToVerifyData = verifyTimes;
   state.l2BlockTimeData = l2Times;
   state.l2GasUsedData = l2Gas;
-  state.l1BlockTimeData = l1Times;
   state.sequencerDistribution = sequencerDist;
   state.slashingEvents = slashingEventsData;
   state.forcedInclusionEvents = forcedInclusionEventsData;
@@ -354,7 +347,6 @@ it('app integration', async () => {
     secondsToVerifyData: [],
     l2BlockTimeData: [],
     l2GasUsedData: [],
-    l1BlockTimeData: [],
     sequencerDistribution: [],
     l2ReorgEvents: [],
     slashingEvents: [],

--- a/dashboard/tests/dataFetcher.test.ts
+++ b/dashboard/tests/dataFetcher.test.ts
@@ -41,7 +41,6 @@ describe('dataFetcher', () => {
       fetchL1HeadBlock: ok(11),
       fetchProveTimes: ok([{ name: '1', value: 1, timestamp: 0 }]),
       fetchVerifyTimes: ok([{ name: '2', value: 2, timestamp: 0 }]),
-      fetchL1BlockTimes: ok([{ value: 1, timestamp: 0 }]),
       fetchL2BlockTimes: ok([{ value: 2, timestamp: 0 }]),
       fetchL2GasUsed: ok([{ value: 3, timestamp: 0 }]),
       fetchSequencerDistribution: ok([{ name: 'foo', value: 1 }]),
@@ -56,7 +55,7 @@ describe('dataFetcher', () => {
     expect(res.avgVerify).toBe(4);
     expect(res.sequencerDist[0].name).toBe('foo');
     expect(res.txPerBlock).toHaveLength(1);
-    expect(res.badRequestResults).toHaveLength(20);
+    expect(res.badRequestResults).toHaveLength(19);
   });
 
   it('defaults to empty arrays when service data missing', async () => {
@@ -75,7 +74,6 @@ describe('dataFetcher', () => {
       fetchL1HeadBlock: ok(null),
       fetchProveTimes: ok(null),
       fetchVerifyTimes: ok(null),
-      fetchL1BlockTimes: ok(null),
       fetchL2BlockTimes: ok(null),
       fetchL2GasUsed: ok(null),
       fetchSequencerDistribution: ok(null),

--- a/dashboard/utils/dataFetcher.ts
+++ b/dashboard/utils/dataFetcher.ts
@@ -14,7 +14,6 @@ import {
     fetchL1HeadBlock,
     fetchProveTimes,
     fetchVerifyTimes,
-    fetchL1BlockTimes,
     fetchL2BlockTimes,
     fetchL2GasUsed,
     fetchSequencerDistribution,
@@ -40,7 +39,6 @@ export interface MainDashboardData {
     l1Block: number | null;
     proveTimes: any[];
     verifyTimes: any[];
-    l1Times: any[];
     l2Times: any[];
     l2Gas: any[];
     sequencerDist: any[];
@@ -77,7 +75,6 @@ export const fetchMainDashboardData = async (
         l1BlockRes,
         proveTimesRes,
         verifyTimesRes,
-        l1TimesRes,
         l2TimesRes,
         l2GasUsedRes,
         sequencerDistRes,
@@ -106,7 +103,6 @@ export const fetchMainDashboardData = async (
         fetchL1HeadBlock(timeRange),
         fetchProveTimes(timeRange),
         fetchVerifyTimes(timeRange),
-        fetchL1BlockTimes(timeRange),
         fetchL2BlockTimes(
             timeRange,
             selectedSequencer ? getSequencerAddress(selectedSequencer) : undefined,
@@ -146,7 +142,6 @@ export const fetchMainDashboardData = async (
         l1BlockRes,
         proveTimesRes,
         verifyTimesRes,
-        l1TimesRes,
         l2TimesRes,
         l2GasUsedRes,
         sequencerDistRes,
@@ -169,7 +164,6 @@ export const fetchMainDashboardData = async (
         l1Block: l1BlockRes.data,
         proveTimes: proveTimesRes.data || [],
         verifyTimes: verifyTimesRes.data || [],
-        l1Times: l1TimesRes.data || [],
         l2Times: l2TimesRes.data || [],
         l2Gas: l2GasUsedRes.data || [],
         sequencerDist: sequencerDistRes.data || [],


### PR DESCRIPTION
## Summary
- drop L1 block times chart and table
- update chart hooks and metrics logic
- adjust dashboard tests

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_684163daefd48328930ef135920cb5c6