### PR TITLE
Fix block number labels

### DIFF
--- a/dashboard/components/BlockTimeChart.tsx
+++ b/dashboard/components/BlockTimeChart.tsx
@@ -50,7 +50,7 @@ const BlockTimeChartComponent: React.FC<BlockTimeChartProps> = ({
           stroke="#666666"
           fontSize={12}
           label={{
-            value: 'Block Number',
+            value: 'L2 Block Number',
             position: 'insideBottom',
             offset: -35,
             fontSize: 10,

--- a/dashboard/components/BlockTxChart.tsx
+++ b/dashboard/components/BlockTxChart.tsx
@@ -43,7 +43,7 @@ const BlockTxChartComponent: React.FC<BlockTxChartProps> = ({
           stroke="#666666"
           fontSize={12}
           label={{
-            value: 'Block Number',
+            value: 'L2 Block Number',
             position: 'insideBottom',
             offset: -35,
             fontSize: 10,

--- a/dashboard/components/GasUsedChart.tsx
+++ b/dashboard/components/GasUsedChart.tsx
@@ -40,7 +40,7 @@ const GasUsedChartComponent: React.FC<GasUsedChartProps> = ({
           stroke="#666666"
           fontSize={12}
           label={{
-            value: 'Block Number',
+            value: 'L2 Block Number',
             position: 'insideBottom',
             offset: -35,
             fontSize: 10,

--- a/dashboard/components/TpsChart.tsx
+++ b/dashboard/components/TpsChart.tsx
@@ -40,7 +40,7 @@ const TpsChartComponent: React.FC<TpsChartProps> = ({ data, lineColor }) => {
           stroke="#666666"
           fontSize={12}
           label={{
-            value: 'Block Number',
+            value: 'L2 Block Number',
             position: 'insideBottom',
             offset: -10,
             fontSize: 10,

--- a/dashboard/components/routes/TableRoute.tsx
+++ b/dashboard/components/routes/TableRoute.tsx
@@ -104,7 +104,7 @@ export const TableRoute: React.FC = () => {
             title: 'L2 Transactions Per Second',
             description: undefined,
             columns: [
-              { key: 'block', label: 'Block Number' },
+              { key: 'block', label: 'L2 Block Number' },
               { key: 'tps', label: 'TPS' },
             ],
             rows: data.map((d: any) => ({

--- a/dashboard/config/tableConfig.ts
+++ b/dashboard/config/tableConfig.ts
@@ -45,7 +45,7 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
   'sequencer-blocks': {
     title: (params) => `Blocks proposed by ${getSequencerName(params.address)}`,
     fetcher: fetchSequencerBlocks,
-    columns: [{ key: 'block', label: 'Block Number' }],
+    columns: [{ key: 'block', label: 'L2 Block Number' }],
     mapData: (data) => data.map((b) => ({ block: blockLink(b) })),
     urlKey: 'sequencer-blocks',
   },
@@ -55,7 +55,7 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
     fetcher: fetchL2ReorgEvents,
     columns: [
       { key: 'timestamp', label: 'Time' },
-      { key: 'l2_block_number', label: 'Block Number' },
+      { key: 'l2_block_number', label: 'L2 Block Number' },
       { key: 'depth', label: 'Depth' },
     ],
     mapData: (data) =>
@@ -208,7 +208,7 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
     title: 'Tx Count Per Block',
     fetcher: (range) => fetchBlockTransactions(range, 50),
     columns: [
-      { key: 'block', label: 'Block Number' },
+      { key: 'block', label: 'L2 Block Number' },
       { key: 'txs', label: 'Tx Count' },
       { key: 'sequencer', label: 'Sequencer' },
     ],
@@ -228,7 +228,7 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
     title: 'L2 Block Times',
     fetcher: fetchL2BlockTimes,
     columns: [
-      { key: 'value', label: 'Block Number' },
+      { key: 'value', label: 'L2 Block Number' },
       { key: 'timestamp', label: 'Interval (ms)' },
     ],
     mapData: (data) => data as Record<string, string | number>[],

--- a/dashboard/hooks/useTableActions.ts
+++ b/dashboard/hooks/useTableActions.ts
@@ -233,7 +233,7 @@ export const useTableActions = (
       'L2 Transactions Per Second',
       undefined,
       [
-        { key: 'block', label: 'Block Number' },
+        { key: 'block', label: 'L2 Block Number' },
         { key: 'tps', label: 'TPS' },
       ],
       data.map((d) => ({
@@ -364,7 +364,7 @@ export const useTableActions = (
         {
           title: 'Transactions',
           columns: [
-            { key: 'block', label: 'Block Number' },
+            { key: 'block', label: 'L2 Block Number' },
             { key: 'txs', label: 'Tx Count' },
             { key: 'sequencer', label: 'Sequencer' },
           ],


### PR DESCRIPTION
## Summary
- clarify L2 block number labels in table headers and charts

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6841b9b947308328ae369e11739e413a