### PR TITLE
Fix redundant navigation in dashboard

### DIFF
--- a/dashboard/utils/navigationUtils.ts
+++ b/dashboard/utils/navigationUtils.ts
@@ -160,5 +160,11 @@ export const safeNavigate = (
   replace = false,
 ) => {
   const sanitized = sanitizeUrl(url);
+  if (
+    typeof window !== 'undefined' &&
+    sanitized === window.location.pathname + window.location.search
+  ) {
+    return;
+  }
   routerNavigate(sanitized, { replace });
 };


### PR DESCRIPTION
## Summary
- avoid navigating when URL already matches current location

## Testing
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_6842e1b01ce48328b57e2adddae3a2d0