### PR TITLE
Fix L2 Reorgs chart layout

### DIFF
--- a/dashboard/components/ReorgDepthChart.tsx
+++ b/dashboard/components/ReorgDepthChart.tsx
@@ -72,7 +72,7 @@ const ReorgDepthChartComponent: React.FC<ReorgDepthChartProps> = ({ data }) => {
     <ResponsiveContainer width="100%" height="100%">
       <BarChart
         data={data}
-        margin={{ top: 5, right: 70, left: 80, bottom: 40 }}
+        margin={{ top: 5, right: 70, left: 60, bottom: 40 }}
       >
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis


### PR DESCRIPTION
## Summary
- tweak margin in `ReorgDepthChart` to shift the chart left

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68419c7e8f248328b348d1df3d2c424d