### PR TITLE
Fix L2 reorg insert

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1331,6 +1331,7 @@ checksum = "9a9a81a1dffadd762ee662635ce409232258ce9beebd7cc0fa227df0b5e7efc0"
 dependencies = [
  "bstr",
  "bytes",
+ "chrono",
  "cityhash-rs",
  "clickhouse-derive",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ async-stream = "0.3"
 axum = { version = "0.7.9", features = ["json"] }
 chrono = { version = "0.4.41", features = ["serde"] }
 clap = { version = "4.5.39", features = ["derive", "env"] }
-clickhouse = { version = "0.13.3", features = ["native-tls", "test-util"] }
+clickhouse = { version = "0.13.3", features = ["native-tls", "test-util", "chrono"] }
 derive_more = { version = "1.0.0", features = ["debug", "deref"] }
 dotenvy = "0.15.7"
 eyre = "0.6.12"

--- a/crates/clickhouse/src/models.rs
+++ b/crates/clickhouse/src/models.rs
@@ -95,6 +95,7 @@ pub struct L2ReorgRow {
     /// Depth
     pub depth: u16,
     /// Time the reorg was recorded
+    #[serde(with = "clickhouse::serde::chrono::datetime64::millis")]
     pub inserted_at: DateTime<Utc>,
 }
 


### PR DESCRIPTION
## Summary
- encode L2 reorg `inserted_at` field as DateTime64
- enable `chrono` feature for clickhouse crate

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6842c1aeacf48328a5118713c0890865