### PR TITLE
Fix time range reset on dashboard header

### DIFF
--- a/dashboard/components/DashboardHeader.tsx
+++ b/dashboard/components/DashboardHeader.tsx
@@ -45,7 +45,7 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({
           className="text-3xl font-bold cursor-pointer hover:underline"
           style={{ color: TAIKO_PINK }}
           onClick={() => {
-            navigateToDashboard();
+            navigateToDashboard(true);
           }}
         >
           {' '}


### PR DESCRIPTION
## Summary
- keep the current time range when navigating back to the main dashboard via the header

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6842b33ebc648328ad84cbdd071365bb