### PR TITLE
Display L1 block numbers on blobs chart

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -2323,13 +2323,23 @@ mod tests {
         let mock = Mock::new();
         #[derive(Serialize, Row)]
         struct BlobRowTest {
+            l1_block_number: u64,
             batch_id: u64,
             blob_count: u8,
         }
-        mock.add(handlers::provide(vec![BlobRowTest { batch_id: 1, blob_count: 3 }]));
+        mock.add(handlers::provide(vec![BlobRowTest {
+            l1_block_number: 10,
+            batch_id: 1,
+            blob_count: 3,
+        }]));
         let app = build_app(mock.url());
         let body = send_request(app, "/blobs-per-batch?range=1h").await;
-        assert_eq!(body, json!({ "batches": [ { "batch_id": 1, "blob_count": 3 } ] }));
+        assert_eq!(
+            body,
+            json!({
+                "batches": [ { "l1_block_number": 10, "batch_id": 1, "blob_count": 3 } ]
+            })
+        );
     }
 
     #[test]

--- a/crates/clickhouse/src/models.rs
+++ b/crates/clickhouse/src/models.rs
@@ -213,6 +213,8 @@ pub struct L2TpsRow {
 /// Row representing the blob count for each batch
 #[derive(Debug, Row, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
 pub struct BatchBlobCountRow {
+    /// L1 block number
+    pub l1_block_number: u64,
     /// Batch ID
     pub batch_id: u64,
     /// Number of blobs in the batch

--- a/crates/clickhouse/src/reader.rs
+++ b/crates/clickhouse/src/reader.rs
@@ -1944,9 +1944,9 @@ impl ClickhouseReader {
     /// Get the blob count for each batch in the last hour
     pub async fn get_blobs_per_batch_last_hour(&self) -> Result<Vec<BatchBlobCountRow>> {
         let query = format!(
-            "SELECT batch_id, blob_count FROM {db}.batches \
+            "SELECT l1_block_number, batch_id, blob_count FROM {db}.batches \
              WHERE inserted_at >= now64() - INTERVAL 1 HOUR \
-             ORDER BY batch_id",
+             ORDER BY l1_block_number",
             db = self.db_name
         );
 
@@ -1957,9 +1957,9 @@ impl ClickhouseReader {
     /// Get the blob count for each batch in the last 24 hours
     pub async fn get_blobs_per_batch_last_24_hours(&self) -> Result<Vec<BatchBlobCountRow>> {
         let query = format!(
-            "SELECT batch_id, blob_count FROM {db}.batches \
+            "SELECT l1_block_number, batch_id, blob_count FROM {db}.batches \
              WHERE inserted_at >= now64() - INTERVAL 24 HOUR \
-             ORDER BY batch_id",
+             ORDER BY l1_block_number",
             db = self.db_name
         );
 
@@ -1970,9 +1970,9 @@ impl ClickhouseReader {
     /// Get the blob count for each batch in the last 7 days
     pub async fn get_blobs_per_batch_last_7_days(&self) -> Result<Vec<BatchBlobCountRow>> {
         let query = format!(
-            "SELECT batch_id, blob_count FROM {db}.batches \
+            "SELECT l1_block_number, batch_id, blob_count FROM {db}.batches \
              WHERE inserted_at >= now64() - INTERVAL 7 DAY \
-             ORDER BY batch_id",
+             ORDER BY l1_block_number",
             db = self.db_name
         );
 
@@ -1983,9 +1983,9 @@ impl ClickhouseReader {
     /// Get the blob count for each batch within the given range
     pub async fn get_blobs_per_batch(&self, range: TimeRange) -> Result<Vec<BatchBlobCountRow>> {
         let query = format!(
-            "SELECT batch_id, blob_count FROM {db}.batches \
+            "SELECT l1_block_number, batch_id, blob_count FROM {db}.batches \
              WHERE inserted_at >= now64() - INTERVAL {interval} \
-             ORDER BY batch_id",
+             ORDER BY l1_block_number",
             interval = range.interval(),
             db = self.db_name,
         );

--- a/dashboard/components/BlobsPerBatchChart.tsx
+++ b/dashboard/components/BlobsPerBatchChart.tsx
@@ -28,20 +28,25 @@ const BlobsPerBatchChartComponent: React.FC<BlobsPerBatchChartProps> = ({
   }
 
 
+  const sortedData = React.useMemo(
+    () => [...data].sort((a, b) => a.block - b.block),
+    [data],
+  );
+
   return (
     <ResponsiveContainer width="100%" height="100%">
       <BarChart
-        data={data}
+        data={sortedData}
         margin={{ top: 5, right: 70, left: 80, bottom: 40 }}
       >
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis
-          dataKey="batch"
+          dataKey="block"
           tickFormatter={(v: number) => v.toLocaleString()}
           stroke="#666666"
           fontSize={12}
           label={{
-            value: 'Batch',
+            value: 'L1 Block',
             position: 'insideBottom',
             offset: -35,
             fontSize: 10,
@@ -65,7 +70,10 @@ const BlobsPerBatchChartComponent: React.FC<BlobsPerBatchChartProps> = ({
           }}
         />
         <Tooltip
-          labelFormatter={(label: number) => `Batch ${label.toLocaleString()}`}
+          labelFormatter={(label: number, payload) => {
+            const batch = payload?.[0]?.payload.batch as number;
+            return `Block ${label.toLocaleString()} (Batch ${batch.toLocaleString()})`;
+          }}
           formatter={(value: number) => [value.toLocaleString(), 'blobs']}
           contentStyle={{
             backgroundColor: 'rgba(255, 255, 255, 0.8)',

--- a/dashboard/config/tableConfig.ts
+++ b/dashboard/config/tableConfig.ts
@@ -123,12 +123,14 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
     title: 'Blobs per Batch',
     fetcher: fetchBatchBlobCounts,
     columns: [
+      { key: 'block', label: 'L1 Block' },
       { key: 'batch', label: 'Batch' },
       { key: 'blobs', label: 'Blobs' },
     ],
     mapData: (data) =>
       (data as Record<string, any>[]).map((d) => ({
-        batch: blockLink(d.batch as number),
+        block: blockLink(d.block as number),
+        batch: d.batch,
         blobs: d.blobs,
       })),
     urlKey: 'blobs-per-batch',

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -476,6 +476,7 @@ export const fetchBlockTransactions = async (
 };
 
 export interface BatchBlobCount {
+  block: number;
   batch: number;
   blobs: number;
 }
@@ -485,11 +486,12 @@ export const fetchBatchBlobCounts = async (
 ): Promise<RequestResult<BatchBlobCount[]>> => {
   const url = `${API_BASE}/blobs-per-batch?range=${range}`;
   const res = await fetchJson<{
-    batches: { batch_id: number; blob_count: number }[];
+    batches: { l1_block_number: number; batch_id: number; blob_count: number }[];
   }>(url);
   return {
     data: res.data
       ? res.data.batches.map((b) => ({
+          block: b.l1_block_number,
           batch: b.batch_id,
           blobs: b.blob_count,
         }))

--- a/dashboard/tests/dataFetcher.test.ts
+++ b/dashboard/tests/dataFetcher.test.ts
@@ -44,7 +44,7 @@ describe('dataFetcher', () => {
       fetchL2GasUsed: ok([{ value: 3, timestamp: 0 }]),
       fetchSequencerDistribution: ok([{ name: 'foo', value: 1 }]),
       fetchBlockTransactions: ok([{ block: 1, txs: 2, sequencer: 'bar' }]),
-      fetchBatchBlobCounts: ok([{ batch: 1, blobs: 2 }]),
+      fetchBatchBlobCounts: ok([{ block: 10, batch: 1, blobs: 2 }]),
       fetchL2TxFee: ok(12),
       fetchCloudCost: ok(13),
     });


### PR DESCRIPTION
## Summary
- include `l1_block_number` in blobs-per-batch API
- expose block number to the dashboard
- update blobs-per-batch chart and table to show L1 block numbers

## Testing
- `just ci` *(fails: `cargo` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6841b9e500b88328b4c886a935a96fda