### PR TITLE
Fix seconds display for short L2 block times

### DIFF
--- a/dashboard/utils.ts
+++ b/dashboard/utils.ts
@@ -80,8 +80,10 @@ export const computeBatchDurationFlags = (data: { value: number }[]) => {
   return { showHours, showMinutes };
 };
 
-export const shouldShowMinutes = (data: { timestamp: number }[]) => {
-  return data.some((d) => d.timestamp >= 120000);
+export const shouldShowMinutes = (data: { timestamp: number }[]): boolean => {
+  if (data.length === 0) return false;
+  const max = data.reduce((acc, cur) => Math.max(acc, cur.timestamp), 0);
+  return max >= 120000;
 };
 
 export const findMetricValue = (


### PR DESCRIPTION
## Summary
- update `shouldShowMinutes` so the axis changes to seconds when the largest block interval is under 2 minutes

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6841a09ab95883288370c7f2fdb6eb79