### PR TITLE
Display sequencer names in Active Sequencers table

### DIFF
--- a/dashboard/config/tableConfig.ts
+++ b/dashboard/config/tableConfig.ts
@@ -135,8 +135,9 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
   gateways: {
     title: 'Active Sequencers',
     fetcher: fetchActiveSequencerAddresses,
-    columns: [{ key: 'address', label: 'Address' }],
-    mapData: (data) => data.map((g) => ({ address: g })),
+    columns: [{ key: 'sequencer', label: 'Sequencer' }],
+    mapData: (data) =>
+      data.map((g) => ({ sequencer: getSequencerName(g) })),
     urlKey: 'gateways',
   },
 


### PR DESCRIPTION
## Summary
- show mapped sequencer names instead of raw addresses on the Active Sequencers table

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68417547274c83289ab6d8bb683af918