### PR TITLE
Add centralized error handling hook

### DIFF
--- a/dashboard/hooks/useDashboardController.ts
+++ b/dashboard/hooks/useDashboardController.ts
@@ -9,10 +9,12 @@ import { useSequencerHandler } from './useSequencerHandler';
 import { useTableActions } from './useTableActions';
 import { useTimeRangeSync } from './useTimeRangeSync';
 import { useSearchParams } from 'react-router-dom';
+import { useErrorHandler } from './useErrorHandler';
 
 export const useDashboardController = () => {
     const { timeRange, setTimeRange } = useTimeRangeSync();
     const [searchParams] = useSearchParams();
+    const { setErrorMessage } = useErrorHandler();
 
     // Data management hooks
     const metricsData = useMetricsData();
@@ -57,7 +59,7 @@ export const useDashboardController = () => {
 
     // Navigation handling
     const { handleBack, handleSequencerChange } = useNavigationHandler({
-        onError: metricsData.setErrorMessage,
+        onError: setErrorMessage,
     });
 
     // Table routing
@@ -69,7 +71,7 @@ export const useDashboardController = () => {
         openGenericTable,
         openTpsTable,
         openSequencerDistributionTable,
-        onError: metricsData.setErrorMessage,
+        onError: setErrorMessage,
     });
 
     // Combined sequencer change handler

--- a/dashboard/hooks/useErrorHandler.tsx
+++ b/dashboard/hooks/useErrorHandler.tsx
@@ -1,0 +1,28 @@
+import React, { createContext, useContext, useState } from 'react';
+
+interface ErrorContextValue {
+  errorMessage: string;
+  setErrorMessage: (msg: string) => void;
+  clearError: () => void;
+}
+
+const ErrorContext = createContext<ErrorContextValue | undefined>(undefined);
+
+export const ErrorProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const [errorMessage, setErrorMessage] = useState('');
+  const clearError = () => setErrorMessage('');
+
+  return (
+    <ErrorContext.Provider value={{ errorMessage, setErrorMessage, clearError }}>
+      {children}
+    </ErrorContext.Provider>
+  );
+};
+
+export const useErrorHandler = (): ErrorContextValue => {
+  const ctx = useContext(ErrorContext);
+  if (!ctx) {
+    throw new Error('useErrorHandler must be used within ErrorProvider');
+  }
+  return ctx;
+};

--- a/dashboard/hooks/useMetricsData.ts
+++ b/dashboard/hooks/useMetricsData.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback, useMemo } from 'react';
+import { useErrorHandler } from './useErrorHandler';
 import { MetricData, TimeRange } from '../types';
 import { createMetrics, type MetricInputData } from '../utils/metricsCreator';
 import { hasBadRequest, getErrorMessage } from '../utils/errorHandler';
@@ -8,7 +9,7 @@ import { useSearchParams } from 'react-router-dom';
 export const useMetricsData = () => {
     const [metrics, setMetrics] = useState<MetricData[]>([]);
     const [loadingMetrics, setLoadingMetrics] = useState(true);
-    const [errorMessage, setErrorMessage] = useState<string>('');
+    const { errorMessage, setErrorMessage } = useErrorHandler();
 
     const [searchParams] = useSearchParams();
 

--- a/dashboard/index.tsx
+++ b/dashboard/index.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { ToastProvider } from './components/ToastProvider';
+import { ErrorProvider } from './hooks/useErrorHandler';
 import { BrowserRouter } from 'react-router-dom';
 import './index.css';
 
@@ -16,9 +17,11 @@ root.render(
   <React.StrictMode>
     <ToastProvider>
       <ErrorBoundary>
-        <BrowserRouter>
-          <App />
-        </BrowserRouter>
+        <ErrorProvider>
+          <BrowserRouter>
+            <App />
+          </BrowserRouter>
+        </ErrorProvider>
       </ErrorBoundary>
     </ToastProvider>
   </React.StrictMode>,


### PR DESCRIPTION
## Summary
- introduce `ErrorProvider` and `useErrorHandler`
- wrap dashboard in `ErrorProvider`
- connect metrics and controller hooks to the new context

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6841651ccf44832882d171e0150f456f