### PR TITLE
Implement safe navigation in dashboard hooks

### DIFF
--- a/dashboard/components/DashboardHeader.tsx
+++ b/dashboard/components/DashboardHeader.tsx
@@ -3,7 +3,8 @@ import { TimeRange } from '../types';
 import { RefreshCountdown } from './RefreshCountdown';
 import { TAIKO_PINK } from '../theme';
 import { isValidRefreshRate } from '../utils';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useSearchParams as useRouterSearchParams } from 'react-router-dom';
+import { useRouterNavigation } from '../hooks/useRouterNavigation';
 
 const metaEnv = (import.meta as any).env as ImportMetaEnv | undefined;
 const NETWORK_NAME =
@@ -32,8 +33,8 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({
   selectedSequencer,
   onSequencerChange,
 }) => {
-  const navigate = useNavigate();
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams] = useRouterSearchParams();
+  const { navigateToDashboard, updateSearchParams } = useRouterNavigation();
   return (
     <header className="flex flex-col md:flex-row justify-between items-center pb-4 border-b border-gray-200">
       <div className="flex items-baseline space-x-4">
@@ -41,13 +42,7 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({
           className="text-3xl font-bold cursor-pointer hover:underline"
           style={{ color: TAIKO_PINK }}
           onClick={() => {
-            try {
-              setSearchParams({});
-              navigate('/');
-            } catch (err) {
-              console.error('Failed to navigate to home:', err);
-              window.location.href = window.location.pathname;
-            }
+            navigateToDashboard();
           }}
         >
           {' '}
@@ -58,26 +53,12 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({
       <div className="flex items-center space-x-2 mt-4 md:mt-0">
         <button
           onClick={() => {
-            try {
-              const params = new URLSearchParams(searchParams);
-              if (params.get('view') === 'economics') {
-                // Already on economics view - reload instead of navigating to home
-                navigate(0);
-              } else {
-                params.set('view', 'economics');
-                params.delete('table');
-                navigate({ pathname: '/', search: params.toString() });
-              }
-            } catch (err) {
-              console.error('Failed to toggle economics view:', err);
-              const fallbackUrl = new URL(window.location.href);
-              try {
-                fallbackUrl.searchParams.set('view', 'economics');
-                window.location.href = fallbackUrl.toString();
-              } catch (fallbackErr) {
-                console.error('Fallback navigation also failed:', fallbackErr);
-              }
+            const params = new URLSearchParams(searchParams);
+            if (params.get('view') === 'economics') {
+              navigateToDashboard(true);
+              return;
             }
+            updateSearchParams({ view: 'economics', table: null });
           }}
           className="text-sm hover:underline"
           style={{ color: TAIKO_PINK }}

--- a/dashboard/components/routes/SequencerRoute.tsx
+++ b/dashboard/components/routes/SequencerRoute.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
-import { useParams, useOutletContext, useNavigate } from 'react-router-dom';
+import { useParams, useOutletContext } from 'react-router-dom';
+import { useRouterNavigation } from '../../hooks/useRouterNavigation';
 import { TimeRange } from '../../types';
 
 interface DashboardContextType {
@@ -16,7 +17,7 @@ interface DashboardContextType {
 
 export const SequencerRoute: React.FC = () => {
   const { address } = useParams<{ address: string }>();
-  const navigate = useNavigate();
+  const { navigateToTable, navigateToDashboard } = useRouterNavigation();
   
   const {
     setSelectedSequencer,
@@ -27,13 +28,11 @@ export const SequencerRoute: React.FC = () => {
   useEffect(() => {
     if (address && sequencerList.includes(address)) {
       setSelectedSequencer(address);
-      // Redirect to sequencer blocks table
-      navigate(`/table/sequencer-blocks?address=${address}&range=${timeRange}`, { replace: true });
+      navigateToTable('sequencer-blocks', { address }, timeRange);
     } else {
-      // Invalid sequencer address, redirect to dashboard
-      navigate('/', { replace: true });
+      navigateToDashboard();
     }
-  }, [address, sequencerList, setSelectedSequencer, navigate, timeRange]);
+  }, [address, sequencerList, setSelectedSequencer, navigateToTable, navigateToDashboard, timeRange]);
 
   return <div>Redirecting...</div>;
 };

--- a/dashboard/components/routes/TableRoute.tsx
+++ b/dashboard/components/routes/TableRoute.tsx
@@ -3,8 +3,8 @@ import {
   useParams,
   useSearchParams,
   useOutletContext,
-  useNavigate,
 } from 'react-router-dom';
+import { useRouterNavigation } from '../../hooks/useRouterNavigation';
 import { TableView } from '../views/TableView';
 import { DashboardHeader } from '../DashboardHeader';
 import { TableViewState } from '../../hooks/useTableActions';
@@ -28,7 +28,7 @@ interface DashboardContextType {
 export const TableRoute: React.FC = () => {
   const { tableType } = useParams<{ tableType: string }>();
   const [searchParams, setSearchParams] = useSearchParams();
-  const navigate = useNavigate();
+  const { navigateToDashboard } = useRouterNavigation();
 
   const {
     timeRange,
@@ -182,7 +182,7 @@ export const TableRoute: React.FC = () => {
   ]);
 
   const handleBack = () => {
-    navigate('/');
+    navigateToDashboard();
   };
 
   if (!tableView && !tableLoading) {

--- a/dashboard/hooks/useRouterNavigation.ts
+++ b/dashboard/hooks/useRouterNavigation.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
+import { safeNavigate } from '../utils/navigationUtils';
 import { TimeRange } from '../types';
 
 export const useRouterNavigation = () => {
@@ -25,11 +26,11 @@ export const useRouterNavigation = () => {
     
     const queryString = queryParams.toString();
     const path = `/table/${tableType}${queryString ? `?${queryString}` : ''}`;
-    navigate(path);
+    safeNavigate(navigate, path);
   }, [navigate]);
 
   const navigateToSequencer = useCallback((address: string) => {
-    navigate(`/sequencer/${address}`);
+    safeNavigate(navigate, `/sequencer/${address}`);
   }, [navigate]);
 
   const navigateToDashboard = useCallback((preserveParams = false) => {
@@ -42,9 +43,9 @@ export const useRouterNavigation = () => {
       if (range) params.set('range', range);
       
       const queryString = params.toString();
-      navigate(`/${queryString ? `?${queryString}` : ''}`);
+      safeNavigate(navigate, `/${queryString ? `?${queryString}` : ''}`);
     } else {
-      navigate('/');
+      safeNavigate(navigate, '/');
     }
   }, [navigate, searchParams]);
 
@@ -60,7 +61,7 @@ export const useRouterNavigation = () => {
     });
     
     const queryString = newParams.toString();
-    navigate(`?${queryString}`, { replace: true });
+    safeNavigate(navigate, `?${queryString}`, true);
   }, [navigate, searchParams]);
 
   return {

--- a/dashboard/hooks/useSearchParams.ts
+++ b/dashboard/hooks/useSearchParams.ts
@@ -3,6 +3,7 @@ import {
   useSearchParams as useRouterSearchParams,
   useNavigate,
 } from 'react-router-dom';
+import { safeNavigate } from '../utils/navigationUtils';
 
 interface NavigationState {
   canGoBack: boolean;
@@ -30,24 +31,12 @@ export const useSearchParams = (): URLSearchParams & {
   const navigate = useCallback(
     (url: string | URL, replace = false) => {
       setNavigationState((prev) => ({ ...prev, isNavigating: true }));
-      try {
-        const to = url instanceof URL ? url.pathname + url.search : url;
-        routerNavigate(to, { replace });
-      } catch (err) {
-        console.error('Navigation error:', err);
-        setNavigationState((prev) => ({
-          ...prev,
-          errorCount: prev.errorCount + 1,
-          lastError: 'Navigation failed',
-        }));
-      } finally {
-        setNavigationState((prev) => ({
-          ...prev,
-          isNavigating: false,
-          canGoBack:
-            typeof window !== 'undefined' ? window.history.length > 1 : false,
-        }));
-      }
+      safeNavigate(routerNavigate, url, replace);
+      setNavigationState((prev) => ({
+        ...prev,
+        isNavigating: false,
+        canGoBack: typeof window !== 'undefined' ? window.history.length > 1 : false,
+      }));
     },
     [routerNavigate],
   );
@@ -57,7 +46,7 @@ export const useSearchParams = (): URLSearchParams & {
   }, [routerNavigate]);
 
   const resetNavigation = useCallback(() => {
-    routerNavigate('/', { replace: true });
+    safeNavigate(routerNavigate, '/', true);
   }, [routerNavigate]);
 
   useEffect(() => {

--- a/dashboard/tests/routerNavigation.test.ts
+++ b/dashboard/tests/routerNavigation.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+const navSpy = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => navSpy,
+    useSearchParams: () => [new URLSearchParams(), vi.fn()],
+  };
+});
+
+import { useRouterNavigation } from '../hooks/useRouterNavigation';
+
+const mockLocation = {
+  origin: 'https://example.com',
+  pathname: '/dashboard',
+  href: 'https://example.com/dashboard',
+};
+
+describe('useRouterNavigation', () => {
+  beforeEach(() => {
+    vi.stubGlobal('window', { location: mockLocation, history: { length: 1 } });
+    navSpy.mockClear();
+  });
+
+  it('sanitizes table navigation', () => {
+    function Test() {
+      const { navigateToTable } = useRouterNavigation();
+      navigateToTable('blocks', { page: -1 });
+      return null;
+    }
+
+    renderToStaticMarkup(React.createElement(Test));
+    expect(navSpy).toHaveBeenCalledWith('/table/blocks', { replace: false });
+  });
+
+  it('cleans params in updateSearchParams', () => {
+    function Test() {
+      const { updateSearchParams } = useRouterNavigation();
+      updateSearchParams({ view: 'table', page: '-1' });
+      return null;
+    }
+
+    renderToStaticMarkup(React.createElement(Test));
+    expect(navSpy).toHaveBeenCalledWith('/?view=table', { replace: true });
+  });
+});


### PR DESCRIPTION
## Summary
- use `safeNavigate` in custom router hooks
- refactor DashboardHeader, TableRoute, SequencerRoute to use new hooks
- add tests for router navigation sanitization

## Testing
- `npm run test`
- `npm run check`
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_68417b68fb008328ad559fbf390f84d4