### PR TITLE
Introduce client-side API caching

### DIFF
--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -4,6 +4,7 @@ export const API_BASE: string =
 
 import { getSequencerName } from '../sequencerConfig';
 import { showToast } from '../utils/toast';
+import { dashboardCache, chartCache, tableCache } from '../utils/smartCache';
 
 import type {
   TimeSeriesData,
@@ -20,6 +21,24 @@ export interface RequestResult<T> {
   badRequest: boolean;
   error: ErrorResponse | null;
 }
+
+const cached = async <T>(
+  key: string,
+  params: Record<string, any> | undefined,
+  cache: typeof dashboardCache | typeof chartCache | typeof tableCache,
+  fetcher: () => Promise<RequestResult<T>>,
+): Promise<RequestResult<T>> => {
+  const cachedValue = cache.get(key, params);
+  if (cachedValue) {
+    return cachedValue as RequestResult<T>;
+  }
+
+  const result = await fetcher();
+  if (!result.badRequest && result.error === null) {
+    cache.set(key, result, params);
+  }
+  return result;
+};
 
 const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
@@ -77,165 +96,206 @@ export interface AvgTimeResponse {
 export const fetchAvgProveTime = async (
   range: TimeRange,
 ): Promise<RequestResult<number>> => {
-  const url = `${API_BASE}/avg-prove-time?range=${range}`;
-  const res = await fetchJson<{ avg_prove_time_ms?: number }>(url);
-  return {
-    data: res.data?.avg_prove_time_ms ?? null,
-    badRequest: res.badRequest,
-    error: res.error,
-  };
+  const key = 'metrics:avgProveTime';
+  return cached(key, { range }, dashboardCache, async () => {
+    const url = `${API_BASE}/avg-prove-time?range=${range}`;
+    const res = await fetchJson<{ avg_prove_time_ms?: number }>(url);
+    return {
+      data: res.data?.avg_prove_time_ms ?? null,
+      badRequest: res.badRequest,
+      error: res.error,
+    };
+  });
 };
 
 export const fetchAvgVerifyTime = async (
   range: TimeRange,
 ): Promise<RequestResult<number>> => {
-  const url = `${API_BASE}/avg-verify-time?range=${range}`;
-  const res = await fetchJson<{ avg_verify_time_ms?: number }>(url);
-  return {
-    data: res.data?.avg_verify_time_ms ?? null,
-    badRequest: res.badRequest,
-    error: res.error,
-  };
+  const key = 'metrics:avgVerifyTime';
+  return cached(key, { range }, dashboardCache, async () => {
+    const url = `${API_BASE}/avg-verify-time?range=${range}`;
+    const res = await fetchJson<{ avg_verify_time_ms?: number }>(url);
+    return {
+      data: res.data?.avg_verify_time_ms ?? null,
+      badRequest: res.badRequest,
+      error: res.error,
+    };
+  });
 };
 
 export const fetchL2BlockCadence = async (
   range: TimeRange,
   address?: string,
 ): Promise<RequestResult<number>> => {
-  const url = `${API_BASE}/l2-block-cadence?range=${range}${address ? `&address=${address}` : ''}`;
-  const res = await fetchJson<{ l2_block_cadence_ms?: number }>(url);
-  return {
-    data: res.data?.l2_block_cadence_ms ?? null,
-    badRequest: res.badRequest,
-    error: res.error,
-  };
+  const key = 'metrics:l2BlockCadence';
+  return cached(key, { range, address }, dashboardCache, async () => {
+    const url = `${API_BASE}/l2-block-cadence?range=${range}${
+      address ? `&address=${address}` : ''
+    }`;
+    const res = await fetchJson<{ l2_block_cadence_ms?: number }>(url);
+    return {
+      data: res.data?.l2_block_cadence_ms ?? null,
+      badRequest: res.badRequest,
+      error: res.error,
+    };
+  });
 };
 
 export const fetchBatchPostingCadence = async (
   range: TimeRange,
 ): Promise<RequestResult<number>> => {
-  const url = `${API_BASE}/batch-posting-cadence?range=${range}`;
-  const res = await fetchJson<{ batch_posting_cadence_ms?: number }>(url);
-  return {
-    data: res.data?.batch_posting_cadence_ms ?? null,
-    badRequest: res.badRequest,
-    error: res.error,
-  };
+  const key = 'metrics:batchPostingCadence';
+  return cached(key, { range }, dashboardCache, async () => {
+    const url = `${API_BASE}/batch-posting-cadence?range=${range}`;
+    const res = await fetchJson<{ batch_posting_cadence_ms?: number }>(url);
+    return {
+      data: res.data?.batch_posting_cadence_ms ?? null,
+      badRequest: res.badRequest,
+      error: res.error,
+    };
+  });
 };
 
 export const fetchActiveSequencerAddresses = async (): Promise<
   RequestResult<string[]>
 > => {
-  const res = await fetchPreconfData();
-  return {
-    data: res.data?.candidates ?? null,
-    badRequest: res.badRequest,
-    error: res.error,
-  };
+  const key = 'metrics:activeSequencers';
+  return cached(key, undefined, dashboardCache, async () => {
+    const res = await fetchPreconfData();
+    return {
+      data: res.data?.candidates ?? null,
+      badRequest: res.badRequest,
+      error: res.error,
+    };
+  });
 };
 
 export const fetchL2Reorgs = async (
   range: TimeRange,
 ): Promise<RequestResult<number>> => {
-  const url = `${API_BASE}/reorgs?range=${range}`;
-  const res = await fetchJson<{ events: unknown[] }>(url);
-  return {
-    data: res.data ? res.data.events.length : null,
-    badRequest: res.badRequest,
-    error: res.error,
-  };
+  const key = 'metrics:l2Reorgs';
+  return cached(key, { range }, dashboardCache, async () => {
+    const url = `${API_BASE}/reorgs?range=${range}`;
+    const res = await fetchJson<{ events: unknown[] }>(url);
+    return {
+      data: res.data ? res.data.events.length : null,
+      badRequest: res.badRequest,
+      error: res.error,
+    };
+  });
 };
 
 export const fetchL2ReorgEvents = async (
   range: TimeRange,
 ): Promise<RequestResult<L2ReorgEvent[]>> => {
-  const url = `${API_BASE}/reorgs?range=${range}`;
-  const res = await fetchJson<{
-    events: { l2_block_number: number; depth: number; inserted_at: string }[];
-  }>(url);
-  return {
-    data: res.data
-      ? res.data.events.map((e) => ({
-          l2_block_number: e.l2_block_number,
-          depth: e.depth,
-          timestamp: Date.parse(e.inserted_at),
-        }))
-      : null,
-    badRequest: res.badRequest,
-    error: res.error,
-  };
+  const key = 'metrics:l2ReorgEvents';
+  return cached(key, { range }, dashboardCache, async () => {
+    const url = `${API_BASE}/reorgs?range=${range}`;
+    const res = await fetchJson<{
+      events: { l2_block_number: number; depth: number; inserted_at: string }[];
+    }>(url);
+    return {
+      data: res.data
+        ? res.data.events.map((e) => ({
+            l2_block_number: e.l2_block_number,
+            depth: e.depth,
+            timestamp: Date.parse(e.inserted_at),
+          }))
+        : null,
+      badRequest: res.badRequest,
+      error: res.error,
+    };
+  });
 };
 
 export const fetchSlashingEventCount = async (
   range: TimeRange,
 ): Promise<RequestResult<number>> => {
-  const url = `${API_BASE}/slashings?range=${range}`;
-  const res = await fetchJson<{ events: unknown[] }>(url);
-  return {
-    data: res.data ? res.data.events.length : null,
-    badRequest: res.badRequest,
-    error: res.error,
-  };
+  const key = 'metrics:slashingCount';
+  return cached(key, { range }, dashboardCache, async () => {
+    const url = `${API_BASE}/slashings?range=${range}`;
+    const res = await fetchJson<{ events: unknown[] }>(url);
+    return {
+      data: res.data ? res.data.events.length : null,
+      badRequest: res.badRequest,
+      error: res.error,
+    };
+  });
 };
 
 export const fetchForcedInclusionCount = async (
   range: TimeRange,
 ): Promise<RequestResult<number>> => {
-  const url = `${API_BASE}/forced-inclusions?range=${range}`;
-  const res = await fetchJson<{ events: unknown[] }>(url);
-  return {
-    data: res.data ? res.data.events.length : null,
-    badRequest: res.badRequest,
-    error: res.error,
-  };
+  const key = 'metrics:forcedInclusionCount';
+  return cached(key, { range }, dashboardCache, async () => {
+    const url = `${API_BASE}/forced-inclusions?range=${range}`;
+    const res = await fetchJson<{ events: unknown[] }>(url);
+    return {
+      data: res.data ? res.data.events.length : null,
+      badRequest: res.badRequest,
+      error: res.error,
+    };
+  });
 };
 
 export const fetchSlashingEvents = async (
   range: TimeRange,
 ): Promise<RequestResult<SlashingEvent[]>> => {
-  const url = `${API_BASE}/slashings?range=${range}`;
-  const res = await fetchJson<{ events: SlashingEvent[] }>(url);
-  return {
-    data: res.data ? res.data.events : null,
-    badRequest: res.badRequest,
-    error: res.error,
-  };
+  const key = 'metrics:slashingEvents';
+  return cached(key, { range }, dashboardCache, async () => {
+    const url = `${API_BASE}/slashings?range=${range}`;
+    const res = await fetchJson<{ events: SlashingEvent[] }>(url);
+    return {
+      data: res.data ? res.data.events : null,
+      badRequest: res.badRequest,
+      error: res.error,
+    };
+  });
 };
 
 export const fetchForcedInclusionEvents = async (
   range: TimeRange,
 ): Promise<RequestResult<ForcedInclusionEvent[]>> => {
-  const url = `${API_BASE}/forced-inclusions?range=${range}`;
-  const res = await fetchJson<{ events: ForcedInclusionEvent[] }>(url);
-  return {
-    data: res.data ? res.data.events : null,
-    badRequest: res.badRequest,
-    error: res.error,
-  };
+  const key = 'metrics:forcedInclusionEvents';
+  return cached(key, { range }, dashboardCache, async () => {
+    const url = `${API_BASE}/forced-inclusions?range=${range}`;
+    const res = await fetchJson<{ events: ForcedInclusionEvent[] }>(url);
+    return {
+      data: res.data ? res.data.events : null,
+      badRequest: res.badRequest,
+      error: res.error,
+    };
+  });
 };
 
 export const fetchL2HeadBlock = async (
   range: TimeRange,
 ): Promise<RequestResult<number>> => {
-  const url = `${API_BASE}/l2-block-times?range=${range}`;
-  const res = await fetchJson<{ blocks: { l2_block_number: number }[] }>(url);
-  const value =
-    res.data && res.data.blocks.length > 0
-      ? res.data.blocks[res.data.blocks.length - 1].l2_block_number
-      : null;
-  return { data: value, badRequest: res.badRequest, error: res.error };
+  const key = 'metrics:l2HeadBlock';
+  return cached(key, { range }, dashboardCache, async () => {
+    const url = `${API_BASE}/l2-block-times?range=${range}`;
+    const res = await fetchJson<{ blocks: { l2_block_number: number }[] }>(url);
+    const value =
+      res.data && res.data.blocks.length > 0
+        ? res.data.blocks[res.data.blocks.length - 1].l2_block_number
+        : null;
+    return { data: value, badRequest: res.badRequest, error: res.error };
+  });
 };
 
 export const fetchL1HeadBlock = async (
   range: TimeRange,
 ): Promise<RequestResult<number>> => {
-  const url = `${API_BASE}/l1-block-times?range=${range}`;
-  const res = await fetchJson<{ blocks: { block_number: number }[] }>(url);
-  const value =
-    res.data && res.data.blocks.length > 0
-      ? res.data.blocks[res.data.blocks.length - 1].block_number
-      : null;
-  return { data: value, badRequest: res.badRequest, error: res.error };
+  const key = 'metrics:l1HeadBlock';
+  return cached(key, { range }, dashboardCache, async () => {
+    const url = `${API_BASE}/l1-block-times?range=${range}`;
+    const res = await fetchJson<{ blocks: { block_number: number }[] }>(url);
+    const value =
+      res.data && res.data.blocks.length > 0
+        ? res.data.blocks[res.data.blocks.length - 1].block_number
+        : null;
+    return { data: value, badRequest: res.badRequest, error: res.error };
+  });
 };
 
 export interface PreconfData {
@@ -247,197 +307,238 @@ export interface PreconfData {
 export const fetchPreconfData = async (): Promise<
   RequestResult<PreconfData>
 > => {
-  const url = `${API_BASE}/preconf-data`;
-  return fetchJson<PreconfData>(url);
+  const key = 'metrics:preconfData';
+  return cached(key, undefined, dashboardCache, async () => {
+    const url = `${API_BASE}/preconf-data`;
+    return fetchJson<PreconfData>(url);
+  });
 };
 
 export const fetchL2HeadNumber = async (): Promise<RequestResult<number>> => {
-  const url = `${API_BASE}/l2-head-block`;
-  const res = await fetchJson<{ l2_head_block?: number }>(url);
-  return {
-    data: res.data?.l2_head_block ?? null,
-    badRequest: res.badRequest,
-    error: res.error,
-  };
+  const key = 'metrics:l2HeadNumber';
+  return cached(key, undefined, dashboardCache, async () => {
+    const url = `${API_BASE}/l2-head-block`;
+    const res = await fetchJson<{ l2_head_block?: number }>(url);
+    return {
+      data: res.data?.l2_head_block ?? null,
+      badRequest: res.badRequest,
+      error: res.error,
+    };
+  });
 };
 
 export const fetchL1HeadNumber = async (): Promise<RequestResult<number>> => {
-  const url = `${API_BASE}/l1-head-block`;
-  const res = await fetchJson<{ l1_head_block?: number }>(url);
-  return {
-    data: res.data?.l1_head_block ?? null,
-    badRequest: res.badRequest,
-    error: res.error,
-  };
+  const key = 'metrics:l1HeadNumber';
+  return cached(key, undefined, dashboardCache, async () => {
+    const url = `${API_BASE}/l1-head-block`;
+    const res = await fetchJson<{ l1_head_block?: number }>(url);
+    return {
+      data: res.data?.l1_head_block ?? null,
+      badRequest: res.badRequest,
+      error: res.error,
+    };
+  });
 };
 
 export const fetchProveTimes = async (
   range: TimeRange,
 ): Promise<RequestResult<TimeSeriesData[]>> => {
-  const url = `${API_BASE}/prove-times?range=${range}`;
-  const res = await fetchJson<{
-    batches: { batch_id: number; seconds_to_prove: number }[];
-  }>(url);
-  return {
-    data: res.data
-      ? res.data.batches.map((b) => ({
-          name: b.batch_id.toString(),
-          value: b.seconds_to_prove,
-          timestamp: 0,
-        }))
-      : null,
-    badRequest: res.badRequest,
-    error: res.error,
-  };
+  const key = 'chart:proveTimes';
+  return cached(key, { range }, chartCache, async () => {
+    const url = `${API_BASE}/prove-times?range=${range}`;
+    const res = await fetchJson<{
+      batches: { batch_id: number; seconds_to_prove: number }[];
+    }>(url);
+    return {
+      data: res.data
+        ? res.data.batches.map((b) => ({
+            name: b.batch_id.toString(),
+            value: b.seconds_to_prove,
+            timestamp: 0,
+          }))
+        : null,
+      badRequest: res.badRequest,
+      error: res.error,
+    };
+  });
 };
 
 export const fetchVerifyTimes = async (
   range: TimeRange,
 ): Promise<RequestResult<TimeSeriesData[]>> => {
-  const url = `${API_BASE}/verify-times?range=${range}`;
-  const res = await fetchJson<{
-    batches: { batch_id: number; seconds_to_verify: number }[];
-  }>(url);
-  return {
-    data: res.data
-      ? res.data.batches.map((b) => ({
-          name: b.batch_id.toString(),
-          value: b.seconds_to_verify,
-          timestamp: 0,
-        }))
-      : null,
-    badRequest: res.badRequest,
-    error: res.error,
-  };
+  const key = 'chart:verifyTimes';
+  return cached(key, { range }, chartCache, async () => {
+    const url = `${API_BASE}/verify-times?range=${range}`;
+    const res = await fetchJson<{
+      batches: { batch_id: number; seconds_to_verify: number }[];
+    }>(url);
+    return {
+      data: res.data
+        ? res.data.batches.map((b) => ({
+            name: b.batch_id.toString(),
+            value: b.seconds_to_verify,
+            timestamp: 0,
+          }))
+        : null,
+      badRequest: res.badRequest,
+      error: res.error,
+    };
+  });
 };
 
 export const fetchL1BlockTimes = async (
   range: TimeRange,
 ): Promise<RequestResult<TimeSeriesData[]>> => {
-  const url = `${API_BASE}/l1-block-times?range=${range}`;
-  const res = await fetchJson<{
-    blocks: { minute: number; block_number: number }[];
-  }>(url);
-  if (!res.data) {
-    return { data: null, badRequest: res.badRequest, error: res.error };
-  }
+  const key = 'chart:l1BlockTimes';
+  return cached(key, { range }, chartCache, async () => {
+    const url = `${API_BASE}/l1-block-times?range=${range}`;
+    const res = await fetchJson<{
+      blocks: { minute: number; block_number: number }[];
+    }>(url);
+    if (!res.data) {
+      return { data: null, badRequest: res.badRequest, error: res.error };
+    }
 
-  const blocks = res.data.blocks.map((b) => ({
-    ts: b.minute * 1000,
-    block: b.block_number,
-  }));
+    const blocks = res.data.blocks.map((b) => ({
+      ts: b.minute * 1000,
+      block: b.block_number,
+    }));
 
-  const data = blocks
-    .slice(1)
-    .map((b, i): TimeSeriesData | null => {
-      const prev = blocks[i];
-      const deltaBlocks = b.block - prev.block;
-      if (deltaBlocks <= 0) {
-        return null;
-      }
-      const deltaTimeMs = b.ts - prev.ts;
-      const interval = deltaTimeMs / deltaBlocks;
-      return { timestamp: interval, value: b.block };
-    })
-    .filter((d): d is TimeSeriesData => d !== null);
+    const data = blocks
+      .slice(1)
+      .map((b, i): TimeSeriesData | null => {
+        const prev = blocks[i];
+        const deltaBlocks = b.block - prev.block;
+        if (deltaBlocks <= 0) {
+          return null;
+        }
+        const deltaTimeMs = b.ts - prev.ts;
+        const interval = deltaTimeMs / deltaBlocks;
+        return { timestamp: interval, value: b.block };
+      })
+      .filter((d): d is TimeSeriesData => d !== null);
 
-  return { data, badRequest: res.badRequest, error: res.error };
+    return { data, badRequest: res.badRequest, error: res.error };
+  });
 };
 
 export const fetchL2BlockTimes = async (
   range: TimeRange,
   address?: string,
 ): Promise<RequestResult<TimeSeriesData[]>> => {
-  const url = `${API_BASE}/l2-block-times?range=${range}${address ? `&address=${address}` : ''}`;
-  const res = await fetchJson<{
-    blocks: { l2_block_number: number; ms_since_prev_block: number }[];
-  }>(url);
-  if (!res.data) {
-    return { data: null, badRequest: res.badRequest, error: res.error };
-  }
+  const key = 'chart:l2BlockTimes';
+  return cached(key, { range, address }, chartCache, async () => {
+    const url = `${API_BASE}/l2-block-times?range=${range}${
+      address ? `&address=${address}` : ''
+    }`;
+    const res = await fetchJson<{
+      blocks: { l2_block_number: number; ms_since_prev_block: number }[];
+    }>(url);
+    if (!res.data) {
+      return { data: null, badRequest: res.badRequest, error: res.error };
+    }
 
-  const data = res.data.blocks.slice(1).map(
-    (b): TimeSeriesData => ({
-      value: b.l2_block_number,
-      timestamp: b.ms_since_prev_block / 1000,
-    }),
-  );
+    const data = res.data.blocks.slice(1).map(
+      (b): TimeSeriesData => ({
+        value: b.l2_block_number,
+        timestamp: b.ms_since_prev_block / 1000,
+      }),
+    );
 
-  return { data, badRequest: res.badRequest, error: res.error };
+    return { data, badRequest: res.badRequest, error: res.error };
+  });
 };
 
 export const fetchBatchPostingTimes = async (
   range: TimeRange,
 ): Promise<RequestResult<TimeSeriesData[]>> => {
-  const url = `${API_BASE}/batch-posting-times?range=${range}`;
-  const res = await fetchJson<{
-    batches: { batch_id: number; ms_since_prev_batch: number }[];
-  }>(url);
-  if (!res.data) {
-    return { data: null, badRequest: res.badRequest, error: res.error };
-  }
-  const data = res.data.batches.map(
-    (b): TimeSeriesData => ({
-      value: b.batch_id,
-      timestamp: b.ms_since_prev_batch / 1000,
-    }),
-  );
-  return { data, badRequest: res.badRequest, error: res.error };
+  const key = 'chart:batchPostingTimes';
+  return cached(key, { range }, chartCache, async () => {
+    const url = `${API_BASE}/batch-posting-times?range=${range}`;
+    const res = await fetchJson<{
+      batches: { batch_id: number; ms_since_prev_batch: number }[];
+    }>(url);
+    if (!res.data) {
+      return { data: null, badRequest: res.badRequest, error: res.error };
+    }
+    const data = res.data.batches.map(
+      (b): TimeSeriesData => ({
+        value: b.batch_id,
+        timestamp: b.ms_since_prev_batch / 1000,
+      }),
+    );
+    return { data, badRequest: res.badRequest, error: res.error };
+  });
 };
 
 export const fetchL2GasUsed = async (
   range: TimeRange,
   address?: string,
 ): Promise<RequestResult<TimeSeriesData[]>> => {
-  const url = `${API_BASE}/l2-gas-used?range=${range}${address ? `&address=${address}` : ''}`;
-  const res = await fetchJson<{
-    blocks: { l2_block_number: number; gas_used: number }[];
-  }>(url);
-  if (!res.data) {
-    return { data: null, badRequest: res.badRequest, error: res.error };
-  }
+  const key = 'chart:l2GasUsed';
+  return cached(key, { range, address }, chartCache, async () => {
+    const url = `${API_BASE}/l2-gas-used?range=${range}${
+      address ? `&address=${address}` : ''
+    }`;
+    const res = await fetchJson<{
+      blocks: { l2_block_number: number; gas_used: number }[];
+    }>(url);
+    if (!res.data) {
+      return { data: null, badRequest: res.badRequest, error: res.error };
+    }
 
-  const data = res.data.blocks.map(
-    (b): TimeSeriesData => ({
-      value: b.l2_block_number,
-      timestamp: b.gas_used,
-    }),
-  );
+    const data = res.data.blocks.map(
+      (b): TimeSeriesData => ({
+        value: b.l2_block_number,
+        timestamp: b.gas_used,
+      }),
+    );
 
-  return { data, badRequest: res.badRequest, error: res.error };
+    return { data, badRequest: res.badRequest, error: res.error };
+  });
 };
 
 export const fetchSequencerDistribution = async (
   range: TimeRange,
 ): Promise<RequestResult<PieChartDataItem[]>> => {
-  const url = `${API_BASE}/sequencer-distribution?range=${range}`;
-  const res = await fetchJson<{
-    sequencers: { address: string; blocks: number }[];
-  }>(url);
-  return {
-    data: res.data
-      ? res.data.sequencers.map((s) => ({
-          name: getSequencerName(s.address),
-          value: s.blocks,
-        }))
-      : null,
-    badRequest: res.badRequest,
-    error: res.error,
-  };
+  const key = 'chart:sequencerDistribution';
+  return cached(key, { range }, chartCache, async () => {
+    const url = `${API_BASE}/sequencer-distribution?range=${range}`;
+    const res = await fetchJson<{
+      sequencers: { address: string; blocks: number }[];
+    }>(url);
+    return {
+      data: res.data
+        ? res.data.sequencers.map((s) => ({
+            name: getSequencerName(s.address),
+            value: s.blocks,
+          }))
+        : null,
+      badRequest: res.badRequest,
+      error: res.error,
+    };
+  });
 };
 
 export const fetchSequencerBlocks = async (
   range: TimeRange,
   address: string,
 ): Promise<RequestResult<number[]>> => {
-  const url = `${API_BASE}/sequencer-blocks?range=${range}&address=${address}`;
-  const res = await fetchJson<{
-    sequencers: { address: string; blocks: number[] }[];
-  }>(url);
-  const blocks = res.data?.sequencers.find(
-    (s) => s.address.toLowerCase() === address.toLowerCase(),
-  )?.blocks;
-  return { data: blocks ?? null, badRequest: res.badRequest, error: res.error };
+  const key = 'chart:sequencerBlocks';
+  return cached(key, { range, address }, chartCache, async () => {
+    const url = `${API_BASE}/sequencer-blocks?range=${range}&address=${address}`;
+    const res = await fetchJson<{
+      sequencers: { address: string; blocks: number[] }[];
+    }>(url);
+    const blocks = res.data?.sequencers.find(
+      (s) => s.address.toLowerCase() === address.toLowerCase(),
+    )?.blocks;
+    return {
+      data: blocks ?? null,
+      badRequest: res.badRequest,
+      error: res.error,
+    };
+  });
 };
 
 export interface BlockTransaction {
@@ -454,36 +555,44 @@ export const fetchBlockTransactions = async (
   address?: string,
   unlimited = false,
 ): Promise<RequestResult<BlockTransaction[]>> => {
-  let url = `${API_BASE}/block-transactions?range=${range}`;
+  const key = 'table:blockTransactions';
+  return cached(
+    key,
+    { range, limit, startingAfter, endingBefore, address, unlimited },
+    tableCache,
+    async () => {
+      let url = `${API_BASE}/block-transactions?range=${range}`;
 
-  // Only add limit parameter if not unlimited
-  if (!unlimited) {
-    url += `&limit=${limit}`;
-  }
+      // Only add limit parameter if not unlimited
+      if (!unlimited) {
+        url += `&limit=${limit}`;
+      }
 
-  // For unlimited fetching, we ignore pagination parameters to get all data
-  if (!unlimited) {
-    if (startingAfter !== undefined) {
-      url += `&starting_after=${startingAfter}`;
-    } else if (endingBefore !== undefined) {
-      url += `&ending_before=${endingBefore}`;
-    }
-  }
+      // For unlimited fetching, we ignore pagination parameters to get all data
+      if (!unlimited) {
+        if (startingAfter !== undefined) {
+          url += `&starting_after=${startingAfter}`;
+        } else if (endingBefore !== undefined) {
+          url += `&ending_before=${endingBefore}`;
+        }
+      }
 
-  if (address) {
-    url += `&address=${address}`;
-  }
-  const res = await fetchJson<{ blocks: BlockTransaction[] }>(url);
-  return {
-    data: res.data?.blocks
-      ? res.data.blocks.map((b) => ({
-          ...b,
-          sequencer: getSequencerName(b.sequencer),
-        }))
-      : null,
-    badRequest: res.badRequest,
-    error: res.error,
-  };
+      if (address) {
+        url += `&address=${address}`;
+      }
+      const res = await fetchJson<{ blocks: BlockTransaction[] }>(url);
+      return {
+        data: res.data?.blocks
+          ? res.data.blocks.map((b) => ({
+              ...b,
+              sequencer: getSequencerName(b.sequencer),
+            }))
+          : null,
+        badRequest: res.badRequest,
+        error: res.error,
+      };
+    },
+  );
 };
 
 // New function specifically for fetching all block transactions in a time range
@@ -511,100 +620,118 @@ export interface BatchBlobCount {
 export const fetchBatchBlobCounts = async (
   range: TimeRange,
 ): Promise<RequestResult<BatchBlobCount[]>> => {
-  const url = `${API_BASE}/blobs-per-batch?range=${range}`;
-  const res = await fetchJson<{
-    batches: {
-      l1_block_number?: number;
-      batch_id: number;
-      blob_count: number;
-    }[];
-  }>(url);
-  return {
-    data: res.data
-      ? res.data.batches.map((b) => ({
-          block: b.l1_block_number ?? b.batch_id, // Fallback to batch_id for backward compatibility
-          batch: b.batch_id,
-          blobs: b.blob_count,
-        }))
-      : null,
-    badRequest: res.badRequest,
-    error: res.error,
-  };
+  const key = 'chart:batchBlobCounts';
+  return cached(key, { range }, chartCache, async () => {
+    const url = `${API_BASE}/blobs-per-batch?range=${range}`;
+    const res = await fetchJson<{
+      batches: {
+        l1_block_number?: number;
+        batch_id: number;
+        blob_count: number;
+      }[];
+    }>(url);
+    return {
+      data: res.data
+        ? res.data.batches.map((b) => ({
+            block: b.l1_block_number ?? b.batch_id, // Fallback to batch_id for backward compatibility
+            batch: b.batch_id,
+            blobs: b.blob_count,
+          }))
+        : null,
+      badRequest: res.badRequest,
+      error: res.error,
+    };
+  });
 };
 
 export const fetchAvgBlobsPerBatch = async (
   range: TimeRange,
 ): Promise<RequestResult<number>> => {
-  const url = `${API_BASE}/avg-blobs-per-batch?range=${range}`;
-  const res = await fetchJson<{ avg_blobs?: number }>(url);
-  return {
-    data: res.data?.avg_blobs ?? null,
-    badRequest: res.badRequest,
-    error: res.error,
-  };
+  const key = 'metrics:avgBlobsPerBatch';
+  return cached(key, { range }, dashboardCache, async () => {
+    const url = `${API_BASE}/avg-blobs-per-batch?range=${range}`;
+    const res = await fetchJson<{ avg_blobs?: number }>(url);
+    return {
+      data: res.data?.avg_blobs ?? null,
+      badRequest: res.badRequest,
+      error: res.error,
+    };
+  });
 };
 
 export const fetchAvgL2Tps = async (
   range: TimeRange,
   address?: string,
 ): Promise<RequestResult<number>> => {
-  const url =
-    `${API_BASE}/avg-l2-tps?range=${range}` +
-    (address ? `&address=${address}` : '');
-  const res = await fetchJson<{ avg_tps?: number }>(url);
-  return {
-    data: res.data?.avg_tps ?? null,
-    badRequest: res.badRequest,
-    error: res.error,
-  };
+  const key = 'metrics:avgL2Tps';
+  return cached(key, { range, address }, dashboardCache, async () => {
+    const url =
+      `${API_BASE}/avg-l2-tps?range=${range}` +
+      (address ? `&address=${address}` : '');
+    const res = await fetchJson<{ avg_tps?: number }>(url);
+    return {
+      data: res.data?.avg_tps ?? null,
+      badRequest: res.badRequest,
+      error: res.error,
+    };
+  });
 };
 
 export const fetchL2TxFee = async (
   range: TimeRange,
   address?: string,
 ): Promise<RequestResult<number>> => {
-  const url =
-    `${API_BASE}/l2-tx-fee?range=${range}` +
-    (address ? `&address=${address}` : '');
-  const res = await fetchJson<{ tx_fee?: number }>(url);
-  return {
-    data: res.data?.tx_fee ?? null,
-    badRequest: res.badRequest,
-    error: res.error,
-  };
+  const key = 'metrics:l2TxFee';
+  return cached(key, { range, address }, dashboardCache, async () => {
+    const url =
+      `${API_BASE}/l2-tx-fee?range=${range}` +
+      (address ? `&address=${address}` : '');
+    const res = await fetchJson<{ tx_fee?: number }>(url);
+    return {
+      data: res.data?.tx_fee ?? null,
+      badRequest: res.badRequest,
+      error: res.error,
+    };
+  });
 };
 
 export const fetchL2Tps = async (
   range: TimeRange,
   address?: string,
 ): Promise<RequestResult<{ block: number; tps: number }[]>> => {
-  const url =
-    `${API_BASE}/l2-tps?range=${range}` +
-    (address ? `&address=${address}` : '');
-  const res = await fetchJson<{
-    blocks: { l2_block_number: number; tps: number }[];
-  }>(url);
+  const key = 'chart:l2Tps';
+  return cached(key, { range, address }, chartCache, async () => {
+    const url =
+      `${API_BASE}/l2-tps?range=${range}` +
+      (address ? `&address=${address}` : '');
+    const res = await fetchJson<{
+      blocks: { l2_block_number: number; tps: number }[];
+    }>(url);
 
-  if (!res.data) {
-    return { data: null, badRequest: res.badRequest, error: res.error };
-  }
+    if (!res.data) {
+      return { data: null, badRequest: res.badRequest, error: res.error };
+    }
 
-  const data = res.data.blocks.map((b) => ({
-    block: b.l2_block_number,
-    tps: b.tps,
-  }));
+    const data = res.data.blocks.map((b) => ({
+      block: b.l2_block_number,
+      tps: b.tps,
+    }));
 
-  return { data, badRequest: res.badRequest, error: res.error };
+    return { data, badRequest: res.badRequest, error: res.error };
+  });
 };
 
 export const fetchCloudCost = async (
   range: TimeRange,
 ): Promise<RequestResult<number>> => {
-  const url = `${API_BASE}/cloud-cost?range=${range}`;
-  const res = await fetchJson<{ cost_usd: number }>(url);
-  return {
-    data: res.data?.cost_usd ?? null,
-    badRequest: res.badRequest,
-    error: res.error,
-  };
+  const key = 'metrics:cloudCost';
+  return cached(key, { range }, dashboardCache, async () => {
+    const url = `${API_BASE}/cloud-cost?range=${range}`;
+    const res = await fetchJson<{ cost_usd: number }>(url);
+    return {
+      data: res.data?.cost_usd ?? null,
+      badRequest: res.badRequest,
+      error: res.error,
+    };
+  });
 };

--- a/dashboard/tests/apiService.test.ts
+++ b/dashboard/tests/apiService.test.ts
@@ -8,6 +8,7 @@ import {
   fetchBlockTransactions,
   fetchAvgL2Tps,
 } from '../services/apiService.ts';
+import { cacheManager } from '../utils/smartCache';
 
 const originalFetch = globalThis.fetch;
 
@@ -15,6 +16,7 @@ beforeEach(() => {
   vi.stubGlobal('window', {
     dispatchEvent: vi.fn(),
   });
+  cacheManager.invalidateAll();
 });
 
 // helper to create mock fetch response


### PR DESCRIPTION
## Summary
- cache apiService responses with SmartCache
- reset SmartCache in apiService tests

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6842cae505008328a668f3e20c69df3c