### PR TITLE
Add L2 header timestamp to insert logs

### DIFF
--- a/crates/driver/src/lib.rs
+++ b/crates/driver/src/lib.rs
@@ -463,7 +463,11 @@ impl Driver {
                     if let Err(e) = self.clickhouse.insert_l2_header(&event).await {
                         tracing::error!(block_number = header.number, err = %e, "Failed to insert L2 header");
                     } else {
-                        info!(l2_header = header.number, "Inserted L2 header");
+                        info!(
+                            l2_header = header.number,
+                            block_ts = header.timestamp,
+                            "Inserted L2 header"
+                        );
                     }
                 }
                 Err(e) => {


### PR DESCRIPTION
## Summary
- log the block timestamp when inserting an L2 header

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6842e27013d0832886eb7a022bf3db92