### PR TITLE
Fix L2 reorg refresh on tab switch

### DIFF
--- a/dashboard/hooks/useDataFetcher.ts
+++ b/dashboard/hooks/useDataFetcher.ts
@@ -46,7 +46,7 @@ export const useDataFetcher = ({
     () => fetchMetricsData(timeRange, selectedSequencer),
     {
       refreshInterval: Math.max(refreshRate, 60000),
-      revalidateOnFocus: true,
+      revalidateOnFocus: false,
       refreshWhenHidden: false,
       onSuccess: () => {
         setIsTimeRangeChanging(false);


### PR DESCRIPTION
## Summary
- prevent re-fetching on focus by disabling `revalidateOnFocus`

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6842a391184883289b7d4c68657b023e