### PR TITLE
Fix brush labels in Reorg chart

### DIFF
--- a/dashboard/components/ReorgDepthChart.tsx
+++ b/dashboard/components/ReorgDepthChart.tsx
@@ -115,6 +115,7 @@ const ReorgDepthChartComponent: React.FC<ReorgDepthChartProps> = ({ data }) => {
           dataKey="timestamp"
           height={20}
           stroke={TAIKO_PINK}
+          tickFormatter={(v: number) => new Date(v).toLocaleString()}
           startIndex={clampedRange.startIndex}
           endIndex={clampedRange.endIndex}
           onChange={handleBrushChange}


### PR DESCRIPTION
## Summary
- improve time labels for the brush in ReorgDepthChart

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_684177a9fff88328b3956f8ddd7253eb