### PR TITLE
Add L2 TPS API endpoint

### DIFF
--- a/crates/api-types/src/lib.rs
+++ b/crates/api-types/src/lib.rs
@@ -7,7 +7,7 @@
 use clickhouse_lib::{
     BatchBlobCountRow, BatchPostingTimeRow, BatchProveTimeRow, BatchVerifyTimeRow,
     ForcedInclusionProcessedRow, L1BlockTimeRow, L2BlockTimeRow, L2GasUsedRow, L2ReorgRow,
-    MissedBlockProposalRow, SlashingEventRow,
+    L2TpsRow, MissedBlockProposalRow, SlashingEventRow,
 };
 
 use axum::{Json, http::StatusCode, response::IntoResponse};
@@ -219,6 +219,13 @@ pub struct L2BlockTimesResponse {
 pub struct L2GasUsedResponse {
     /// Gas usage for each L2 block.
     pub blocks: Vec<L2GasUsedRow>,
+}
+
+/// TPS values for each L2 block.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct L2TpsResponse {
+    /// TPS values for each L2 block.
+    pub blocks: Vec<L2TpsRow>,
 }
 
 /// Number of blocks produced by a sequencer.

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -65,6 +65,7 @@ pub const DEFAULT_RATE_PERIOD: StdDuration = StdDuration::from_secs(60);
         l1_block_times,
         l2_block_times,
         l2_gas_used,
+        l2_tps,
         sequencer_distribution,
         sequencer_blocks,
         block_transactions
@@ -100,6 +101,7 @@ pub const DEFAULT_RATE_PERIOD: StdDuration = StdDuration::from_secs(60);
             L1BlockTimesResponse,
             L2BlockTimesResponse,
             L2GasUsedResponse,
+            L2TpsResponse,
             SequencerDistributionResponse,
             SequencerDistributionItem,
             SequencerBlocksResponse,
@@ -114,6 +116,7 @@ pub const DEFAULT_RATE_PERIOD: StdDuration = StdDuration::from_secs(60);
             clickhouse_lib::L1BlockTimeRow,
             clickhouse_lib::L2BlockTimeRow,
             clickhouse_lib::L2GasUsedRow,
+            clickhouse_lib::L2TpsRow,
             clickhouse_lib::BatchBlobCountRow,
             clickhouse_lib::BatchPostingTimeRow,
             HealthResponse,
@@ -1241,6 +1244,48 @@ async fn l2_gas_used(
 
 #[utoipa::path(
     get,
+    path = "/l2-tps",
+    params(
+        RangeQuery
+    ),
+    responses(
+        (status = 200, description = "L2 TPS", body = L2TpsResponse),
+        (status = 500, description = "Database error", body = ErrorResponse)
+    ),
+    tag = "taikoscope"
+)]
+async fn l2_tps(
+    Query(params): Query<RangeQuery>,
+    State(state): State<ApiState>,
+) -> Result<Json<L2TpsResponse>, ErrorResponse> {
+    let address = params.address.as_ref().and_then(|addr| match addr.parse::<Address>() {
+        Ok(a) => Some(AddressBytes::from(a)),
+        Err(e) => {
+            tracing::warn!(error = %e, "Failed to parse address");
+            None
+        }
+    });
+    let blocks = match state
+        .client
+        .get_l2_tps(address, TimeRange::from_duration(range_duration(&params.range)))
+        .await
+    {
+        Ok(rows) => rows,
+        Err(e) => {
+            tracing::error!("Failed to get L2 TPS: {}", e);
+            return Err(ErrorResponse::new(
+                "database-error",
+                "Database error",
+                StatusCode::INTERNAL_SERVER_ERROR,
+                e.to_string(),
+            ));
+        }
+    };
+    Ok(Json(L2TpsResponse { blocks }))
+}
+
+#[utoipa::path(
+    get,
     path = "/sequencer-distribution",
     params(
         RangeQuery
@@ -1452,6 +1497,8 @@ pub fn router(state: ApiState) -> Router {
         .route("/l1-block-times", get(l1_block_times))
         .route("/l2-block-times", get(l2_block_times))
         .route("/l2-gas-used", get(l2_gas_used))
+        .route("/l2-tps", get(l2_tps))
+        .route("/tps", get(l2_tps))
         .route("/sequencer-distribution", get(sequencer_distribution))
         .route("/sequencer-blocks", get(sequencer_blocks))
         .route("/block-transactions", get(block_transactions))
@@ -2014,6 +2061,26 @@ mod tests {
         let app = build_app(mock.url());
         let body = send_request(app, "/l2-gas-used?range=7d").await;
         assert_eq!(body, json!({ "blocks": [ { "l2_block_number": 1, "gas_used": 42 } ] }));
+    }
+
+    #[derive(Serialize, Row)]
+    struct L2TpsRowTest {
+        l2_block_number: u64,
+        sum_tx: u32,
+        ms_since_prev_block: Option<u64>,
+    }
+
+    #[tokio::test]
+    async fn l2_tps_endpoint() {
+        let mock = Mock::new();
+        mock.add(handlers::provide(vec![L2TpsRowTest {
+            l2_block_number: 1,
+            sum_tx: 6,
+            ms_since_prev_block: Some(2000),
+        }]));
+        let app = build_app(mock.url());
+        let body = send_request(app, "/l2-tps").await;
+        assert_eq!(body, json!({ "blocks": [ { "l2_block_number": 1, "tps": 3.0 } ] }));
     }
 
     #[derive(Serialize, Row)]

--- a/crates/clickhouse/src/models.rs
+++ b/crates/clickhouse/src/models.rs
@@ -201,6 +201,15 @@ pub struct L2GasUsedRow {
     pub gas_used: u64,
 }
 
+/// Row representing the transactions per second for an L2 block
+#[derive(Debug, Serialize, Deserialize, PartialEq, ToSchema)]
+pub struct L2TpsRow {
+    /// L2 block number
+    pub l2_block_number: u64,
+    /// Transactions per second between this and the previous block
+    pub tps: f64,
+}
+
 /// Row representing the blob count for each batch
 #[derive(Debug, Row, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
 pub struct BatchBlobCountRow {


### PR DESCRIPTION
## Summary
- expose `L2TpsRow` and `L2TpsResponse` types
- add ClickHouse query to compute TPS per block
- create `/l2-tps` API endpoint with alias `/tps`
- document and test the new route

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68418b81ef5c832894bd8f608024fbb5