### PR TITLE
Fix Batch Posting cadence interval units

### DIFF
--- a/dashboard/components/BlockTimeChart.tsx
+++ b/dashboard/components/BlockTimeChart.tsx
@@ -17,12 +17,14 @@ interface BlockTimeChartProps {
   data: TimeSeriesData[];
   lineColor: string;
   histogram?: boolean;
+  seconds?: boolean;
 }
 
 const BlockTimeChartComponent: React.FC<BlockTimeChartProps> = ({
   data,
   lineColor,
   histogram = false,
+  seconds = false,
 }) => {
   if (!data || data.length === 0) {
     return (
@@ -31,7 +33,7 @@ const BlockTimeChartComponent: React.FC<BlockTimeChartProps> = ({
       </div>
     );
   }
-  const { showHours, showMinutes } = computeIntervalFlags(data);
+  const { showHours, showMinutes } = computeIntervalFlags(data, seconds);
   const ChartComponent = histogram ? BarChart : LineChart;
   return (
     <ResponsiveContainer width="100%" height="100%">
@@ -60,10 +62,10 @@ const BlockTimeChartComponent: React.FC<BlockTimeChartProps> = ({
           domain={['auto', 'auto']}
           tickFormatter={(v) =>
             showHours
-              ? String(Number(formatDecimal(v / 3600000)))
+              ? String(Number(formatDecimal(v / (seconds ? 3600 : 3600000))))
               : showMinutes
-                ? String(Number(formatDecimal(v / 60000)))
-                : String(Number(formatDecimal(v / 1000)))
+                ? String(Number(formatDecimal(v / (seconds ? 60 : 60000))))
+                : String(Number(formatDecimal(seconds ? v : v / 1000)))
           }
           label={{
             value: showHours ? 'Hours' : showMinutes ? 'Minutes' : 'Seconds',
@@ -77,7 +79,7 @@ const BlockTimeChartComponent: React.FC<BlockTimeChartProps> = ({
         <Tooltip
           labelFormatter={(label: number) => `Block ${label.toLocaleString()}`}
           formatter={(value: number) => [
-            formatInterval(value, showHours, showMinutes),
+            formatInterval(seconds ? value : value / 1000, showHours, showMinutes),
           ]}
           contentStyle={{
             backgroundColor: 'rgba(255, 255, 255, 0.8)',

--- a/dashboard/config/tableConfig.ts
+++ b/dashboard/config/tableConfig.ts
@@ -151,7 +151,7 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
     fetcher: fetchBatchPostingTimes,
     columns: [
       { key: 'value', label: 'Batch' },
-      { key: 'timestamp', label: 'Interval (ms)' },
+      { key: 'timestamp', label: 'Interval (s)' },
     ],
     mapData: (data) =>
       (data as Record<string, any>[]).map((d) => ({
@@ -167,6 +167,7 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
       return React.createElement(BlockTimeChart, {
         data,
         lineColor: '#FF9DA7',
+        seconds: true,
       });
     },
     urlKey: 'batch-posting-cadence',
@@ -245,7 +246,7 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
     fetcher: fetchL2BlockTimes,
     columns: [
       { key: 'value', label: 'L2 Block Number' },
-      { key: 'timestamp', label: 'Interval (ms)' },
+      { key: 'timestamp', label: 'Interval (s)' },
     ],
     mapData: (data) => data as Record<string, string | number>[],
     chart: (data) => {
@@ -258,6 +259,7 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
         data,
         lineColor: '#FAA43A',
         histogram: true,
+        seconds: true,
       });
     },
     urlKey: 'l2-block-times',

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -359,7 +359,7 @@ export const fetchL2BlockTimes = async (
   const data = res.data.blocks.slice(1).map(
     (b): TimeSeriesData => ({
       value: b.l2_block_number,
-      timestamp: b.ms_since_prev_block,
+      timestamp: b.ms_since_prev_block / 1000,
     }),
   );
 
@@ -379,7 +379,7 @@ export const fetchBatchPostingTimes = async (
   const data = res.data.batches.map(
     (b): TimeSeriesData => ({
       value: b.batch_id,
-      timestamp: b.ms_since_prev_batch,
+      timestamp: b.ms_since_prev_batch / 1000,
     }),
   );
   return { data, badRequest: res.badRequest, error: res.error };

--- a/dashboard/tests/apiService.test.ts
+++ b/dashboard/tests/apiService.test.ts
@@ -63,7 +63,7 @@ describe('apiService', () => {
     });
     const blockTimes = await fetchL2BlockTimes('1h');
     expect(blockTimes.error).toBeNull();
-    expect(blockTimes.data).toStrictEqual([{ value: 2, timestamp: 20 }]);
+    expect(blockTimes.data).toStrictEqual([{ value: 2, timestamp: 0.02 }]);
   });
 
   it('transforms block transactions', async () => {

--- a/dashboard/tests/utils.test.ts
+++ b/dashboard/tests/utils.test.ts
@@ -26,9 +26,9 @@ describe('utils', () => {
     expect(formatSeconds(150)).toBe('2.5m');
     expect(formatSeconds(7200)).toBe('2h');
 
-    expect(formatInterval(30000, false, false)).toBe('30 seconds');
-    expect(formatInterval(180000, false, true)).toBe('3.00 minutes');
-    expect(formatInterval(7200000, true, false)).toBe('2.00 hours');
+    expect(formatInterval(30, false, false)).toBe('30 seconds');
+    expect(formatInterval(180, false, true)).toBe('3.00 minutes');
+    expect(formatInterval(7200, true, false)).toBe('2.00 hours');
 
     expect(formatBatchDuration(45, false, false)).toBe('45 seconds');
     expect(formatBatchDuration(150, false, true)).toBe('2.50 minutes');
@@ -53,35 +53,56 @@ describe('utils', () => {
   });
 
   it('computes interval flags', () => {
-    const flags = computeIntervalFlags([
-      { timestamp: 1000 },
-      { timestamp: 8_000_000 },
-    ]);
+    const flags = computeIntervalFlags(
+      [
+        { timestamp: 1 },
+        { timestamp: 8_000 },
+      ],
+      true,
+    );
     expect(flags.showHours).toBe(true);
     expect(flags.showMinutes).toBe(false);
 
-    const flagsMinutes = computeIntervalFlags([
-      { timestamp: 150_000 },
-      { timestamp: 100_000 },
-    ]);
+    const flagsMinutes = computeIntervalFlags(
+      [
+        { timestamp: 150 },
+        { timestamp: 100 },
+      ],
+      true,
+    );
     expect(flagsMinutes.showHours).toBe(false);
     expect(flagsMinutes.showMinutes).toBe(true);
 
-    const flagsNone = computeIntervalFlags([
-      { timestamp: 50_000 },
-      { timestamp: 80_000 },
-    ]);
+    const flagsNone = computeIntervalFlags(
+      [
+        { timestamp: 50 },
+        { timestamp: 80 },
+      ],
+      true,
+    );
     expect(flagsNone.showHours).toBe(false);
     expect(flagsNone.showMinutes).toBe(false);
   });
 
   it('determines minute display correctly', () => {
     expect(
-      shouldShowMinutes([{ timestamp: 1000 }, { timestamp: 200000 }]),
+      shouldShowMinutes(
+        [
+          { timestamp: 1 },
+          { timestamp: 200 },
+        ],
+        true,
+      ),
     ).toBe(true);
 
     expect(
-      shouldShowMinutes([{ timestamp: 1000 }, { timestamp: 110000 }]),
+      shouldShowMinutes(
+        [
+          { timestamp: 1 },
+          { timestamp: 110 },
+        ],
+        true,
+      ),
     ).toBe(false);
   });
 

--- a/dashboard/utils.ts
+++ b/dashboard/utils.ts
@@ -57,15 +57,15 @@ export const formatTime = (ms: number): string =>
   });
 
 export const formatInterval = (
-  ms: number,
+  seconds: number,
   showHours: boolean,
   showMinutes: boolean,
 ): string => {
   return showHours
-    ? `${formatDecimal(ms / 3600000)} hours`
+    ? `${formatDecimal(seconds / 3600)} hours`
     : showMinutes
-      ? `${formatDecimal(ms / 60000)} minutes`
-      : `${Number(formatDecimal(ms / 1000))} seconds`;
+      ? `${formatDecimal(seconds / 60)} minutes`
+      : `${Number(formatDecimal(seconds))} seconds`;
 };
 
 export const formatBatchDuration = (
@@ -86,14 +86,21 @@ export const computeBatchDurationFlags = (data: { value: number }[]) => {
   return { showHours, showMinutes };
 };
 
-export const computeIntervalFlags = (data: { timestamp: number }[]) => {
-  const showHours = data.some((d) => d.timestamp >= 120 * 60 * 1000);
-  const showMinutes = !showHours && data.some((d) => d.timestamp >= 120000);
+export const computeIntervalFlags = (
+  data: { timestamp: number }[],
+  seconds = false,
+) => {
+  const toSeconds = (v: number) => (seconds ? v : v / 1000);
+  const showHours = data.some((d) => toSeconds(d.timestamp) >= 120 * 60);
+  const showMinutes =
+    !showHours && data.some((d) => toSeconds(d.timestamp) >= 120);
   return { showHours, showMinutes };
 };
 
-export const shouldShowMinutes = (data: { timestamp: number }[]) =>
-  computeIntervalFlags(data).showMinutes;
+export const shouldShowMinutes = (
+  data: { timestamp: number }[],
+  seconds = false,
+) => computeIntervalFlags(data, seconds).showMinutes;
 
 export const findMetricValue = (
   metrics: { title: string | unknown; value: string }[],


### PR DESCRIPTION
## Summary
- update BlockTimeChart to support seconds
- add seconds option to interval helpers
- convert block times and posting times to seconds
- label interval columns with seconds
- adjust dashboard tests for new units

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6841f3e67714832895cca0af0df6de14