### PR TITLE
Add cached ETH price in profit calculator

### DIFF
--- a/dashboard/components/ProfitCalculator.tsx
+++ b/dashboard/components/ProfitCalculator.tsx
@@ -16,11 +16,18 @@ export const ProfitCalculator: React.FC<ProfitCalculatorProps> = ({
   const [cloudCost, setCloudCost] = useState(0);
   const [proverCost, setProverCost] = useState(0);
   const [ethPrice, setEthPrice] = useState(0);
+  const [ethPriceError, setEthPriceError] = useState(false);
 
   useEffect(() => {
     getEthPrice()
-      .then((p) => setEthPrice(p))
-      .catch((err) => console.error('Failed to fetch ETH price', err));
+      .then((p) => {
+        setEthPrice(p);
+        setEthPriceError(false);
+      })
+      .catch((err) => {
+        console.error('Failed to fetch ETH price', err);
+        setEthPriceError(true);
+      });
   }, []);
 
   const profit = fee * ethPrice - cloudCost - proverCost;
@@ -50,6 +57,9 @@ export const ProfitCalculator: React.FC<ProfitCalculatorProps> = ({
       </div>
       <p className="mt-3 text-sm">
         Profit: <span className="font-semibold">${profit.toFixed(2)}</span>
+        {ethPriceError && (
+          <span className="text-red-500 ml-2 text-xs">(ETH price unavailable)</span>
+        )}
       </p>
     </div>
   );

--- a/dashboard/services/priceService.ts
+++ b/dashboard/services/priceService.ts
@@ -22,7 +22,15 @@ export const getEthPrice = async (): Promise<number> => {
   const res = await fetch(
     'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd',
   );
-  const data = (await res.json()) as { ethereum: { usd: number } };
+  if (!res.ok) {
+    throw new Error(`Failed to fetch ETH price: ${res.status}`);
+  }
+  
+  const data = await res.json();
+  if (!data?.ethereum?.usd || typeof data.ethereum.usd !== 'number') {
+    throw new Error('Invalid ETH price response format');
+  }
+  
   const price = data.ethereum.usd;
 
   if (typeof localStorage !== 'undefined') {


### PR DESCRIPTION
## Summary
- show profit in USD in the dashboard
- fetch ETH price from Coingecko and cache it in localStorage for 1 hour
- test ETH price fetching logic

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6841a256943c832897646208bf6c035a