### PR TITLE
Update L2 block times chart

### DIFF
--- a/dashboard/components/BlockTimeDistributionChart.tsx
+++ b/dashboard/components/BlockTimeDistributionChart.tsx
@@ -1,0 +1,98 @@
+import React, { useMemo } from 'react';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import { TimeSeriesData } from '../types';
+import { formatInterval, shouldShowMinutes } from '../utils';
+
+interface BlockTimeDistributionChartProps {
+  data: TimeSeriesData[];
+  barColor: string;
+}
+
+const BlockTimeDistributionChartComponent: React.FC<BlockTimeDistributionChartProps> = ({
+  data,
+  barColor,
+}) => {
+  if (!data || data.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-full text-gray-500">
+        No data available
+      </div>
+    );
+  }
+
+  const showMinutes = shouldShowMinutes(data);
+
+  const distributionData = useMemo(() => {
+    const times = data.map((d) => d.timestamp);
+    const min = Math.min(...times);
+    const max = Math.max(...times);
+    if (min === max) {
+      return [{ interval: min, count: times.length }];
+    }
+    const binCount = 20;
+    const binSize = (max - min) / binCount;
+    const bins = Array.from({ length: binCount }, (_, i) => ({
+      interval: min + (i + 0.5) * binSize,
+      count: 0,
+    }));
+    times.forEach((t) => {
+      const idx = Math.min(Math.floor((t - min) / binSize), binCount - 1);
+      bins[idx].count += 1;
+    });
+    return bins;
+  }, [data]);
+
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <BarChart data={distributionData} margin={{ top: 5, right: 70, left: 80, bottom: 40 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
+        <XAxis
+          dataKey="interval"
+          tickFormatter={(v: number) => formatInterval(v, showMinutes)}
+          stroke="#666666"
+          fontSize={12}
+          label={{
+            value: showMinutes ? 'Minutes' : 'Seconds',
+            position: 'insideBottom',
+            offset: -35,
+            fontSize: 10,
+            fill: '#666666',
+          }}
+        />
+        <YAxis
+          stroke="#666666"
+          fontSize={12}
+          allowDecimals={false}
+          label={{
+            value: 'Blocks',
+            angle: -90,
+            position: 'insideLeft',
+            offset: -16,
+            fontSize: 10,
+            fill: '#666666',
+          }}
+        />
+        <Tooltip
+          labelFormatter={(label: number) => formatInterval(label, showMinutes)}
+          formatter={(value: number) => [value.toLocaleString(), 'blocks']}
+          contentStyle={{
+            backgroundColor: 'rgba(255, 255, 255, 0.8)',
+            borderColor: barColor,
+          }}
+          labelStyle={{ color: '#333' }}
+        />
+        <Bar dataKey="count" fill={barColor} name="Blocks" />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+};
+
+export const BlockTimeDistributionChart = React.memo(BlockTimeDistributionChartComponent);

--- a/dashboard/components/BlockTimeDistributionChart.tsx
+++ b/dashboard/components/BlockTimeDistributionChart.tsx
@@ -62,6 +62,11 @@ const BlockTimeDistributionChartComponent: React.FC<BlockTimeDistributionChartPr
     );
     
     const binSize = (max - min) / binCount;
+    const EPSILON = 1e-10; // Small constant to prevent floating point issues
+    
+    if (binSize < EPSILON) {
+      return [{ interval: (min + max) / 2, count: times.length }];
+    }
     const bins = Array.from({ length: binCount }, (_, i) => ({
       interval: min + (i + 0.5) * binSize,
       count: 0,

--- a/dashboard/components/BlockTimeDistributionChart.tsx
+++ b/dashboard/components/BlockTimeDistributionChart.tsx
@@ -14,7 +14,6 @@ import { formatInterval, shouldShowMinutes } from '../utils';
 // Constants for histogram configuration
 const MIN_BIN_COUNT = 5;
 const MAX_BIN_COUNT = 20;
-const DEFAULT_BIN_COUNT = 20;
 const MIN_REASONABLE_BLOCK_TIME_MS = 0;
 const MAX_REASONABLE_BLOCK_TIME_MS = 24 * 60 * 60 * 1000; // 24 hours in milliseconds
 const CHART_MARGINS = { top: 5, right: 70, left: 80, bottom: 40 };
@@ -94,7 +93,7 @@ const BlockTimeDistributionChartComponent: React.FC<BlockTimeDistributionChartPr
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis
           dataKey="interval"
-          tickFormatter={(v: number) => formatInterval(v, showMinutes)}
+          tickFormatter={(v: number) => formatInterval(v, false, showMinutes)}
           stroke="#666666"
           fontSize={12}
           label={{
@@ -119,7 +118,7 @@ const BlockTimeDistributionChartComponent: React.FC<BlockTimeDistributionChartPr
           }}
         />
         <Tooltip
-          labelFormatter={(label: number) => formatInterval(label, showMinutes)}
+          labelFormatter={(label: number) => formatInterval(label, false, showMinutes)}
           formatter={(value: number) => [value.toLocaleString(), 'blocks']}
           contentStyle={{
             backgroundColor: 'rgba(255, 255, 255, 0.8)',

--- a/dashboard/components/layout/ChartsGrid.tsx
+++ b/dashboard/components/layout/ChartsGrid.tsx
@@ -9,9 +9,9 @@ const SequencerPieChart = lazy(() =>
         default: m.SequencerPieChart,
     })),
 );
-const BlockTimeChart = lazy(() =>
-    import('../BlockTimeChart').then((m) => ({
-        default: m.BlockTimeChart,
+const BlockTimeDistributionChart = lazy(() =>
+    import('../BlockTimeDistributionChart').then((m) => ({
+        default: m.BlockTimeDistributionChart,
     })),
 );
 const BatchProcessChart = lazy(() =>
@@ -89,10 +89,10 @@ export const ChartsGrid: React.FC<ChartsGridProps> = ({
                 onMore={() => onOpenTable('l2-block-times', timeRange)}
                 loading={isLoading}
             >
-                <BlockTimeChart
+                <BlockTimeDistributionChart
                     key={timeRange}
                     data={chartsData.l2BlockTimeData}
-                    lineColor="#FAA43A"
+                    barColor="#FAA43A"
                 />
             </ChartCard>
         </>
@@ -131,6 +131,17 @@ export const ChartsGrid: React.FC<ChartsGridProps> = ({
                     key={timeRange}
                     data={chartsData.batchBlobCounts}
                     barColor="#A0CBE8"
+                />
+            </ChartCard>
+            <ChartCard
+                title="L2 Block Time Distribution"
+                onMore={() => onOpenTable('l2-block-times', timeRange)}
+                loading={isLoading}
+            >
+                <BlockTimeDistributionChart
+                    key={timeRange}
+                    data={chartsData.l2BlockTimeData}
+                    barColor="#FAA43A"
                 />
             </ChartCard>
         </>


### PR DESCRIPTION
## Summary
- add `BlockTimeDistributionChart` to show a histogram of block times
- replace the L2 block times line chart with the distribution chart on the dashboard

## Testing
- `npm run check`
- `npm run lint:whitespace`
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_6841c9d9399483288281a7b5a4372a21