### PR TITLE
Fix grouped metrics recomputation

### DIFF
--- a/dashboard/components/views/DashboardView.tsx
+++ b/dashboard/components/views/DashboardView.tsx
@@ -57,14 +57,15 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
     [metricsData.metrics, selectedSequencer, isEconomicsView],
   );
 
-  const groupedMetrics = visibleMetrics.reduce<Record<string, MetricData[]>>(
-    (acc, m) => {
-      const group = m.group ?? 'Other';
-      if (!acc[group]) acc[group] = [];
-      acc[group].push(m);
-      return acc;
-    },
-    {},
+  const groupedMetrics = React.useMemo(
+    () =>
+      visibleMetrics.reduce<Record<string, MetricData[]>>((acc, m) => {
+        const group = m.group ?? 'Other';
+        if (!acc[group]) acc[group] = [];
+        acc[group].push(m);
+        return acc;
+      }, {}),
+    [visibleMetrics],
   );
 
   const groupOrder = isEconomicsView


### PR DESCRIPTION
## Summary
- use `React.useMemo` for grouped metrics in DashboardView

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6842e0d331d08328b607889269588969