### PR TITLE
Fix TPS back navigation time range reset

### DIFF
--- a/dashboard/components/routes/TableRoute.tsx
+++ b/dashboard/components/routes/TableRoute.tsx
@@ -140,7 +140,7 @@ export const TableRoute: React.FC = () => {
   ]);
 
   const handleBack = () => {
-    navigateToDashboard();
+    navigateToDashboard(true);
   };
 
   if (!tableView && !tableLoading) {


### PR DESCRIPTION
## Summary
- preserve query parameters when returning to the main dashboard

## Testing
- `npm run lint:whitespace`
- `npm run check`
- `just ci` *(fails: build aborted due to environment constraints)*

------
https://chatgpt.com/codex/tasks/task_b_6842b6538db083289b8632c3bbebb7df