### PR TITLE
Add 15m range option

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -2609,6 +2609,12 @@ mod tests {
         assert_eq!(d.num_hours(), 72);
     }
 
+    #[test]
+    fn range_duration_parses_minutes() {
+        let d = range_duration(&Some("15m".to_owned()));
+        assert_eq!(d.num_minutes(), 15);
+    }
+
     #[tokio::test]
     async fn sequencer_blocks_invalid_address() {
         let mock = Mock::new();

--- a/crates/clickhouse/src/reader.rs
+++ b/crates/clickhouse/src/reader.rs
@@ -29,6 +29,8 @@ struct MaxTs {
 /// Supported time ranges for analytics queries
 #[derive(Copy, Clone, Debug)]
 pub enum TimeRange {
+    /// Data from the last 15 minutes
+    Last15Min,
     /// Data from the last hour
     LastHour,
     /// Data from the last 24 hours
@@ -48,6 +50,7 @@ impl TimeRange {
     pub fn from_duration(duration: chrono::Duration) -> Self {
         let secs = duration.num_seconds().clamp(0, Self::MAX_SECONDS as i64) as u64;
         match secs {
+            900 => Self::Last15Min,
             3600 => Self::LastHour,
             86400 => Self::Last24Hours,
             604800 => Self::Last7Days,
@@ -58,6 +61,7 @@ impl TimeRange {
     /// Return the `ClickHouse` interval string for this range.
     pub fn interval(&self) -> String {
         match self {
+            Self::Last15Min => "15 MINUTE".to_owned(),
             Self::LastHour => "1 HOUR".to_owned(),
             Self::Last24Hours => "24 HOUR".to_owned(),
             Self::Last7Days => "7 DAY".to_owned(),
@@ -68,6 +72,7 @@ impl TimeRange {
     /// Return the duration in seconds for this range.
     pub const fn seconds(&self) -> u64 {
         match self {
+            Self::Last15Min => 900,
             Self::LastHour => 3600,
             Self::Last24Hours => 86400,
             Self::Last7Days => 604800,

--- a/dashboard/components/DashboardHeader.tsx
+++ b/dashboard/components/DashboardHeader.tsx
@@ -98,7 +98,7 @@ export const TimeRangeSelector: React.FC<TimeRangeSelectorProps> = ({
   onTimeRangeChange,
   isChanging,
 }) => {
-  const ranges: TimeRange[] = ['1h', '24h', '7d'];
+  const ranges: TimeRange[] = ['15m', '1h', '24h', '7d'];
 
   return (
     <div className="flex space-x-1 bg-gray-200 dark:bg-gray-700 p-0.5 rounded-md">

--- a/dashboard/hooks/useTimeRangeSync.ts
+++ b/dashboard/hooks/useTimeRangeSync.ts
@@ -3,7 +3,7 @@ import { useSearchParams, useNavigate } from 'react-router-dom';
 import { TimeRange } from '../types';
 
 const DEFAULT_TIME_RANGE: TimeRange = '1h';
-const VALID_TIME_RANGES: TimeRange[] = ['1h', '24h', '7d'];
+const VALID_TIME_RANGES: TimeRange[] = ['15m', '1h', '24h', '7d'];
 
 /**
  * Hook that synchronizes time range state with URL parameters to prevent navigation loops

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -12,6 +12,7 @@ import type {
   SlashingEvent,
   ForcedInclusionEvent,
   ErrorResponse,
+  TimeRange,
 } from '../types';
 
 export interface RequestResult<T> {
@@ -74,7 +75,7 @@ export interface AvgTimeResponse {
 }
 
 export const fetchAvgProveTime = async (
-  range: '1h' | '24h' | '7d',
+  range: TimeRange,
 ): Promise<RequestResult<number>> => {
   const url = `${API_BASE}/avg-prove-time?range=${range}`;
   const res = await fetchJson<{ avg_prove_time_ms?: number }>(url);
@@ -86,7 +87,7 @@ export const fetchAvgProveTime = async (
 };
 
 export const fetchAvgVerifyTime = async (
-  range: '1h' | '24h' | '7d',
+  range: TimeRange,
 ): Promise<RequestResult<number>> => {
   const url = `${API_BASE}/avg-verify-time?range=${range}`;
   const res = await fetchJson<{ avg_verify_time_ms?: number }>(url);
@@ -98,7 +99,7 @@ export const fetchAvgVerifyTime = async (
 };
 
 export const fetchL2BlockCadence = async (
-  range: '1h' | '24h' | '7d',
+  range: TimeRange,
   address?: string,
 ): Promise<RequestResult<number>> => {
   const url = `${API_BASE}/l2-block-cadence?range=${range}${address ? `&address=${address}` : ''}`;
@@ -111,7 +112,7 @@ export const fetchL2BlockCadence = async (
 };
 
 export const fetchBatchPostingCadence = async (
-  range: '1h' | '24h' | '7d',
+  range: TimeRange,
 ): Promise<RequestResult<number>> => {
   const url = `${API_BASE}/batch-posting-cadence?range=${range}`;
   const res = await fetchJson<{ batch_posting_cadence_ms?: number }>(url);
@@ -134,7 +135,7 @@ export const fetchActiveSequencerAddresses = async (): Promise<
 };
 
 export const fetchL2Reorgs = async (
-  range: '1h' | '24h' | '7d',
+  range: TimeRange,
 ): Promise<RequestResult<number>> => {
   const url = `${API_BASE}/reorgs?range=${range}`;
   const res = await fetchJson<{ events: unknown[] }>(url);
@@ -146,7 +147,7 @@ export const fetchL2Reorgs = async (
 };
 
 export const fetchL2ReorgEvents = async (
-  range: '1h' | '24h' | '7d',
+  range: TimeRange,
 ): Promise<RequestResult<L2ReorgEvent[]>> => {
   const url = `${API_BASE}/reorgs?range=${range}`;
   const res = await fetchJson<{
@@ -166,7 +167,7 @@ export const fetchL2ReorgEvents = async (
 };
 
 export const fetchSlashingEventCount = async (
-  range: '1h' | '24h' | '7d',
+  range: TimeRange,
 ): Promise<RequestResult<number>> => {
   const url = `${API_BASE}/slashings?range=${range}`;
   const res = await fetchJson<{ events: unknown[] }>(url);
@@ -178,7 +179,7 @@ export const fetchSlashingEventCount = async (
 };
 
 export const fetchForcedInclusionCount = async (
-  range: '1h' | '24h' | '7d',
+  range: TimeRange,
 ): Promise<RequestResult<number>> => {
   const url = `${API_BASE}/forced-inclusions?range=${range}`;
   const res = await fetchJson<{ events: unknown[] }>(url);
@@ -190,7 +191,7 @@ export const fetchForcedInclusionCount = async (
 };
 
 export const fetchSlashingEvents = async (
-  range: '1h' | '24h' | '7d',
+  range: TimeRange,
 ): Promise<RequestResult<SlashingEvent[]>> => {
   const url = `${API_BASE}/slashings?range=${range}`;
   const res = await fetchJson<{ events: SlashingEvent[] }>(url);
@@ -202,7 +203,7 @@ export const fetchSlashingEvents = async (
 };
 
 export const fetchForcedInclusionEvents = async (
-  range: '1h' | '24h' | '7d',
+  range: TimeRange,
 ): Promise<RequestResult<ForcedInclusionEvent[]>> => {
   const url = `${API_BASE}/forced-inclusions?range=${range}`;
   const res = await fetchJson<{ events: ForcedInclusionEvent[] }>(url);
@@ -214,7 +215,7 @@ export const fetchForcedInclusionEvents = async (
 };
 
 export const fetchL2HeadBlock = async (
-  range: '1h' | '24h' | '7d',
+  range: TimeRange,
 ): Promise<RequestResult<number>> => {
   const url = `${API_BASE}/l2-block-times?range=${range}`;
   const res = await fetchJson<{ blocks: { l2_block_number: number }[] }>(url);
@@ -226,7 +227,7 @@ export const fetchL2HeadBlock = async (
 };
 
 export const fetchL1HeadBlock = async (
-  range: '1h' | '24h' | '7d',
+  range: TimeRange,
 ): Promise<RequestResult<number>> => {
   const url = `${API_BASE}/l1-block-times?range=${range}`;
   const res = await fetchJson<{ blocks: { block_number: number }[] }>(url);
@@ -271,7 +272,7 @@ export const fetchL1HeadNumber = async (): Promise<RequestResult<number>> => {
 };
 
 export const fetchProveTimes = async (
-  range: '1h' | '24h' | '7d',
+  range: TimeRange,
 ): Promise<RequestResult<TimeSeriesData[]>> => {
   const url = `${API_BASE}/prove-times?range=${range}`;
   const res = await fetchJson<{
@@ -291,7 +292,7 @@ export const fetchProveTimes = async (
 };
 
 export const fetchVerifyTimes = async (
-  range: '1h' | '24h' | '7d',
+  range: TimeRange,
 ): Promise<RequestResult<TimeSeriesData[]>> => {
   const url = `${API_BASE}/verify-times?range=${range}`;
   const res = await fetchJson<{
@@ -311,7 +312,7 @@ export const fetchVerifyTimes = async (
 };
 
 export const fetchL1BlockTimes = async (
-  range: '1h' | '24h' | '7d',
+  range: TimeRange,
 ): Promise<RequestResult<TimeSeriesData[]>> => {
   const url = `${API_BASE}/l1-block-times?range=${range}`;
   const res = await fetchJson<{
@@ -344,7 +345,7 @@ export const fetchL1BlockTimes = async (
 };
 
 export const fetchL2BlockTimes = async (
-  range: '1h' | '24h' | '7d',
+  range: TimeRange,
   address?: string,
 ): Promise<RequestResult<TimeSeriesData[]>> => {
   const url = `${API_BASE}/l2-block-times?range=${range}${address ? `&address=${address}` : ''}`;
@@ -366,7 +367,7 @@ export const fetchL2BlockTimes = async (
 };
 
 export const fetchBatchPostingTimes = async (
-  range: '1h' | '24h' | '7d',
+  range: TimeRange,
 ): Promise<RequestResult<TimeSeriesData[]>> => {
   const url = `${API_BASE}/batch-posting-times?range=${range}`;
   const res = await fetchJson<{
@@ -385,7 +386,7 @@ export const fetchBatchPostingTimes = async (
 };
 
 export const fetchL2GasUsed = async (
-  range: '1h' | '24h' | '7d',
+  range: TimeRange,
   address?: string,
 ): Promise<RequestResult<TimeSeriesData[]>> => {
   const url = `${API_BASE}/l2-gas-used?range=${range}${address ? `&address=${address}` : ''}`;
@@ -407,7 +408,7 @@ export const fetchL2GasUsed = async (
 };
 
 export const fetchSequencerDistribution = async (
-  range: '1h' | '24h' | '7d',
+  range: TimeRange,
 ): Promise<RequestResult<PieChartDataItem[]>> => {
   const url = `${API_BASE}/sequencer-distribution?range=${range}`;
   const res = await fetchJson<{
@@ -426,7 +427,7 @@ export const fetchSequencerDistribution = async (
 };
 
 export const fetchSequencerBlocks = async (
-  range: '1h' | '24h' | '7d',
+  range: TimeRange,
   address: string,
 ): Promise<RequestResult<number[]>> => {
   const url = `${API_BASE}/sequencer-blocks?range=${range}&address=${address}`;
@@ -446,7 +447,7 @@ export interface BlockTransaction {
 }
 
 export const fetchBlockTransactions = async (
-  range: '1h' | '24h' | '7d',
+  range: TimeRange,
   limit = 50,
   startingAfter?: number,
   endingBefore?: number,
@@ -488,7 +489,7 @@ export const fetchBlockTransactions = async (
 // New function specifically for fetching all block transactions in a time range
 // This will be used by both charts and tables to ensure data consistency
 export const fetchAllBlockTransactions = async (
-  range: '1h' | '24h' | '7d',
+  range: TimeRange,
   address?: string,
 ): Promise<RequestResult<BlockTransaction[]>> => {
   return fetchBlockTransactions(
@@ -508,7 +509,7 @@ export interface BatchBlobCount {
 }
 
 export const fetchBatchBlobCounts = async (
-  range: '1h' | '24h' | '7d',
+  range: TimeRange,
 ): Promise<RequestResult<BatchBlobCount[]>> => {
   const url = `${API_BASE}/blobs-per-batch?range=${range}`;
   const res = await fetchJson<{
@@ -532,7 +533,7 @@ export const fetchBatchBlobCounts = async (
 };
 
 export const fetchAvgBlobsPerBatch = async (
-  range: '1h' | '24h' | '7d',
+  range: TimeRange,
 ): Promise<RequestResult<number>> => {
   const url = `${API_BASE}/avg-blobs-per-batch?range=${range}`;
   const res = await fetchJson<{ avg_blobs?: number }>(url);
@@ -544,7 +545,7 @@ export const fetchAvgBlobsPerBatch = async (
 };
 
 export const fetchAvgL2Tps = async (
-  range: '1h' | '24h' | '7d',
+  range: TimeRange,
   address?: string,
 ): Promise<RequestResult<number>> => {
   const url =
@@ -559,7 +560,7 @@ export const fetchAvgL2Tps = async (
 };
 
 export const fetchL2TxFee = async (
-  range: '1h' | '24h' | '7d',
+  range: TimeRange,
   address?: string,
 ): Promise<RequestResult<number>> => {
   const url =
@@ -574,7 +575,7 @@ export const fetchL2TxFee = async (
 };
 
 export const fetchL2Tps = async (
-  range: '1h' | '24h' | '7d',
+  range: TimeRange,
   address?: string,
 ): Promise<RequestResult<{ block: number; tps: number }[]>> => {
   const url =
@@ -597,7 +598,7 @@ export const fetchL2Tps = async (
 };
 
 export const fetchCloudCost = async (
-  range: '1h' | '24h' | '7d',
+  range: TimeRange,
 ): Promise<RequestResult<number>> => {
   const url = `${API_BASE}/cloud-cost?range=${range}`;
   const res = await fetchJson<{ cost_usd: number }>(url);

--- a/dashboard/tests/app.integration.test.ts
+++ b/dashboard/tests/app.integration.test.ts
@@ -26,7 +26,7 @@ import {
 import { createMetrics, hasBadRequest } from '../helpers';
 import type { MetricData } from '../types';
 
-type TimeRange = '1h' | '24h' | '7d';
+type TimeRange = '15m' | '1h' | '24h' | '7d';
 
 type State = {
   metrics: MetricData[];

--- a/dashboard/types.ts
+++ b/dashboard/types.ts
@@ -1,4 +1,4 @@
-export type TimeRange = '1h' | '24h' | '7d';
+export type TimeRange = '15m' | '1h' | '24h' | '7d';
 
 export interface TimeSeriesData {
   timestamp: number; // Unix timestamp (ms)

--- a/dashboard/utils/navigationUtils.ts
+++ b/dashboard/utils/navigationUtils.ts
@@ -94,7 +94,7 @@ export const validateSearchParams = (params: URLSearchParams): boolean => {
     }
 
     const range = params.get('range');
-    if (range && !['1h', '24h', '7d'].includes(range)) {
+    if (range && !['15m', '1h', '24h', '7d'].includes(range)) {
       console.warn('Invalid range parameter:', range);
       return false;
     }
@@ -132,7 +132,7 @@ export const cleanSearchParams = (params: URLSearchParams): URLSearchParams => {
       page: (v) => /^\d+$/.test(v),
       start: (v) => /^\d+$/.test(v),
       end: (v) => /^\d+$/.test(v),
-      range: (v) => ['1h', '24h', '7d'].includes(v),
+      range: (v) => ['15m', '1h', '24h', '7d'].includes(v),
       sequencer: (v) => /^[0-9a-zA-Z]+$/.test(v),
       address: (v) => /^[0-9a-zA-Z]+$/.test(v),
       table: (v) => /^[a-zA-Z0-9_-]+$/.test(v),


### PR DESCRIPTION
## Summary
- support a 15 minute range in API and UI
- parse minutes in range parser
- expose new TimeRange variant and update dashboard
- update dashboard validation and tests

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6842ad111b088328abfa44374c722475