### PR TITLE
Lazy mount charts only when visible

### DIFF
--- a/dashboard/components/ChartCard.tsx
+++ b/dashboard/components/ChartCard.tsx
@@ -1,4 +1,5 @@
 import React, { Suspense } from 'react';
+import { LazyMount } from './LazyMount';
 
 type ChartCardProps = React.PropsWithChildren<{
   title: string;
@@ -29,15 +30,17 @@ export const ChartCard: React.FC<ChartCardProps> = ({
         )}
       </div>
       <div className="h-64 md:h-80 w-full relative">
-        <Suspense
-          fallback={
-            <div className="flex items-center justify-center h-full text-gray-500 dark:text-gray-400">
-              Loading...
-            </div>
-          }
-        >
-          {children}
-        </Suspense>
+        <LazyMount>
+          <Suspense
+            fallback={
+              <div className="flex items-center justify-center h-full text-gray-500 dark:text-gray-400">
+                Loading...
+              </div>
+            }
+          >
+            {children}
+          </Suspense>
+        </LazyMount>
         {loading && (
           <div className="absolute inset-0 flex items-center justify-center bg-white/60 dark:bg-gray-800/60">
             <span className="text-gray-500 dark:text-gray-400">Loading...</span>

--- a/dashboard/components/LazyMount.tsx
+++ b/dashboard/components/LazyMount.tsx
@@ -1,0 +1,45 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+interface LazyMountProps {
+  children: React.ReactNode;
+}
+
+/**
+ * Mounts children only after the component scrolls into view
+ * using an IntersectionObserver.
+ */
+export const LazyMount: React.FC<LazyMountProps> = ({ children }) => {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [isVisible, setIsVisible] = useState(
+    () => typeof window === 'undefined',
+  );
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element || typeof window === 'undefined') {
+      setIsVisible(true);
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) {
+          setIsVisible(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin: '200px' },
+    );
+
+    observer.observe(element);
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  return (
+    <div ref={ref} className="w-full h-full">
+      {isVisible ? children : null}
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- add `LazyMount` component that uses IntersectionObserver to mount children when visible
- wrap ChartCard contents in `LazyMount`

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6842cab7770c832889633533bcb0b016