### PR TITLE
Add detailed Gas Used table view

### DIFF
--- a/dashboard/components/layout/ChartsGrid.tsx
+++ b/dashboard/components/layout/ChartsGrid.tsx
@@ -96,7 +96,11 @@ export const ChartsGrid: React.FC<ChartsGridProps> = ({
                     lineColor="#5DA5DA"
                 />
             </ChartCard>
-            <ChartCard title="Gas Used Per Block" loading={isLoading}>
+            <ChartCard
+                title="Gas Used Per Block"
+                onMore={() => onOpenTable('l2-gas-used', timeRange)}
+                loading={isLoading}
+            >
                 <GasUsedChart
                     key={timeRange}
                     data={chartsData.l2GasUsedData}

--- a/dashboard/config/tableConfig.ts
+++ b/dashboard/config/tableConfig.ts
@@ -16,6 +16,7 @@ import {
   fetchVerifyTimes,
   fetchBlockTransactions,
   fetchL2BlockTimes,
+  fetchL2GasUsed,
   fetchSequencerDistribution,
 } from '../services/apiService';
 import { getSequencerName } from '../sequencerConfig';
@@ -245,6 +246,28 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
       });
     },
     urlKey: 'l2-block-times',
+  },
+
+  'l2-gas-used': {
+    title: 'Gas Used Per Block',
+    fetcher: fetchL2GasUsed,
+    columns: [
+      { key: 'value', label: 'Block Number' },
+      { key: 'timestamp', label: 'Gas Used' },
+    ],
+    mapData: (data) => data as Record<string, string | number>[],
+    chart: (data) => {
+      const GasUsedChart = React.lazy(() =>
+        import('../components/GasUsedChart').then((m) => ({
+          default: m.GasUsedChart,
+        })),
+      );
+      return React.createElement(GasUsedChart, {
+        data,
+        lineColor: '#E573B5',
+      });
+    },
+    urlKey: 'l2-gas-used',
   },
 
   'sequencer-dist': {


### PR DESCRIPTION
## Summary
- allow viewing Gas Used Per Block table from chart
- create `l2-gas-used` table config with chart rendering

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6841a629a85483289a79ef67a44e2055