### PR TITLE
Fix preconf data fetch path

### DIFF
--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -252,8 +252,12 @@ export interface PreconfData {
 export const fetchPreconfData = async (): Promise<
   RequestResult<PreconfData>
 > => {
-  const url = `${API_BASE}/preconf-data`;
-  return fetchJson<PreconfData>(url);
+  const res = await fetchDashboardData('1h');
+  return {
+    data: res.data?.preconf_data ?? null,
+    badRequest: res.badRequest,
+    error: res.error,
+  };
 };
 
 export const fetchL2HeadNumber = async (): Promise<RequestResult<number>> => {

--- a/dashboard/tests/apiService.test.ts
+++ b/dashboard/tests/apiService.test.ts
@@ -57,7 +57,7 @@ describe('apiService', () => {
   });
 
   it('fetches active sequencer addresses from preconf', async () => {
-    globalThis.fetch = mockFetch({ candidates: ['a', 'b'] });
+    globalThis.fetch = mockFetch({ preconf_data: { candidates: ['a', 'b'] } });
     const gateways = await fetchActiveSequencerAddresses();
     expect(gateways.data).toStrictEqual(['a', 'b']);
   });

--- a/dashboard/tests/app.integration.test.ts
+++ b/dashboard/tests/app.integration.test.ts
@@ -57,10 +57,12 @@ const responses: Record<string, Record<string, unknown>> = {
   '/v1/batch-posting-cadence?range=1h': { batch_posting_cadence_ms: 120000 },
   '/v1/avg-prove-time?range=1h': { avg_prove_time_ms: 1500 },
   '/v1/avg-verify-time?range=1h': { avg_verify_time_ms: 2500 },
-  '/v1/preconf-data': {
-    candidates: ['gw1', 'gw2'],
-    current_operator: '0xaaa',
-    next_operator: '0xbbb',
+  '/v1/dashboard-data?range=1h': {
+    preconf_data: {
+      candidates: ['gw1', 'gw2'],
+      current_operator: '0xaaa',
+      next_operator: '0xbbb',
+    },
   },
   '/v1/reorgs?range=1h': {
     events: [


### PR DESCRIPTION
## Summary
- update preconf-data fetcher to use `/dashboard-data`
- adjust integration and unit tests

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6843438b94548328bb41132135d258ec