### PR TITLE
Remove chart from block tx table

### DIFF
--- a/dashboard/config/tableConfig.ts
+++ b/dashboard/config/tableConfig.ts
@@ -220,14 +220,6 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
       { key: 'sequencer', label: 'Sequencer' },
     ],
     mapData: (data) => data as Record<string, string | number>[],
-    chart: (data) => {
-      const BlockTxChart = React.lazy(() =>
-        import('../components/BlockTxChart').then((m) => ({
-          default: m.BlockTxChart,
-        })),
-      );
-      return React.createElement(BlockTxChart, { data, barColor: '#4E79A7' });
-    },
     useUnlimitedData: true,
     urlKey: 'block-tx',
   },


### PR DESCRIPTION
## Summary
- remove chart component from Tx Count Per L2 Block table configuration

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6842b697e2a08328b61fd55856390fac