### PR TITLE
Remove 7d range from dashboard

### DIFF
--- a/dashboard/components/DashboardHeader.tsx
+++ b/dashboard/components/DashboardHeader.tsx
@@ -98,7 +98,7 @@ export const TimeRangeSelector: React.FC<TimeRangeSelectorProps> = ({
   onTimeRangeChange,
   isChanging,
 }) => {
-  const ranges: TimeRange[] = ['15m', '1h', '24h', '7d'];
+  const ranges: TimeRange[] = ['15m', '1h', '24h'];
 
   return (
     <div className="flex space-x-1 bg-gray-200 dark:bg-gray-700 p-0.5 rounded-md">

--- a/dashboard/hooks/useTimeRangeSync.ts
+++ b/dashboard/hooks/useTimeRangeSync.ts
@@ -3,7 +3,7 @@ import { useSearchParams, useNavigate } from 'react-router-dom';
 import { TimeRange } from '../types';
 
 const DEFAULT_TIME_RANGE: TimeRange = '1h';
-const VALID_TIME_RANGES: TimeRange[] = ['15m', '1h', '24h', '7d'];
+const VALID_TIME_RANGES: TimeRange[] = ['15m', '1h', '24h'];
 
 /**
  * Hook that synchronizes time range state with URL parameters to prevent navigation loops

--- a/dashboard/tests/app.integration.test.ts
+++ b/dashboard/tests/app.integration.test.ts
@@ -26,7 +26,7 @@ import {
 import { createMetrics, hasBadRequest } from '../helpers';
 import type { MetricData } from '../types';
 
-type TimeRange = '15m' | '1h' | '24h' | '7d';
+type TimeRange = '15m' | '1h' | '24h';
 
 type State = {
   metrics: MetricData[];
@@ -141,9 +141,7 @@ const responses: Record<string, Record<string, unknown>> = {
   '/v1/l2-head-block': { l2_head_block: 123 },
   '/v1/l1-head-block': { l1_head_block: 456 },
   '/v1/l2-tx-fee?range=24h': { tx_fee: 2000 },
-  '/v1/l2-tx-fee?range=7d': { tx_fee: 3000 },
   '/v1/cloud-cost?range=24h': { cost_usd: 72 },
-  '/v1/cloud-cost?range=7d': { cost_usd: 504 },
 };
 
 (

--- a/dashboard/tests/dashboardHeader.test.ts
+++ b/dashboard/tests/dashboardHeader.test.ts
@@ -29,7 +29,6 @@ describe('DashboardHeader', () => {
     expect(html.includes('15M')).toBe(true);
     expect(html.includes('1H')).toBe(true);
     expect(html.includes('24H')).toBe(true);
-    expect(html.includes('7D')).toBe(true);
     expect(html.includes('Refresh')).toBe(true);
     expect(html.includes('Status')).toBe(true);
     expect(html.includes('Economics')).toBe(false);

--- a/dashboard/types.ts
+++ b/dashboard/types.ts
@@ -1,4 +1,4 @@
-export type TimeRange = '15m' | '1h' | '24h' | '7d';
+export type TimeRange = '15m' | '1h' | '24h';
 
 export interface TimeSeriesData {
   timestamp: number; // Unix timestamp (ms)

--- a/dashboard/utils/navigationUtils.ts
+++ b/dashboard/utils/navigationUtils.ts
@@ -94,7 +94,7 @@ export const validateSearchParams = (params: URLSearchParams): boolean => {
     }
 
     const range = params.get('range');
-    if (range && !['15m', '1h', '24h', '7d'].includes(range)) {
+    if (range && !['15m', '1h', '24h'].includes(range)) {
       console.warn('Invalid range parameter:', range);
       return false;
     }
@@ -132,7 +132,7 @@ export const cleanSearchParams = (params: URLSearchParams): URLSearchParams => {
       page: (v) => /^\d+$/.test(v),
       start: (v) => /^\d+$/.test(v),
       end: (v) => /^\d+$/.test(v),
-      range: (v) => ['15m', '1h', '24h', '7d'].includes(v),
+      range: (v) => ['15m', '1h', '24h'].includes(v),
       sequencer: (v) => /^[0-9a-zA-Z]+$/.test(v),
       address: (v) => /^[0-9a-zA-Z]+$/.test(v),
       table: (v) => /^[a-zA-Z0-9_-]+$/.test(v),


### PR DESCRIPTION
## Summary
- remove 7-day time range option from dashboard types
- update header and time range sync hook
- clean navigation utils and tests

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6842c1d82b3c8328a38a24f2f12a1c57