### PR TITLE
Implement fetch cancellation

### DIFF
--- a/dashboard/hooks/useDataFetcher.ts
+++ b/dashboard/hooks/useDataFetcher.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import useSWR from 'swr';
 import { TimeRange } from '../types';
 import { useSearchParams } from 'react-router-dom';
@@ -11,6 +11,7 @@ interface UseDataFetcherProps {
   fetchMetricsData: (
     timeRange: TimeRange,
     selectedSequencer: string | null,
+    signal?: AbortSignal,
   ) => Promise<any>;
   updateChartsData: (data: any) => void;
   refreshRate: number;
@@ -30,6 +31,8 @@ export const useDataFetcher = ({
   const [isTimeRangeChanging, setIsTimeRangeChanging] = useState(false);
   const [lastFetchedTimeRange, setLastFetchedTimeRange] =
     useState<TimeRange | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+  const requestRangeRef = useRef<TimeRange>(timeRange);
 
   // Memoize the specific value we need to prevent infinite re-renders
   const viewParam = searchParams.get('view');
@@ -42,16 +45,41 @@ export const useDataFetcher = ({
     ? null
     : ['metrics', timeRange, selectedSequencer];
 
+  useEffect(() => {
+    abortRef.current?.abort();
+  }, [timeRange]);
+
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort();
+    };
+  }, []);
+
+  const fetcher = () => {
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    requestRangeRef.current = timeRange;
+    return fetchMetricsData(timeRange, selectedSequencer, controller.signal);
+  };
+
   const { data, mutate, isLoading, isValidating } = useSWR(
     fetchKey,
-    () => fetchMetricsData(timeRange, selectedSequencer),
+    fetcher,
     {
       refreshInterval: Math.max(refreshRate, 60000),
       revalidateOnFocus: false,
       refreshWhenHidden: false,
       onSuccess: () => {
-        setIsTimeRangeChanging(false);
-        setLastFetchedTimeRange(timeRange);
+        if (requestRangeRef.current === timeRange) {
+          setIsTimeRangeChanging(false);
+          setLastFetchedTimeRange(timeRange);
+        }
+      },
+      onError: () => {
+        if (requestRangeRef.current === timeRange) {
+          setIsTimeRangeChanging(false);
+        }
       },
     },
   );
@@ -84,11 +112,12 @@ export const useDataFetcher = ({
 
   useEffect(() => {
     if (!data) return;
+    if (lastFetchedTimeRange !== timeRange) return;
     updateLastRefresh();
     if (data.chartData) {
       updateChartsData(data.chartData);
     }
-  }, [data, updateChartsData, updateLastRefresh]);
+  }, [data, updateChartsData, updateLastRefresh, timeRange, lastFetchedTimeRange]);
 
   // Enhanced loading state that considers both SWR loading and time range changes
   const isLoadingData = isLoading || isValidating || isTimeRangeChanging;


### PR DESCRIPTION
## Summary
- cancel previous metrics requests when time range changes
- ignore outdated responses
- update charts only for the latest range

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6847f78fc7d883289a182e326b677924