### PR TITLE
Show address in active sequencer table

### DIFF
--- a/dashboard/config/tableConfig.ts
+++ b/dashboard/config/tableConfig.ts
@@ -135,10 +135,14 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
   gateways: {
     title: 'Active Sequencers',
     fetcher: fetchActiveSequencerAddresses,
-    columns: [{ key: 'sequencer', label: 'Sequencer' }],
+    columns: [
+      { key: 'sequencer', label: 'Sequencer' },
+      { key: 'address', label: 'Address' },
+    ],
     mapData: (data) =>
       data.map((g) => ({
-        sequencer: `${getSequencerName(g)} (${g})`,
+        sequencer: getSequencerName(g),
+        address: g,
       })),
     urlKey: 'gateways',
   },

--- a/dashboard/config/tableConfig.ts
+++ b/dashboard/config/tableConfig.ts
@@ -137,7 +137,9 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
     fetcher: fetchActiveSequencerAddresses,
     columns: [{ key: 'sequencer', label: 'Sequencer' }],
     mapData: (data) =>
-      data.map((g) => ({ sequencer: getSequencerName(g) })),
+      data.map((g) => ({
+        sequencer: `${getSequencerName(g)} (${g})`,
+      })),
     urlKey: 'gateways',
   },
 

--- a/dashboard/sequencerConfig.ts
+++ b/dashboard/sequencerConfig.ts
@@ -12,7 +12,7 @@ export const SEQUENCER_ADDRESS_BY_NAME: Record<string, string> =
   Object.fromEntries(SEQUENCER_PAIRS.map(([addr, name]) => [name, addr]));
 
 export const getSequencerName = (address: string): string =>
-  SEQUENCER_NAME_BY_ADDRESS[address.toLowerCase()] ?? address;
+  SEQUENCER_NAME_BY_ADDRESS[address.toLowerCase()] ?? 'Unknown';
 
 export const getSequencerAddress = (name: string): string | undefined =>
   SEQUENCER_ADDRESS_BY_NAME[name];

--- a/dashboard/tests/apiService.test.ts
+++ b/dashboard/tests/apiService.test.ts
@@ -72,7 +72,7 @@ describe('apiService', () => {
     });
     const txs = await fetchBlockTransactions('1h');
     expect(txs.error).toBeNull();
-    expect(txs.data).toStrictEqual([{ block: 1, txs: 3, sequencer: '0xabc' }]);
+    expect(txs.data).toStrictEqual([{ block: 1, txs: 3, sequencer: 'Unknown' }]);
   });
 
   it('fetchAvgL2Tps succeeds', async () => {

--- a/dashboard/tests/helpers.test.ts
+++ b/dashboard/tests/helpers.test.ts
@@ -58,7 +58,7 @@ describe('helpers', () => {
     expect(metrics[4].group).toBe('Network Performance');
     expect(metrics[5].value).toBe('2');
     expect(metrics[5].group).toBe('Sequencers');
-    expect(metrics[6].value).toBe('0xabc');
+    expect(metrics[6].value).toBe('Unknown');
     expect(metrics[6].group).toBe('Sequencers');
     expect(metrics[7].value).toBe('N/A');
     expect(metrics[7].group).toBe('Sequencers');

--- a/dashboard/tests/sequencerConfig.test.ts
+++ b/dashboard/tests/sequencerConfig.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { getSequencerName } from '../sequencerConfig';
+
+const addressA = '0x00a00800c28f2616360dcfadee02d761d14ad94e';
+const unknown = '0xdeadbeef';
+
+describe('getSequencerName', () => {
+  it('returns known sequencer name', () => {
+    expect(getSequencerName(addressA)).toBe('Chainbound A');
+  });
+
+  it('returns "Unknown" for unmapped address', () => {
+    expect(getSequencerName(unknown)).toBe('Unknown');
+  });
+});


### PR DESCRIPTION
## Summary
- show address in Active Sequencers table column
- return `Unknown` from `getSequencerName` for unmapped addresses
- add unit tests for `getSequencerName`
- update existing tests

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6841782877ac83289c39de9c6ef81868