### PR TITLE
Fix dashboard table navigation flash

### DIFF
--- a/dashboard/hooks/useTimeRangeSync.ts
+++ b/dashboard/hooks/useTimeRangeSync.ts
@@ -43,8 +43,9 @@ export const useTimeRangeSync = () => {
       }
 
       // Use replace to avoid adding history entries for time range changes
+      // Only update query parameters without forcing navigation to '/'
       navigate(
-        { pathname: '/', search: newParams.toString() },
+        { search: newParams.toString() },
         { replace: true },
       );
     },


### PR DESCRIPTION
## Summary
- prevent dashboard time range sync from forcing navigation to `/`

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6847f5a7c3548328a2b52f0107742e01