### PR TITLE
Fix dark mode backgrounds

### DIFF
--- a/dashboard/components/ProfitCalculator.tsx
+++ b/dashboard/components/ProfitCalculator.tsx
@@ -6,7 +6,9 @@ interface ProfitCalculatorProps {
   metrics: MetricData[];
 }
 
-export const ProfitCalculator: React.FC<ProfitCalculatorProps> = ({ metrics }) => {
+export const ProfitCalculator: React.FC<ProfitCalculatorProps> = ({
+  metrics,
+}) => {
   const feeStr = findMetricValue(metrics, 'transaction fee');
   const fee = parseFloat(feeStr.replace(/[^0-9.]/g, '')) || 0;
 
@@ -15,7 +17,7 @@ export const ProfitCalculator: React.FC<ProfitCalculatorProps> = ({ metrics }) =
   const profit = fee - cloudCost - proverCost;
 
   return (
-    <div className="mt-6 p-4 border rounded-md bg-gray-50">
+    <div className="mt-6 p-4 border border-gray-200 dark:border-gray-700 rounded-md bg-gray-50 dark:bg-gray-800">
       <h2 className="text-lg font-semibold mb-2">Profit Calculator</h2>
       <div className="flex flex-col sm:flex-row sm:space-x-4 space-y-2 sm:space-y-0">
         <label className="flex flex-col text-sm">

--- a/dashboard/components/views/DashboardView.tsx
+++ b/dashboard/components/views/DashboardView.tsx
@@ -7,141 +7,143 @@ import { TimeRange, MetricData } from '../../types';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
 interface DashboardViewProps {
-    timeRange: TimeRange;
-    selectedSequencer: string | null;
+  timeRange: TimeRange;
+  selectedSequencer: string | null;
 
-    // Data hooks
-    metricsData: {
-        metrics: MetricData[];
-        loadingMetrics: boolean;
-        errorMessage: string;
-        setErrorMessage: (msg: string) => void;
-    };
-    chartsData: any;
-    // Actions
-    onOpenTable: (table: string, timeRange?: TimeRange) => void;
-    onOpenTpsTable: () => void;
-    onOpenSequencerDistributionTable: (timeRange: TimeRange, page: number) => void;
+  // Data hooks
+  metricsData: {
+    metrics: MetricData[];
+    loadingMetrics: boolean;
+    errorMessage: string;
+    setErrorMessage: (msg: string) => void;
+  };
+  chartsData: any;
+  // Actions
+  onOpenTable: (table: string, timeRange?: TimeRange) => void;
+  onOpenTpsTable: () => void;
+  onOpenSequencerDistributionTable: (
+    timeRange: TimeRange,
+    page: number,
+  ) => void;
 }
 
 export const DashboardView: React.FC<DashboardViewProps> = ({
-    timeRange,
-    selectedSequencer,
-    metricsData,
-    chartsData,
-    onOpenTable,
-    onOpenTpsTable,
-    onOpenSequencerDistributionTable,
+  timeRange,
+  selectedSequencer,
+  metricsData,
+  chartsData,
+  onOpenTable,
+  onOpenTpsTable,
+  onOpenSequencerDistributionTable,
 }) => {
-    const navigate = useNavigate();
-    const [searchParams] = useSearchParams();
-    const isEconomicsView = searchParams.get('view') === 'economics';
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const isEconomicsView = searchParams.get('view') === 'economics';
 
-    const visibleMetrics = React.useMemo(
-        () =>
-            metricsData.metrics.filter((m) => {
-                if (selectedSequencer && m.group === 'Sequencers') return false;
-                if (isEconomicsView) return m.group === 'Network Economics';
-                return m.group !== 'Network Economics';
-            }),
-        [metricsData.metrics, selectedSequencer, isEconomicsView],
-    );
+  const visibleMetrics = React.useMemo(
+    () =>
+      metricsData.metrics.filter((m) => {
+        if (selectedSequencer && m.group === 'Sequencers') return false;
+        if (isEconomicsView) return m.group === 'Network Economics';
+        return m.group !== 'Network Economics';
+      }),
+    [metricsData.metrics, selectedSequencer, isEconomicsView],
+  );
 
-    const groupedMetrics = visibleMetrics.reduce<Record<string, MetricData[]>>(
-        (acc, m) => {
-            const group = m.group ?? 'Other';
-            if (!acc[group]) acc[group] = [];
-            acc[group].push(m);
-            return acc;
-        },
-        {},
-    );
+  const groupedMetrics = visibleMetrics.reduce<Record<string, MetricData[]>>(
+    (acc, m) => {
+      const group = m.group ?? 'Other';
+      if (!acc[group]) acc[group] = [];
+      acc[group].push(m);
+      return acc;
+    },
+    {},
+  );
 
-    const groupOrder = isEconomicsView
-        ? ['Network Economics']
-        : ['Network Performance', 'Network Health', 'Sequencers', 'Other'];
+  const groupOrder = isEconomicsView
+    ? ['Network Economics']
+    : ['Network Performance', 'Network Health', 'Sequencers', 'Other'];
 
-    const skeletonGroupCounts: Record<string, number> = isEconomicsView
-        ? { 'Network Economics': 1 }
-        : {
-            'Network Performance': 5,
-            'Network Health': 4,
-            Sequencers: 3,
-        };
+  const skeletonGroupCounts: Record<string, number> = isEconomicsView
+    ? { 'Network Economics': 1 }
+    : {
+        'Network Performance': 5,
+        'Network Health': 4,
+        Sequencers: 3,
+      };
 
-    const displayGroupName = useCallback(
-        (group: string): string => {
-            if (!selectedSequencer) return group;
-            if (group === 'Network Performance') return 'Sequencer Performance';
-            if (group === 'Network Health') return 'Sequencer Health';
-            return group;
-        },
-        [selectedSequencer],
-    );
+  const displayGroupName = useCallback(
+    (group: string): string => {
+      if (!selectedSequencer) return group;
+      if (group === 'Network Performance') return 'Sequencer Performance';
+      if (group === 'Network Health') return 'Sequencer Health';
+      return group;
+    },
+    [selectedSequencer],
+  );
 
-    const displayedGroupOrder = selectedSequencer
-        ? groupOrder.filter((g) => g !== 'Sequencers')
-        : groupOrder;
+  const displayedGroupOrder = selectedSequencer
+    ? groupOrder.filter((g) => g !== 'Sequencers')
+    : groupOrder;
 
-    const handleResetNavigation = useCallback(() => {
-        navigate('/', { replace: true });
-        metricsData.setErrorMessage('');
-    }, [navigate, metricsData]);
+  const handleResetNavigation = useCallback(() => {
+    navigate('/', { replace: true });
+    metricsData.setErrorMessage('');
+  }, [navigate, metricsData]);
 
-    const handleClearError = useCallback(() => {
-        metricsData.setErrorMessage('');
-    }, [metricsData]);
+  const handleClearError = useCallback(() => {
+    metricsData.setErrorMessage('');
+  }, [metricsData]);
 
-    const getMetricAction = useCallback((title: string) => {
-        const actions: Record<string, () => void> = {
-            'Avg. L2 TPS': onOpenTpsTable,
-            'L2 Reorgs': () => onOpenTable('reorgs'),
-            'Slashing Events': () => onOpenTable('slashings'),
-            'Forced Inclusions': () => onOpenTable('forced-inclusions'),
-            'Active Sequencers': () => onOpenTable('gateways'),
-            'Batch Posting Cadence': () => onOpenTable('batch-posting-cadence'),
-        };
-        return actions[title];
-    }, [onOpenTable, onOpenTpsTable]);
+  const getMetricAction = useCallback(
+    (title: string) => {
+      const actions: Record<string, () => void> = {
+        'Avg. L2 TPS': onOpenTpsTable,
+        'L2 Reorgs': () => onOpenTable('reorgs'),
+        'Slashing Events': () => onOpenTable('slashings'),
+        'Forced Inclusions': () => onOpenTable('forced-inclusions'),
+        'Active Sequencers': () => onOpenTable('gateways'),
+        'Batch Posting Cadence': () => onOpenTable('batch-posting-cadence'),
+      };
+      return actions[title];
+    },
+    [onOpenTable, onOpenTpsTable],
+  );
 
-    return (
-        <div
-            className="bg-white text-gray-800 p-4 md:p-6 lg:p-8"
-            style={{ fontFamily: "'Inter', sans-serif" }}
-        >
-            <ErrorDisplay
-                errorMessage={metricsData.errorMessage}
-                onResetNavigation={handleResetNavigation}
-                onClearError={handleClearError}
-            />
+  return (
+    <div
+      className="bg-white dark:bg-gray-900 text-gray-800 dark:text-gray-100 p-4 md:p-6 lg:p-8"
+      style={{ fontFamily: "'Inter', sans-serif" }}
+    >
+      <ErrorDisplay
+        errorMessage={metricsData.errorMessage}
+        onResetNavigation={handleResetNavigation}
+        onClearError={handleClearError}
+      />
 
-            <main className="mt-6">
-                <MetricsGrid
-                    isLoading={metricsData.loadingMetrics}
-                    groupedMetrics={groupedMetrics}
-                    groupOrder={displayedGroupOrder}
-                    skeletonGroupCounts={skeletonGroupCounts}
-                    displayGroupName={displayGroupName}
-                    onMetricAction={getMetricAction}
-                />
+      <main className="mt-6">
+        <MetricsGrid
+          isLoading={metricsData.loadingMetrics}
+          groupedMetrics={groupedMetrics}
+          groupOrder={displayedGroupOrder}
+          skeletonGroupCounts={skeletonGroupCounts}
+          displayGroupName={displayGroupName}
+          onMetricAction={getMetricAction}
+        />
 
-                {isEconomicsView && (
-                    <ProfitCalculator metrics={metricsData.metrics} />
-                )}
+        {isEconomicsView && <ProfitCalculator metrics={metricsData.metrics} />}
 
-                {!isEconomicsView && (
-                    <ChartsGrid
-                        isLoading={metricsData.loadingMetrics}
-                        timeRange={timeRange}
-                        selectedSequencer={selectedSequencer}
-                        chartsData={chartsData}
-                        onOpenTable={onOpenTable}
-                        onOpenSequencerDistributionTable={onOpenSequencerDistributionTable}
-                    />
-                )}
-            </main>
-
-        </div>
-    );
+        {!isEconomicsView && (
+          <ChartsGrid
+            isLoading={metricsData.loadingMetrics}
+            timeRange={timeRange}
+            selectedSequencer={selectedSequencer}
+            chartsData={chartsData}
+            onOpenTable={onOpenTable}
+            onOpenSequencerDistributionTable={onOpenSequencerDistributionTable}
+          />
+        )}
+      </main>
+    </div>
+  );
 };
-


### PR DESCRIPTION
## Summary
- adjust dashboard layout to use dark background in dark mode
- keep ProfitCalculator background consistent in dark mode

## Testing
- `npm run lint:whitespace`
- `npm run check`
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_6841c1b4cd40832893d17e5e84db9e1b