### PR TITLE
Remove duplicate L2 Block Times chart

### DIFF
--- a/dashboard/components/layout/ChartsGrid.tsx
+++ b/dashboard/components/layout/ChartsGrid.tsx
@@ -92,17 +92,6 @@ export const ChartsGrid: React.FC<ChartsGridProps> = ({
                     lineColor="#5DA5DA"
                 />
             </ChartCard>
-            <ChartCard
-                title="L2 Block Times"
-                onMore={() => onOpenTable('l2-block-times', timeRange)}
-                loading={isLoading}
-            >
-                <BlockTimeDistributionChart
-                    key={timeRange}
-                    data={chartsData.l2BlockTimeData}
-                    barColor="#FAA43A"
-                />
-            </ChartCard>
         </>
     );
 


### PR DESCRIPTION
## Summary
- remove `L2 Block Times` chart from the dashboard grid to avoid duplication with `L2 Block Time Distribution`

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68428cba29ec832896bcca5604518cb4