### PR TITLE
Remove duplicate L2 Block Times chart

### DIFF
--- a/dashboard/components/layout/ChartsGrid.tsx
+++ b/dashboard/components/layout/ChartsGrid.tsx
@@ -84,17 +84,6 @@ export const ChartsGrid: React.FC<ChartsGridProps> = ({
                     lineColor="#5DA5DA"
                 />
             </ChartCard>
-            <ChartCard
-                title="L2 Block Times"
-                onMore={() => onOpenTable('l2-block-times', timeRange)}
-                loading={isLoading}
-            >
-                <BlockTimeDistributionChart
-                    key={timeRange}
-                    data={chartsData.l2BlockTimeData}
-                    barColor="#FAA43A"
-                />
-            </ChartCard>
         </>
     );
 


### PR DESCRIPTION
## Summary
- remove redundant L2 Block Times chart from dashboard grid

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6842813085308328bc89e43d024e2b20