### PR TITLE
Add prover cost in API

### DIFF
--- a/crates/api-types/src/lib.rs
+++ b/crates/api-types/src/lib.rs
@@ -186,6 +186,13 @@ pub struct CloudCostResponse {
     pub cost_usd: f64,
 }
 
+/// Estimated prover infrastructure cost in USD.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ProverCostResponse {
+    /// Estimated prover cost in USD for the requested range.
+    pub cost_usd: f64,
+}
+
 /// Time to prove individual batches.
 #[derive(Debug, Serialize, ToSchema)]
 pub struct ProveTimesResponse {

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -21,7 +21,7 @@ use clickhouse_lib::{AddressBytes, ClickhouseReader, TimeRange};
 use dashmap::DashMap;
 use futures::stream::Stream;
 use hex::encode;
-use primitives::hardware::TOTAL_HARDWARE_COST_USD;
+use primitives::hardware::{PROVER_COST_USD, TOTAL_HARDWARE_COST_USD};
 use runtime::rate_limiter::RateLimiter;
 use serde::Deserialize;
 use std::{convert::Infallible, time::Duration as StdDuration};
@@ -58,6 +58,7 @@ pub const DEFAULT_RATE_PERIOD: StdDuration = StdDuration::from_secs(60);
         avg_l2_tps,
         l2_transaction_fee,
         cloud_cost,
+        prover_cost,
         avg_blobs_per_batch,
         blobs_per_batch,
         prove_times,
@@ -93,6 +94,7 @@ pub const DEFAULT_RATE_PERIOD: StdDuration = StdDuration::from_secs(60);
             AvgL2TpsResponse,
             L2TxFeeResponse,
             CloudCostResponse,
+            ProverCostResponse,
             AvgBlobsPerBatchResponse,
             BatchBlobsResponse,
             ProveTimesResponse,
@@ -979,6 +981,26 @@ async fn cloud_cost(Query(params): Query<RangeQuery>) -> Json<CloudCostResponse>
 
 #[utoipa::path(
     get,
+    path = "/prover-cost",
+    params(
+        RangeQuery
+    ),
+    responses(
+        (status = 200, description = "Estimated prover cost", body = ProverCostResponse)
+    ),
+    tag = "taikoscope"
+)]
+async fn prover_cost(Query(params): Query<RangeQuery>) -> Json<ProverCostResponse> {
+    let duration = range_duration(&params.range);
+    let hours = duration.num_hours() as f64;
+    let hourly_rate = PROVER_COST_USD / (30.0 * 24.0);
+    let cost = hourly_rate * hours;
+    tracing::info!(cost_usd = cost, "Returning prover cost");
+    Json(ProverCostResponse { cost_usd: cost })
+}
+
+#[utoipa::path(
+    get,
     path = "/avg-blobs-per-batch",
     params(
         RangeQuery
@@ -1445,6 +1467,7 @@ pub fn router(state: ApiState) -> Router {
         .route("/avg-l2-tps", get(avg_l2_tps))
         .route("/l2-tx-fee", get(l2_transaction_fee))
         .route("/cloud-cost", get(cloud_cost))
+        .route("/prover-cost", get(prover_cost))
         .route("/avg-blobs-per-batch", get(avg_blobs_per_batch))
         .route("/blobs-per-batch", get(blobs_per_batch))
         .route("/prove-times", get(prove_times))
@@ -1475,7 +1498,7 @@ mod tests {
         Row,
         test::{Mock, handlers},
     };
-    use primitives::hardware::TOTAL_HARDWARE_COST_USD;
+    use primitives::hardware::{PROVER_COST_USD, TOTAL_HARDWARE_COST_USD};
     use serde::Serialize;
     use serde_json::{Value, json};
     use std::time::Duration as StdDuration;
@@ -2099,6 +2122,15 @@ mod tests {
         assert_eq!(body, json!({ "cost_usd": expected }));
     }
 
+    #[tokio::test]
+    async fn prover_cost_endpoint() {
+        let app = build_app(Mock::new().url());
+        let body = send_request(app, "/prover-cost?range=24h").await;
+        let hourly_rate = PROVER_COST_USD / (30.0 * 24.0);
+        let expected = hourly_rate * 24.0;
+        assert_eq!(body, json!({ "cost_usd": expected }));
+    }
+
     #[derive(Serialize, Row)]
     struct SequencerRowTest {
         sequencer: AddressBytes,
@@ -2272,6 +2304,7 @@ mod tests {
             "/avg-l2-tps",
             "/l2-tx-fee",
             "/cloud-cost",
+            "/prover-cost",
             "/avg-blobs-per-batch",
             "/blobs-per-batch",
             "/prove-times",

--- a/crates/primitives/src/hardware.rs
+++ b/crates/primitives/src/hardware.rs
@@ -12,3 +12,6 @@ pub const NETWORKING_COST_USD: f64 = 30.0;
 /// Estimated total hardware cost for a redundant sequencer setup in USD.
 pub const TOTAL_HARDWARE_COST_USD: f64 =
     SEQUENCER_SERVER_COST_USD * SEQUENCER_SERVER_COUNT as f64 + NETWORKING_COST_USD;
+
+/// Estimated monthly cost for running a prover in USD.
+pub const PROVER_COST_USD: f64 = 1000.0;


### PR DESCRIPTION
## Summary
- expose a prover cost constant
- implement `/prover-cost` endpoint
- document ProverCostResponse type
- test the new endpoint

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68418b586aec83289105584d303d75d6