### PR TITLE
Remove chart from L2 Block Times view

### DIFF
--- a/dashboard/config/tableConfig.ts
+++ b/dashboard/config/tableConfig.ts
@@ -233,19 +233,6 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
       { key: 'timestamp', label: 'Interval (s)' },
     ],
     mapData: (data) => data as Record<string, string | number>[],
-    chart: (data) => {
-      const BlockTimeChart = React.lazy(() =>
-        import('../components/BlockTimeChart').then((m) => ({
-          default: m.BlockTimeChart,
-        })),
-      );
-      return React.createElement(BlockTimeChart, {
-        data,
-        lineColor: '#FAA43A',
-        histogram: true,
-        seconds: true,
-      });
-    },
     useUnlimitedData: true,
     urlKey: 'l2-block-times',
   },


### PR DESCRIPTION
## Summary
- remove the chart from the L2 Block Times detailed table view

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6843424730c0832888cf91651503145a