### PR TITLE
Add dashboard data API

### DIFF
--- a/crates/api-types/src/lib.rs
+++ b/crates/api-types/src/lib.rs
@@ -305,3 +305,34 @@ pub struct L1HeadBlockResponse {
     /// Number of the most recent L1 block.
     pub l1_head_block: Option<u64>,
 }
+
+/// Aggregated data for the main dashboard.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct DashboardDataResponse {
+    /// Average delay between L2 blocks in milliseconds.
+    pub l2_block_cadence_ms: Option<u64>,
+    /// Average delay between batch submissions in milliseconds.
+    pub batch_posting_cadence_ms: Option<u64>,
+    /// Average time to prove a batch in milliseconds.
+    pub avg_prove_time_ms: Option<u64>,
+    /// Average time to verify a batch in milliseconds.
+    pub avg_verify_time_ms: Option<u64>,
+    /// Average L2 transactions per second.
+    pub avg_tps: Option<f64>,
+    /// Latest preconfiguration data.
+    pub preconf_data: Option<PreconfDataResponse>,
+    /// Number of L2 reorg events in the selected range.
+    pub l2_reorgs: usize,
+    /// Number of slashing events in the selected range.
+    pub slashings: usize,
+    /// Number of forced inclusion events in the selected range.
+    pub forced_inclusions: usize,
+    /// Number of the most recent L2 block.
+    pub l2_block: Option<u64>,
+    /// Number of the most recent L1 block.
+    pub l1_block: Option<u64>,
+    /// Sum of priority fee and 75% of base fee for the range.
+    pub l2_tx_fee: Option<u128>,
+    /// Estimated infrastructure cost in USD for the requested range.
+    pub cloud_cost: Option<f64>,
+}

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -608,3 +608,29 @@ export const fetchCloudCost = async (
     error: res.error,
   };
 };
+
+export interface DashboardDataResponse {
+  l2_block_cadence_ms: number | null;
+  batch_posting_cadence_ms: number | null;
+  avg_prove_time_ms: number | null;
+  avg_verify_time_ms: number | null;
+  avg_tps: number | null;
+  preconf_data: PreconfData | null;
+  l2_reorgs: number;
+  slashings: number;
+  forced_inclusions: number;
+  l2_block: number | null;
+  l1_block: number | null;
+  l2_tx_fee: number | null;
+  cloud_cost: number | null;
+}
+
+export const fetchDashboardData = async (
+  range: TimeRange,
+  address?: string,
+): Promise<RequestResult<DashboardDataResponse>> => {
+  const url =
+    `${API_BASE}/dashboard-data?range=${range}` +
+    (address ? `&address=${address}` : '');
+  return fetchJson<DashboardDataResponse>(url);
+};

--- a/dashboard/tests/dataFetcher.test.ts
+++ b/dashboard/tests/dataFetcher.test.ts
@@ -23,21 +23,25 @@ beforeEach(() => {
 describe('dataFetcher', () => {
   it('aggregates main dashboard data', async () => {
     setAll({
-      fetchL2BlockCadence: ok(1),
-      fetchBatchPostingCadence: ok(2),
-      fetchAvgProveTime: ok(3),
-      fetchAvgVerifyTime: ok(4),
-      fetchAvgL2Tps: ok(5),
-      fetchPreconfData: ok({
-        candidates: ['a'],
-        current_operator: 'x',
-        next_operator: 'y',
+      fetchDashboardData: ok({
+        l2_block_cadence_ms: 1,
+        batch_posting_cadence_ms: 2,
+        avg_prove_time_ms: 3,
+        avg_verify_time_ms: 4,
+        avg_tps: 5,
+        preconf_data: {
+          candidates: ['a'],
+          current_operator: 'x',
+          next_operator: 'y',
+        },
+        l2_reorgs: 6,
+        slashings: 7,
+        forced_inclusions: 8,
+        l2_block: 10,
+        l1_block: 11,
+        l2_tx_fee: 12,
+        cloud_cost: 13,
       }),
-      fetchL2Reorgs: ok(6),
-      fetchSlashingEventCount: ok(7),
-      fetchForcedInclusionCount: ok(8),
-      fetchL2HeadBlock: ok(10),
-      fetchL1HeadBlock: ok(11),
       fetchProveTimes: ok([{ name: '1', value: 1, timestamp: 0 }]),
       fetchVerifyTimes: ok([{ name: '2', value: 2, timestamp: 0 }]),
       fetchL2BlockTimes: ok([{ value: 2, timestamp: 0 }]),
@@ -45,8 +49,6 @@ describe('dataFetcher', () => {
       fetchSequencerDistribution: ok([{ name: 'foo', value: 1 }]),
       fetchAllBlockTransactions: ok([{ block: 1, txs: 2, sequencer: 'bar' }]),
       fetchBatchBlobCounts: ok([{ block: 10, batch: 1, blobs: 2 }]),
-      fetchL2TxFee: ok(12),
-      fetchCloudCost: ok(13),
     });
 
     const res = await fetchMainDashboardData('1h', null);
@@ -54,22 +56,12 @@ describe('dataFetcher', () => {
     expect(res.avgVerify).toBe(4);
     expect(res.sequencerDist[0].name).toBe('foo');
     expect(res.txPerBlock).toHaveLength(1);
-    expect(res.badRequestResults).toHaveLength(18);
+    expect(res.badRequestResults).toHaveLength(8);
   });
 
   it('defaults to empty arrays when service data missing', async () => {
     setAll({
-      fetchL2BlockCadence: ok(null),
-      fetchBatchPostingCadence: ok(null),
-      fetchAvgProveTime: ok(null),
-      fetchAvgVerifyTime: ok(null),
-      fetchAvgL2Tps: ok(null),
-      fetchPreconfData: ok(null),
-      fetchL2Reorgs: ok(null),
-      fetchSlashingEventCount: ok(null),
-      fetchForcedInclusionCount: ok(null),
-      fetchL2HeadBlock: ok(null),
-      fetchL1HeadBlock: ok(null),
+      fetchDashboardData: ok(null),
       fetchProveTimes: ok(null),
       fetchVerifyTimes: ok(null),
       fetchL2BlockTimes: ok(null),
@@ -77,8 +69,6 @@ describe('dataFetcher', () => {
       fetchSequencerDistribution: ok(null),
       fetchAllBlockTransactions: ok(null),
       fetchBatchBlobCounts: ok(null),
-      fetchL2TxFee: ok(null),
-      fetchCloudCost: ok(null),
     });
 
     const res = await fetchMainDashboardData('1h', null);
@@ -86,6 +76,7 @@ describe('dataFetcher', () => {
     expect(res.sequencerDist).toEqual([]);
     expect(res.txPerBlock).toEqual([]);
     expect(res.blobsPerBatch).toEqual([]);
+    expect(res.badRequestResults).toHaveLength(8);
   });
 
   it('fetches economics data', async () => {


### PR DESCRIPTION
## Summary
- add lightweight `DashboardDataResponse`
- slim down `/dashboard-data` endpoint to avoid large arrays
- adjust dashboard fetcher to request chart data separately
- fix corresponding tests

## Testing
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_6842cd08e628832880ca313327071481