### PR TITLE
Improve stability of dashboard hooks

### DIFF
--- a/dashboard/hooks/useBlockData.ts
+++ b/dashboard/hooks/useBlockData.ts
@@ -1,85 +1,88 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { fetchL1HeadNumber, fetchL2HeadNumber } from '../services/apiService';
 import { MetricData } from '../types';
 
 export const useBlockData = () => {
-    const [l2HeadBlock, setL2HeadBlock] = useState<string>('0');
-    const [l1HeadBlock, setL1HeadBlock] = useState<string>('0');
+  const [l2HeadBlock, setL2HeadBlock] = useState<string>('0');
+  const [l1HeadBlock, setL1HeadBlock] = useState<string>('0');
 
-    const updateBlockHeads = useCallback(async () => {
-        try {
-            const [l1, l2] = await Promise.all([
-                fetchL1HeadNumber(),
-                fetchL2HeadNumber(),
-            ]);
+  const updateBlockHeads = useCallback(async () => {
+    try {
+      const [l1, l2] = await Promise.all([
+        fetchL1HeadNumber(),
+        fetchL2HeadNumber(),
+      ]);
 
-            if (l1.data !== null) {
-                const value = l1.data.toLocaleString();
-                setL1HeadBlock(value);
-            }
+      if (l1.data !== null) {
+        const value = l1.data.toLocaleString();
+        setL1HeadBlock(value);
+      }
 
-            if (l2.data !== null) {
-                const value = l2.data.toLocaleString();
-                setL2HeadBlock(value);
-            }
-        } catch (error) {
-            console.error('Failed to update block heads:', error);
+      if (l2.data !== null) {
+        const value = l2.data.toLocaleString();
+        setL2HeadBlock(value);
+      }
+    } catch (error) {
+      console.error('Failed to update block heads:', error);
+    }
+  }, []);
+
+  const updateMetricsWithBlockHeads = useCallback(
+    (metrics: MetricData[]): MetricData[] => {
+      return metrics.map((metric) => {
+        if (metric.title === 'L1 Block') {
+          return { ...metric, value: l1HeadBlock };
         }
-    }, []);
+        if (metric.title === 'L2 Block') {
+          return { ...metric, value: l2HeadBlock };
+        }
+        return metric;
+      });
+    },
+    [l1HeadBlock, l2HeadBlock],
+  );
 
-    const updateMetricsWithBlockHeads = useCallback(
-        (metrics: MetricData[]): MetricData[] => {
-            return metrics.map((metric) => {
-                if (metric.title === 'L1 Block') {
-                    return { ...metric, value: l1HeadBlock };
-                }
-                if (metric.title === 'L2 Block') {
-                    return { ...metric, value: l2HeadBlock };
-                }
-                return metric;
-            });
-        },
-        [l1HeadBlock, l2HeadBlock],
-    );
+  useEffect(() => {
+    let pollId: ReturnType<typeof setInterval> | undefined;
 
-    useEffect(() => {
-        let pollId: ReturnType<typeof setInterval> | undefined;
-
-        const startPolling = () => {
-            pollId = setInterval(() => {
-                if (document.visibilityState === 'visible') {
-                    void updateBlockHeads();
-                }
-            }, 60000);
-        };
-
+    const startPolling = () => {
+      pollId = setInterval(() => {
         if (document.visibilityState === 'visible') {
-            void updateBlockHeads();
-            startPolling();
+          void updateBlockHeads();
         }
-
-        const onVisibilityChange = () => {
-            if (document.visibilityState === 'visible') {
-                void updateBlockHeads();
-                if (!pollId) startPolling();
-            } else if (pollId) {
-                clearInterval(pollId);
-                pollId = undefined;
-            }
-        };
-
-        document.addEventListener('visibilitychange', onVisibilityChange);
-
-        return () => {
-            if (pollId) clearInterval(pollId);
-            document.removeEventListener('visibilitychange', onVisibilityChange);
-        };
-    }, [updateBlockHeads]);
-
-    return {
-        l2HeadBlock,
-        l1HeadBlock,
-        updateBlockHeads,
-        updateMetricsWithBlockHeads,
+      }, 60000);
     };
+
+    if (document.visibilityState === 'visible') {
+      void updateBlockHeads();
+      startPolling();
+    }
+
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        void updateBlockHeads();
+        if (!pollId) startPolling();
+      } else if (pollId) {
+        clearInterval(pollId);
+        pollId = undefined;
+      }
+    };
+
+    document.addEventListener('visibilitychange', onVisibilityChange);
+
+    return () => {
+      if (pollId) clearInterval(pollId);
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+    };
+  }, [updateBlockHeads]);
+
+  return useMemo(
+    () => ({
+      l2HeadBlock,
+      l1HeadBlock,
+      updateBlockHeads,
+      updateMetricsWithBlockHeads,
+    }),
+    [l2HeadBlock, l1HeadBlock, updateBlockHeads, updateMetricsWithBlockHeads],
+  );
 };

--- a/dashboard/hooks/useDashboardController.ts
+++ b/dashboard/hooks/useDashboardController.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useMetricsData } from './useMetricsData';
 import { useChartsData } from './useChartsData';
 import { useBlockData } from './useBlockData';
@@ -11,99 +12,121 @@ import { useTimeRangeSync } from './useTimeRangeSync';
 import { useSearchParams } from 'react-router-dom';
 
 export const useDashboardController = () => {
-    const { timeRange, setTimeRange } = useTimeRangeSync();
-    const [searchParams] = useSearchParams();
+  const { timeRange, setTimeRange } = useTimeRangeSync();
+  const [searchParams] = useSearchParams();
 
-    // Data management hooks
-    const metricsData = useMetricsData();
-    const chartsData = useChartsData();
-    const blockData = useBlockData();
-    const refreshTimer = useRefreshTimer();
+  // Data management hooks
+  const metricsData = useMetricsData();
+  const chartsData = useChartsData();
+  const blockData = useBlockData();
+  const refreshTimer = useRefreshTimer();
 
-    // Sequencer handling
-    const { selectedSequencer, setSelectedSequencer, sequencerList } = useSequencerHandler({
-        chartsData,
-        blockData,
-        metricsData,
+  // Sequencer handling
+  const { selectedSequencer, setSelectedSequencer, sequencerList } =
+    useSequencerHandler({
+      chartsData,
+      blockData,
+      metricsData,
     });
 
-    // Table actions
-    const {
-        tableView,
-        tableLoading,
-        setTableView,
-        setTableLoading,
-        openGenericTable,
-        openTpsTable,
-        openSequencerDistributionTable,
-    } = useTableActions(
-        timeRange,
-        setTimeRange,
-        selectedSequencer,
-        chartsData.blockTxData,
-        chartsData.l2BlockTimeData,
-    );
+  // Table actions
+  const {
+    tableView,
+    tableLoading,
+    setTableView,
+    setTableLoading,
+    openGenericTable,
+    openTpsTable,
+    openSequencerDistributionTable,
+  } = useTableActions(
+    timeRange,
+    setTimeRange,
+    selectedSequencer,
+    chartsData.blockTxData,
+    chartsData.l2BlockTimeData,
+  );
 
-    // Data fetching coordination
-    const { handleManualRefresh } = useDataFetcher({
-        timeRange,
-        selectedSequencer,
-        tableView,
-        fetchMetricsData: metricsData.fetchMetricsData,
-        updateChartsData: chartsData.updateChartsData,
-        refreshRate: refreshTimer.refreshRate,
-        updateLastRefresh: refreshTimer.updateLastRefresh,
-    });
+  // Data fetching coordination
+  const { handleManualRefresh } = useDataFetcher({
+    timeRange,
+    selectedSequencer,
+    tableView,
+    fetchMetricsData: metricsData.fetchMetricsData,
+    updateChartsData: chartsData.updateChartsData,
+    refreshRate: refreshTimer.refreshRate,
+    updateLastRefresh: refreshTimer.updateLastRefresh,
+  });
 
-    // Navigation handling
-    const { handleBack, handleSequencerChange } = useNavigationHandler({
-        onError: metricsData.setErrorMessage,
-    });
+  // Navigation handling
+  const { handleBack, handleSequencerChange } = useNavigationHandler({
+    onError: metricsData.setErrorMessage,
+  });
 
-    // Table routing
-    useTableRouter({
-        timeRange,
-        setTableView,
-        setTableLoading,
-        tableView,
-        openGenericTable,
-        openTpsTable,
-        openSequencerDistributionTable,
-        onError: metricsData.setErrorMessage,
-    });
+  // Table routing
+  useTableRouter({
+    timeRange,
+    setTableView,
+    setTableLoading,
+    tableView,
+    openGenericTable,
+    openTpsTable,
+    openSequencerDistributionTable,
+    onError: metricsData.setErrorMessage,
+  });
 
-    // Combined sequencer change handler
-    const handleSequencerChangeWithState = (seq: string | null) => {
-        setSelectedSequencer(seq);
-        handleSequencerChange(seq);
-    };
+  // Combined sequencer change handler
+  const handleSequencerChangeWithState = (seq: string | null) => {
+    setSelectedSequencer(seq);
+    handleSequencerChange(seq);
+  };
 
-    return {
-        // State
-        timeRange,
-        setTimeRange,
-        selectedSequencer,
-        sequencerList,
+  return useMemo(
+    () => ({
+      // State
+      timeRange,
+      setTimeRange,
+      selectedSequencer,
+      sequencerList,
 
-        // Data
-        metricsData,
-        chartsData,
-        blockData,
-        refreshTimer,
-        searchParams,
+      // Data
+      metricsData,
+      chartsData,
+      blockData,
+      refreshTimer,
+      searchParams,
 
-        // Table state
-        tableView,
-        tableLoading,
+      // Table state
+      tableView,
+      tableLoading,
 
-        // Handlers
-        handleSequencerChangeWithState,
-        handleBack,
-        handleManualRefresh,
+      // Handlers
+      handleSequencerChangeWithState,
+      handleBack,
+      handleManualRefresh,
 
-        // Table actions
-        openGenericTable,
-        openTpsTable,
-        openSequencerDistributionTable,
-    };
+      // Table actions
+      openGenericTable,
+      openTpsTable,
+      openSequencerDistributionTable,
+    }),
+    [
+      timeRange,
+      setTimeRange,
+      selectedSequencer,
+      sequencerList,
+      metricsData,
+      chartsData,
+      blockData,
+      refreshTimer,
+      searchParams,
+      tableView,
+      tableLoading,
+      handleSequencerChangeWithState,
+      handleBack,
+      handleManualRefresh,
+      openGenericTable,
+      openTpsTable,
+      openSequencerDistributionTable,
+    ],
+  );
 };

--- a/dashboard/hooks/useDataFetcher.ts
+++ b/dashboard/hooks/useDataFetcher.ts
@@ -71,8 +71,11 @@ export const useDataFetcher = ({
     }
   }, [data, updateChartsData, updateLastRefresh]);
 
-  return {
-    fetchData,
-    handleManualRefresh,
-  };
+  return useMemo(
+    () => ({
+      fetchData,
+      handleManualRefresh,
+    }),
+    [fetchData, handleManualRefresh],
+  );
 };

--- a/dashboard/hooks/useNavigationHandler.ts
+++ b/dashboard/hooks/useNavigationHandler.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useRouterNavigation } from './useRouterNavigation';
 
@@ -38,8 +38,11 @@ export const useNavigationHandler = ({
     [updateSearchParams, onError],
   );
 
-  return {
-    handleBack,
-    handleSequencerChange,
-  };
+  return useMemo(
+    () => ({
+      handleBack,
+      handleSequencerChange,
+    }),
+    [handleBack, handleSequencerChange],
+  );
 };

--- a/dashboard/hooks/useRefreshTimer.ts
+++ b/dashboard/hooks/useRefreshTimer.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { loadRefreshRate, saveRefreshRate, isValidRefreshRate } from '../utils';
 
 export const useRefreshTimer = () => {
@@ -21,10 +21,13 @@ export const useRefreshTimer = () => {
     setLastRefresh(Date.now());
   }, []);
 
-  return {
-    refreshRate,
-    setRefreshRate,
-    lastRefresh,
-    updateLastRefresh,
-  };
+  return useMemo(
+    () => ({
+      refreshRate,
+      setRefreshRate,
+      lastRefresh,
+      updateLastRefresh,
+    }),
+    [refreshRate, setRefreshRate, lastRefresh, updateLastRefresh],
+  );
 };

--- a/dashboard/hooks/useRouterNavigation.ts
+++ b/dashboard/hooks/useRouterNavigation.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { TimeRange } from '../types';
 
@@ -6,67 +6,87 @@ export const useRouterNavigation = () => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
 
-  const navigateToTable = useCallback((
-    tableType: string, 
-    params?: Record<string, string | number>,
-    range?: TimeRange
-  ) => {
-    const queryParams = new URLSearchParams();
-    
-    if (range) {
-      queryParams.set('range', range);
-    }
-    
-    if (params) {
-      Object.entries(params).forEach(([key, value]) => {
-        queryParams.set(key, String(value));
-      });
-    }
-    
-    const queryString = queryParams.toString();
-    const path = `/table/${tableType}${queryString ? `?${queryString}` : ''}`;
-    navigate(path);
-  }, [navigate]);
+  const navigateToTable = useCallback(
+    (
+      tableType: string,
+      params?: Record<string, string | number>,
+      range?: TimeRange,
+    ) => {
+      const queryParams = new URLSearchParams();
 
-  const navigateToSequencer = useCallback((address: string) => {
-    navigate(`/sequencer/${address}`);
-  }, [navigate]);
-
-  const navigateToDashboard = useCallback((preserveParams = false) => {
-    if (preserveParams) {
-      const params = new URLSearchParams();
-      const sequencer = searchParams.get('sequencer');
-      const range = searchParams.get('range');
-      
-      if (sequencer) params.set('sequencer', sequencer);
-      if (range) params.set('range', range);
-      
-      const queryString = params.toString();
-      navigate(`/${queryString ? `?${queryString}` : ''}`);
-    } else {
-      navigate('/');
-    }
-  }, [navigate, searchParams]);
-
-  const updateSearchParams = useCallback((updates: Record<string, string | null>) => {
-    const newParams = new URLSearchParams(searchParams);
-    
-    Object.entries(updates).forEach(([key, value]) => {
-      if (value === null) {
-        newParams.delete(key);
-      } else {
-        newParams.set(key, value);
+      if (range) {
+        queryParams.set('range', range);
       }
-    });
-    
-    const queryString = newParams.toString();
-    navigate(`?${queryString}`, { replace: true });
-  }, [navigate, searchParams]);
 
-  return {
-    navigateToTable,
-    navigateToSequencer,
-    navigateToDashboard,
-    updateSearchParams,
-  };
+      if (params) {
+        Object.entries(params).forEach(([key, value]) => {
+          queryParams.set(key, String(value));
+        });
+      }
+
+      const queryString = queryParams.toString();
+      const path = `/table/${tableType}${queryString ? `?${queryString}` : ''}`;
+      navigate(path);
+    },
+    [navigate],
+  );
+
+  const navigateToSequencer = useCallback(
+    (address: string) => {
+      navigate(`/sequencer/${address}`);
+    },
+    [navigate],
+  );
+
+  const navigateToDashboard = useCallback(
+    (preserveParams = false) => {
+      if (preserveParams) {
+        const params = new URLSearchParams();
+        const sequencer = searchParams.get('sequencer');
+        const range = searchParams.get('range');
+
+        if (sequencer) params.set('sequencer', sequencer);
+        if (range) params.set('range', range);
+
+        const queryString = params.toString();
+        navigate(`/${queryString ? `?${queryString}` : ''}`);
+      } else {
+        navigate('/');
+      }
+    },
+    [navigate, searchParams],
+  );
+
+  const updateSearchParams = useCallback(
+    (updates: Record<string, string | null>) => {
+      const newParams = new URLSearchParams(searchParams);
+
+      Object.entries(updates).forEach(([key, value]) => {
+        if (value === null) {
+          newParams.delete(key);
+        } else {
+          newParams.set(key, value);
+        }
+      });
+
+      const queryString = newParams.toString();
+      navigate(`?${queryString}`, { replace: true });
+    },
+    [navigate, searchParams],
+  );
+
+  return useMemo(
+    () => ({
+      navigateToTable,
+      navigateToSequencer,
+      navigateToDashboard,
+      updateSearchParams,
+    }),
+    [
+      navigateToTable,
+      navigateToSequencer,
+      navigateToDashboard,
+      updateSearchParams,
+    ],
+  );
 };

--- a/dashboard/hooks/useSequencerHandler.ts
+++ b/dashboard/hooks/useSequencerHandler.ts
@@ -2,57 +2,65 @@ import { useState, useEffect, useMemo, useRef } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 interface UseSequencerHandlerProps {
-    chartsData: {
-        sequencerDistribution: Array<{ name: string }>;
-    };
-    blockData: {
-        l1HeadBlock: string;
-        l2HeadBlock: string;
-        updateMetricsWithBlockHeads: (metrics: any[]) => any[];
-    };
-    metricsData: {
-        metrics: any[];
-        setMetrics: (metrics: any[]) => void;
-    };
+  chartsData: {
+    sequencerDistribution: Array<{ name: string }>;
+  };
+  blockData: {
+    l1HeadBlock: string;
+    l2HeadBlock: string;
+    updateMetricsWithBlockHeads: (metrics: any[]) => any[];
+  };
+  metricsData: {
+    metrics: any[];
+    setMetrics: (metrics: any[]) => void;
+  };
 }
 
 export const useSequencerHandler = ({
-    chartsData,
-    blockData,
-    metricsData,
+  chartsData,
+  blockData,
+  metricsData,
 }: UseSequencerHandlerProps) => {
-    const [searchParams] = useSearchParams();
-    const [selectedSequencer, setSelectedSequencer] = useState<string | null>(
-        searchParams.get('sequencer'),
-    );
+  const [searchParams] = useSearchParams();
+  const [selectedSequencer, setSelectedSequencer] = useState<string | null>(
+    searchParams.get('sequencer'),
+  );
 
-    const sequencerList = useMemo(
-        () => chartsData.sequencerDistribution.map((s) => s.name),
-        [chartsData.sequencerDistribution],
-    );
+  const sequencerList = useMemo(
+    () => chartsData.sequencerDistribution.map((s) => s.name),
+    [chartsData.sequencerDistribution],
+  );
 
-    // Sync with URL params - extract specific value to avoid object dependency
-    const sequencerParam = searchParams.get('sequencer');
-    useEffect(() => {
-        setSelectedSequencer(sequencerParam ?? null);
-    }, [sequencerParam]);
+  // Sync with URL params - extract specific value to avoid object dependency
+  const sequencerParam = searchParams.get('sequencer');
+  useEffect(() => {
+    setSelectedSequencer(sequencerParam ?? null);
+  }, [sequencerParam]);
 
-    // Update metrics with current block heads whenever they change
-    const lastUpdateRef = useRef<string>('');
+  // Update metrics with current block heads whenever they change
+  const lastUpdateRef = useRef<string>('');
 
-    useEffect(() => {
-        const currentKey = `${blockData.l1HeadBlock}-${blockData.l2HeadBlock}`;
+  useEffect(() => {
+    const currentKey = `${blockData.l1HeadBlock}-${blockData.l2HeadBlock}`;
 
-        if (metricsData.metrics.length > 0 && lastUpdateRef.current !== currentKey) {
-            const updatedMetrics = blockData.updateMetricsWithBlockHeads(metricsData.metrics);
-            metricsData.setMetrics(updatedMetrics);
-            lastUpdateRef.current = currentKey;
-        }
-    }, [blockData.l1HeadBlock, blockData.l2HeadBlock]);
+    if (
+      metricsData.metrics.length > 0 &&
+      lastUpdateRef.current !== currentKey
+    ) {
+      const updatedMetrics = blockData.updateMetricsWithBlockHeads(
+        metricsData.metrics,
+      );
+      metricsData.setMetrics(updatedMetrics);
+      lastUpdateRef.current = currentKey;
+    }
+  }, [blockData.l1HeadBlock, blockData.l2HeadBlock]);
 
-    return {
-        selectedSequencer,
-        setSelectedSequencer,
-        sequencerList,
-    };
+  return useMemo(
+    () => ({
+      selectedSequencer,
+      setSelectedSequencer,
+      sequencerList,
+    }),
+    [selectedSequencer, setSelectedSequencer, sequencerList],
+  );
 };

--- a/dashboard/hooks/useTableActions.ts
+++ b/dashboard/hooks/useTableActions.ts
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useMemo } from 'react';
 import { TimeRange } from '../types';
 import { TABLE_CONFIGS } from '../config/tableConfig';
 import { getSequencerAddress } from '../sequencerConfig';
@@ -152,10 +152,10 @@ export const useTableActions = (
             setTableView((prev) =>
               prev
                 ? {
-                  ...prev,
-                  rows: refreshMappedData,
-                  chart: refreshChart,
-                }
+                    ...prev,
+                    rows: refreshMappedData,
+                    chart: refreshChart,
+                  }
                 : null,
             );
           } catch (error) {
@@ -164,9 +164,9 @@ export const useTableActions = (
             setTableView((prev) =>
               prev
                 ? {
-                  ...prev,
-                  rows: [], // Clear data on error to prevent stale data
-                }
+                    ...prev,
+                    rows: [], // Clear data on error to prevent stale data
+                  }
                 : null,
             );
           }
@@ -181,9 +181,9 @@ export const useTableActions = (
           mappedData,
           tableKey === 'sequencer-dist'
             ? (row) =>
-              openGenericTable('sequencer-blocks', range, {
-                address: row.name,
-              })
+                openGenericTable('sequencer-blocks', range, {
+                  address: row.name,
+                })
             : undefined,
           undefined,
           undefined,
@@ -304,21 +304,21 @@ export const useTableActions = (
           setTableView((prev) =>
             prev
               ? {
-                ...prev,
-                rows: (refreshDistRes.data || []) as unknown as Record<
-                  string,
-                  string | number
-                >[],
-                extraTable: prev.extraTable
-                  ? {
-                    ...prev.extraTable,
-                    rows: (refreshTxRes.data || []) as unknown as Record<
-                      string,
-                      string | number
-                    >[],
-                  }
-                  : undefined,
-              }
+                  ...prev,
+                  rows: (refreshDistRes.data || []) as unknown as Record<
+                    string,
+                    string | number
+                  >[],
+                  extraTable: prev.extraTable
+                    ? {
+                        ...prev.extraTable,
+                        rows: (refreshTxRes.data || []) as unknown as Record<
+                          string,
+                          string | number
+                        >[],
+                      }
+                    : undefined,
+                }
               : null,
           );
         } catch (error) {
@@ -330,15 +330,15 @@ export const useTableActions = (
           setTableView((prev) =>
             prev
               ? {
-                ...prev,
-                rows: [],
-                extraTable: prev.extraTable
-                  ? {
-                    ...prev.extraTable,
-                    rows: [],
-                  }
-                  : undefined,
-              }
+                  ...prev,
+                  rows: [],
+                  extraTable: prev.extraTable
+                    ? {
+                        ...prev.extraTable,
+                        rows: [],
+                      }
+                    : undefined,
+                }
               : null,
           );
         }
@@ -353,7 +353,9 @@ export const useTableActions = (
         ],
         (distRes.data || []) as unknown as Record<string, string | number>[],
         (row) => {
-          const cleanParams: Record<string, string | number> = { address: String(row.name) };
+          const cleanParams: Record<string, string | number> = {
+            address: String(row.name),
+          };
           navigateToTable('sequencer-blocks', cleanParams, range);
         },
         undefined,
@@ -405,13 +407,24 @@ export const useTableActions = (
     ],
   );
 
-  return {
-    tableView,
-    tableLoading,
-    setTableView,
-    setTableLoading,
-    openGenericTable,
-    openTpsTable,
-    openSequencerDistributionTable,
-  };
+  return useMemo(
+    () => ({
+      tableView,
+      tableLoading,
+      setTableView,
+      setTableLoading,
+      openGenericTable,
+      openTpsTable,
+      openSequencerDistributionTable,
+    }),
+    [
+      tableView,
+      tableLoading,
+      setTableView,
+      setTableLoading,
+      openGenericTable,
+      openTpsTable,
+      openSequencerDistributionTable,
+    ],
+  );
 };

--- a/dashboard/hooks/useTableRouter.ts
+++ b/dashboard/hooks/useTableRouter.ts
@@ -4,146 +4,163 @@ import { useSearchParams } from 'react-router-dom';
 import { TableViewState } from './useTableActions';
 
 interface UseTableRouterProps {
-    timeRange: TimeRange;
-    setTableView: (view: TableViewState | null) => void;
-    setTableLoading: (loading: boolean) => void;
-    tableView: TableViewState | null;
-    openGenericTable: (table: string, range?: TimeRange, params?: Record<string, any>) => Promise<void>;
-    openTpsTable: () => void;
-    openSequencerDistributionTable: (range: TimeRange, page: number, start?: number, end?: number) => Promise<void>;
-    onError: (message: string) => void;
+  timeRange: TimeRange;
+  setTableView: (view: TableViewState | null) => void;
+  setTableLoading: (loading: boolean) => void;
+  tableView: TableViewState | null;
+  openGenericTable: (
+    table: string,
+    range?: TimeRange,
+    params?: Record<string, any>,
+  ) => Promise<void>;
+  openTpsTable: () => void;
+  openSequencerDistributionTable: (
+    range: TimeRange,
+    page: number,
+    start?: number,
+    end?: number,
+  ) => Promise<void>;
+  onError: (message: string) => void;
 }
 
 export const useTableRouter = ({
-    timeRange,
-    setTableView,
-    setTableLoading,
-    tableView,
+  timeRange,
+  setTableView,
+  setTableLoading,
+  tableView,
+  openGenericTable,
+  openTpsTable,
+  openSequencerDistributionTable,
+  onError,
+}: UseTableRouterProps) => {
+  const [searchParams] = useSearchParams();
+
+  // Extract specific search param values to avoid unstable object dependencies
+  const urlParams = useMemo(
+    () => ({
+      view: searchParams.get('view'),
+      table: searchParams.get('table'),
+      range: searchParams.get('range') as TimeRange,
+      address: searchParams.get('address'),
+      page: searchParams.get('page'),
+      start: searchParams.get('start'),
+      end: searchParams.get('end'),
+    }),
+    [
+      searchParams.get('view'),
+      searchParams.get('table'),
+      searchParams.get('range'),
+      searchParams.get('address'),
+      searchParams.get('page'),
+      searchParams.get('start'),
+      searchParams.get('end'),
+    ],
+  );
+
+  const handleRouteChange = useCallback(() => {
+    try {
+      const params = urlParams;
+      if (params.view !== 'table') {
+        setTableView(null);
+        return;
+      }
+
+      // If we already have a table view and it matches the current URL state, don't reload
+      const table = params.table;
+      const range = params.range || timeRange;
+
+      if (tableView && tableView.timeRange === range) {
+        return;
+      }
+
+      setTableLoading(true);
+
+      // Add error boundary for table operations
+      const handleTableError = (tableName: string, error: any) => {
+        console.error(`Failed to open ${tableName} table:`, error);
+        setTableLoading(false);
+        onError(`Failed to load ${tableName} table. Please try again.`);
+      };
+
+      switch (table) {
+        case 'sequencer-blocks': {
+          const addr = params.address;
+          if (addr) {
+            openGenericTable('sequencer-blocks', range, {
+              address: addr,
+            }).catch((err) => handleTableError('sequencer-blocks', err));
+          } else {
+            setTableLoading(false);
+          }
+          break;
+        }
+        case 'tps':
+          try {
+            openTpsTable();
+          } catch (err) {
+            handleTableError('TPS', err);
+          }
+          break;
+        case 'sequencer-dist': {
+          const pageStr = params.page ?? '0';
+          const page = parseInt(pageStr, 10);
+          if (isNaN(page) || page < 0) {
+            console.warn('Invalid page parameter:', pageStr);
+            setTableLoading(false);
+            break;
+          }
+          const start = params.start;
+          const end = params.end;
+          openSequencerDistributionTable(
+            range,
+            page,
+            start ? Number(start) : undefined,
+            end ? Number(end) : undefined,
+          ).catch((err) => handleTableError('sequencer-distribution', err));
+          break;
+        }
+        default: {
+          if (table) {
+            openGenericTable(table, range).catch((err) =>
+              handleTableError(table, err),
+            );
+          } else {
+            setTableLoading(false);
+          }
+          break;
+        }
+      }
+    } catch (err) {
+      console.error('Failed to handle route change:', err);
+      setTableLoading(false);
+      onError('Navigation error occurred. Please try again.');
+    }
+  }, [
+    urlParams,
     openGenericTable,
     openTpsTable,
     openSequencerDistributionTable,
+    setTableView,
+    setTableLoading,
+    timeRange,
+    tableView,
     onError,
-}: UseTableRouterProps) => {
-    const [searchParams] = useSearchParams();
+  ]);
 
-    // Extract specific search param values to avoid unstable object dependencies
-    const urlParams = useMemo(() => ({
-        view: searchParams.get('view'),
-        table: searchParams.get('table'),
-        range: searchParams.get('range') as TimeRange,
-        address: searchParams.get('address'),
-        page: searchParams.get('page'),
-        start: searchParams.get('start'),
-        end: searchParams.get('end'),
-    }), [
-        searchParams.get('view'),
-        searchParams.get('table'),
-        searchParams.get('range'),
-        searchParams.get('address'),
-        searchParams.get('page'),
-        searchParams.get('start'),
-        searchParams.get('end'),
-    ]);
+  // Handle route changes
+  useEffect(() => {
+    try {
+      handleRouteChange();
+    } catch (err) {
+      console.error('Route change effect error:', err);
+      onError('Navigation error occurred.');
+    }
+  }, [handleRouteChange]);
 
-    const handleRouteChange = useCallback(() => {
-        try {
-            const params = urlParams;
-            if (params.view !== 'table') {
-                setTableView(null);
-                return;
-            }
-
-            // If we already have a table view and it matches the current URL state, don't reload
-            const table = params.table;
-            const range = params.range || timeRange;
-
-            if (tableView && tableView.timeRange === range) {
-                return;
-            }
-
-            setTableLoading(true);
-
-            // Add error boundary for table operations
-            const handleTableError = (tableName: string, error: any) => {
-                console.error(`Failed to open ${tableName} table:`, error);
-                setTableLoading(false);
-                onError(`Failed to load ${tableName} table. Please try again.`);
-            };
-
-            switch (table) {
-                case 'sequencer-blocks': {
-                    const addr = params.address;
-                    if (addr) {
-                        openGenericTable('sequencer-blocks', range, { address: addr })
-                            .catch((err) => handleTableError('sequencer-blocks', err));
-                    } else {
-                        setTableLoading(false);
-                    }
-                    break;
-                }
-                case 'tps':
-                    try {
-                        openTpsTable();
-                    } catch (err) {
-                        handleTableError('TPS', err);
-                    }
-                    break;
-                case 'sequencer-dist': {
-                    const pageStr = params.page ?? '0';
-                    const page = parseInt(pageStr, 10);
-                    if (isNaN(page) || page < 0) {
-                        console.warn('Invalid page parameter:', pageStr);
-                        setTableLoading(false);
-                        break;
-                    }
-                    const start = params.start;
-                    const end = params.end;
-                    openSequencerDistributionTable(
-                        range,
-                        page,
-                        start ? Number(start) : undefined,
-                        end ? Number(end) : undefined,
-                    ).catch((err) => handleTableError('sequencer-distribution', err));
-                    break;
-                }
-                default: {
-                    if (table) {
-                        openGenericTable(table, range)
-                            .catch((err) => handleTableError(table, err));
-                    } else {
-                        setTableLoading(false);
-                    }
-                    break;
-                }
-            }
-        } catch (err) {
-            console.error('Failed to handle route change:', err);
-            setTableLoading(false);
-            onError('Navigation error occurred. Please try again.');
-        }
-    }, [
-        urlParams,
-        openGenericTable,
-        openTpsTable,
-        openSequencerDistributionTable,
-        setTableView,
-        setTableLoading,
-        timeRange,
-        tableView,
-        onError,
-    ]);
-
-    // Handle route changes
-    useEffect(() => {
-        try {
-            handleRouteChange();
-        } catch (err) {
-            console.error('Route change effect error:', err);
-            onError('Navigation error occurred.');
-        }
-    }, [handleRouteChange]);
-
-    return {
-        handleRouteChange,
-    };
+  return useMemo(
+    () => ({
+      handleRouteChange,
+    }),
+    [handleRouteChange],
+  );
 };

--- a/dashboard/hooks/useTimeRangeSync.ts
+++ b/dashboard/hooks/useTimeRangeSync.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, useMemo } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import { TimeRange } from '../types';
 
@@ -10,48 +10,60 @@ const VALID_TIME_RANGES: TimeRange[] = ['1h', '24h', '7d'];
  * and maintain consistent state across dashboard and table views.
  */
 export const useTimeRangeSync = () => {
-    const [searchParams] = useSearchParams();
-    const navigate = useNavigate();
-    
-    // Get initial time range from URL or use default
-    const getInitialTimeRange = useCallback((): TimeRange => {
-        const urlRange = searchParams.get('range') as TimeRange;
-        return urlRange && VALID_TIME_RANGES.includes(urlRange) ? urlRange : DEFAULT_TIME_RANGE;
-    }, [searchParams]);
-    
-    const [timeRange, setTimeRangeState] = useState<TimeRange>(getInitialTimeRange);
-    
-    // Update time range and sync with URL
-    const setTimeRange = useCallback((newRange: TimeRange) => {
-        if (!VALID_TIME_RANGES.includes(newRange)) {
-            console.warn('Invalid time range:', newRange);
-            return;
-        }
-        
-        setTimeRangeState(newRange);
-        
-        // Update URL parameters without affecting navigation
-        const newParams = new URLSearchParams(searchParams);
-        if (newRange === DEFAULT_TIME_RANGE) {
-            newParams.delete('range');
-        } else {
-            newParams.set('range', newRange);
-        }
-        
-        // Use replace to avoid adding history entries for time range changes
-        navigate({ pathname: '/', search: newParams.toString() }, { replace: true });
-    }, [searchParams, navigate]);
-    
-    // Sync state when URL changes (e.g., browser back/forward)
-    useEffect(() => {
-        const urlRange = getInitialTimeRange();
-        if (urlRange !== timeRange) {
-            setTimeRangeState(urlRange);
-        }
-    }, [searchParams, timeRange, getInitialTimeRange]);
-    
-    return {
-        timeRange,
-        setTimeRange,
-    };
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+
+  // Get initial time range from URL or use default
+  const getInitialTimeRange = useCallback((): TimeRange => {
+    const urlRange = searchParams.get('range') as TimeRange;
+    return urlRange && VALID_TIME_RANGES.includes(urlRange)
+      ? urlRange
+      : DEFAULT_TIME_RANGE;
+  }, [searchParams]);
+
+  const [timeRange, setTimeRangeState] =
+    useState<TimeRange>(getInitialTimeRange);
+
+  // Update time range and sync with URL
+  const setTimeRange = useCallback(
+    (newRange: TimeRange) => {
+      if (!VALID_TIME_RANGES.includes(newRange)) {
+        console.warn('Invalid time range:', newRange);
+        return;
+      }
+
+      setTimeRangeState(newRange);
+
+      // Update URL parameters without affecting navigation
+      const newParams = new URLSearchParams(searchParams);
+      if (newRange === DEFAULT_TIME_RANGE) {
+        newParams.delete('range');
+      } else {
+        newParams.set('range', newRange);
+      }
+
+      // Use replace to avoid adding history entries for time range changes
+      navigate(
+        { pathname: '/', search: newParams.toString() },
+        { replace: true },
+      );
+    },
+    [searchParams, navigate],
+  );
+
+  // Sync state when URL changes (e.g., browser back/forward)
+  useEffect(() => {
+    const urlRange = getInitialTimeRange();
+    if (urlRange !== timeRange) {
+      setTimeRangeState(urlRange);
+    }
+  }, [searchParams, timeRange, getInitialTimeRange]);
+
+  return useMemo(
+    () => ({
+      timeRange,
+      setTimeRange,
+    }),
+    [timeRange, setTimeRange],
+  );
 };


### PR DESCRIPTION
## Summary
- memoize returns from navigation and data hooks

## Testing
- `npm run lint:whitespace`
- `npm run check`
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_684165260bd88328a1b1c03d438dcf65