### PR TITLE
Fix x-axis values in block tx chart

### DIFF
--- a/dashboard/components/BlockTxChart.tsx
+++ b/dashboard/components/BlockTxChart.tsx
@@ -39,6 +39,8 @@ const BlockTxChartComponent: React.FC<BlockTxChartProps> = ({
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis
           dataKey="block"
+          type="number"
+          domain={['dataMin', 'dataMax']}
           tickFormatter={(v: number) => v.toLocaleString()}
           stroke="#666666"
           fontSize={12}


### PR DESCRIPTION
## Summary
- ensure XAxis uses numerical scale for Tx Count Per L2 Block chart

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6842b1a4a9fc832883a1fb9d46304776