### PR TITLE
Fix dashboard table double fetch

### DIFF
--- a/dashboard/hooks/useTableActions.ts
+++ b/dashboard/hooks/useTableActions.ts
@@ -1,4 +1,5 @@
 import React, { useState, useCallback } from 'react';
+import { useLocation } from 'react-router-dom';
 import { TimeRange } from '../types';
 import { TABLE_CONFIGS } from '../config/tableConfig';
 import { getSequencerAddress } from '../sequencerConfig';
@@ -46,6 +47,7 @@ export const useTableActions = (
   const [tableLoading, setTableLoading] = useState<boolean>(false);
   const [seqDistTxPage, setSeqDistTxPage] = useState<number>(0);
   const { navigateToTable } = useRouterNavigation();
+  const location = useLocation();
 
   const setTableUrl = useCallback(
     (
@@ -114,6 +116,13 @@ export const useTableActions = (
     ) => {
       const config = TABLE_CONFIGS[tableKey];
       if (!config) return;
+
+      const onTableRoute = location.pathname.startsWith('/table/');
+
+      if (!onTableRoute) {
+        setTableUrl(config.urlKey, { range, ...extraParams });
+        return;
+      }
 
       setTableLoading(true);
       setTimeRange(range);
@@ -229,6 +238,7 @@ export const useTableActions = (
       openTable,
       setTableUrl,
       setTableView,
+      location.pathname,
     ],
   );
 


### PR DESCRIPTION
## Summary
- avoid fetching data twice when navigating to a table

## Testing
- `just ci`
- `npm run check`
- `npm run lint:whitespace`


------
https://chatgpt.com/codex/tasks/task_b_6847f856b1708328b8fbaffbc1c5547f