### PR TITLE
Remove Batch Posting Cadence chart

### DIFF
--- a/dashboard/config/tableConfig.ts
+++ b/dashboard/config/tableConfig.ts
@@ -149,18 +149,6 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
         value: blockLink(d.value as number),
         timestamp: d.timestamp,
       })),
-    chart: (data) => {
-      const BlockTimeChart = React.lazy(() =>
-        import('../components/BlockTimeChart').then((m) => ({
-          default: m.BlockTimeChart,
-        })),
-      );
-      return React.createElement(BlockTimeChart, {
-        data,
-        lineColor: '#FF9DA7',
-        seconds: true,
-      });
-    },
     urlKey: 'batch-posting-cadence',
   },
 


### PR DESCRIPTION
## Summary
- remove chart from Batch Posting Cadence detailed table

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_684342e6f180832898f12e440e4f1eee