### PR TITLE
Remove L2 reorg chart

### DIFF
--- a/dashboard/config/tableConfig.ts
+++ b/dashboard/config/tableConfig.ts
@@ -70,16 +70,6 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
         l2_block_number: blockLink(e.l2_block_number),
         depth: e.depth,
       })),
-    chart: (data) => {
-      const ReorgDepthChart = React.lazy(() =>
-        import('../components/ReorgDepthChart').then((m) => ({
-          default: m.ReorgDepthChart,
-        })),
-      );
-      return React.createElement(ReorgDepthChart, {
-        data: data as L2ReorgEvent[],
-      });
-    },
     urlKey: 'reorgs',
   },
 


### PR DESCRIPTION
## Summary
- remove L2 reorg chart from table view

## Testing
- `npm run check`
- `npm run lint:whitespace`
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_6842a688b8e88328bb8d7d9b8d4d09ca