### PR TITLE
Fix time unit display for large intervals

### DIFF
--- a/dashboard/components/BlockTimeChart.tsx
+++ b/dashboard/components/BlockTimeChart.tsx
@@ -11,11 +11,7 @@ import {
   ResponsiveContainer,
 } from 'recharts';
 import { TimeSeriesData } from '../types';
-import {
-  formatDecimal,
-  formatInterval,
-  shouldShowMinutes,
-} from '../utils';
+import { formatDecimal, formatInterval, computeIntervalFlags } from '../utils';
 
 interface BlockTimeChartProps {
   data: TimeSeriesData[];
@@ -35,7 +31,7 @@ const BlockTimeChartComponent: React.FC<BlockTimeChartProps> = ({
       </div>
     );
   }
-  const showMinutes = shouldShowMinutes(data);
+  const { showHours, showMinutes } = computeIntervalFlags(data);
   const ChartComponent = histogram ? BarChart : LineChart;
   return (
     <ResponsiveContainer width="100%" height="100%">
@@ -63,12 +59,14 @@ const BlockTimeChartComponent: React.FC<BlockTimeChartProps> = ({
           fontSize={12}
           domain={['auto', 'auto']}
           tickFormatter={(v) =>
-            showMinutes
-              ? String(Number(formatDecimal(v / 60000)))
-              : String(Number(formatDecimal(v / 1000)))
+            showHours
+              ? String(Number(formatDecimal(v / 3600000)))
+              : showMinutes
+                ? String(Number(formatDecimal(v / 60000)))
+                : String(Number(formatDecimal(v / 1000)))
           }
           label={{
-            value: showMinutes ? 'Minutes' : 'Seconds',
+            value: showHours ? 'Hours' : showMinutes ? 'Minutes' : 'Seconds',
             angle: -90,
             position: 'insideLeft',
             offset: -16,
@@ -78,7 +76,9 @@ const BlockTimeChartComponent: React.FC<BlockTimeChartProps> = ({
         />
         <Tooltip
           labelFormatter={(label: number) => `Block ${label.toLocaleString()}`}
-          formatter={(value: number) => [formatInterval(value, showMinutes)]}
+          formatter={(value: number) => [
+            formatInterval(value, showHours, showMinutes),
+          ]}
           contentStyle={{
             backgroundColor: 'rgba(255, 255, 255, 0.8)',
             borderColor: lineColor,

--- a/dashboard/tests/utils.test.ts
+++ b/dashboard/tests/utils.test.ts
@@ -5,6 +5,7 @@ import {
   formatInterval,
   formatBatchDuration,
   computeBatchDurationFlags,
+  computeIntervalFlags,
   shouldShowMinutes,
   findMetricValue,
   formatSequencerTooltip,
@@ -25,8 +26,9 @@ describe('utils', () => {
     expect(formatSeconds(150)).toBe('2.5m');
     expect(formatSeconds(7200)).toBe('2h');
 
-    expect(formatInterval(30000, false)).toBe('30 seconds');
-    expect(formatInterval(180000, true)).toBe('3.00 minutes');
+    expect(formatInterval(30000, false, false)).toBe('30 seconds');
+    expect(formatInterval(180000, false, true)).toBe('3.00 minutes');
+    expect(formatInterval(7200000, true, false)).toBe('2.00 hours');
 
     expect(formatBatchDuration(45, false, false)).toBe('45 seconds');
     expect(formatBatchDuration(150, false, true)).toBe('2.50 minutes');
@@ -46,6 +48,29 @@ describe('utils', () => {
     expect(flagsMinutes.showMinutes).toBe(true);
 
     const flagsNone = computeBatchDurationFlags([{ value: 60 }, { value: 80 }]);
+    expect(flagsNone.showHours).toBe(false);
+    expect(flagsNone.showMinutes).toBe(false);
+  });
+
+  it('computes interval flags', () => {
+    const flags = computeIntervalFlags([
+      { timestamp: 1000 },
+      { timestamp: 8_000_000 },
+    ]);
+    expect(flags.showHours).toBe(true);
+    expect(flags.showMinutes).toBe(false);
+
+    const flagsMinutes = computeIntervalFlags([
+      { timestamp: 150_000 },
+      { timestamp: 100_000 },
+    ]);
+    expect(flagsMinutes.showHours).toBe(false);
+    expect(flagsMinutes.showMinutes).toBe(true);
+
+    const flagsNone = computeIntervalFlags([
+      { timestamp: 50_000 },
+      { timestamp: 80_000 },
+    ]);
     expect(flagsNone.showHours).toBe(false);
     expect(flagsNone.showMinutes).toBe(false);
   });

--- a/dashboard/utils.ts
+++ b/dashboard/utils.ts
@@ -56,10 +56,16 @@ export const formatTime = (ms: number): string =>
     timeZone: 'UTC',
   });
 
-export const formatInterval = (ms: number, showMinutes: boolean): string => {
-  return showMinutes
-    ? `${formatDecimal(ms / 60000)} minutes`
-    : `${Number(formatDecimal(ms / 1000))} seconds`;
+export const formatInterval = (
+  ms: number,
+  showHours: boolean,
+  showMinutes: boolean,
+): string => {
+  return showHours
+    ? `${formatDecimal(ms / 3600000)} hours`
+    : showMinutes
+      ? `${formatDecimal(ms / 60000)} minutes`
+      : `${Number(formatDecimal(ms / 1000))} seconds`;
 };
 
 export const formatBatchDuration = (
@@ -80,10 +86,14 @@ export const computeBatchDurationFlags = (data: { value: number }[]) => {
   return { showHours, showMinutes };
 };
 
-export const shouldShowMinutes = (data: { timestamp: number }[]) => {
-  const maxTimestamp = Math.max(...data.map((d) => d.timestamp));
-  return maxTimestamp >= 120000;
+export const computeIntervalFlags = (data: { timestamp: number }[]) => {
+  const showHours = data.some((d) => d.timestamp >= 120 * 60 * 1000);
+  const showMinutes = !showHours && data.some((d) => d.timestamp >= 120000);
+  return { showHours, showMinutes };
 };
+
+export const shouldShowMinutes = (data: { timestamp: number }[]) =>
+  computeIntervalFlags(data).showMinutes;
 
 export const findMetricValue = (
   metrics: { title: string | unknown; value: string }[],


### PR DESCRIPTION
## Summary
- support hours on batch cadence charts
- update tooltip and axis logic
- improve interval utilities
- test computeIntervalFlags and time formatting

## Testing
- `just lint`
- `just lint-dashboard`
- `just test`
- `just check-dashboard`
- `just test-dashboard`
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6841eee624688328bc06cb4401ac0ee2