### PR TITLE
Fix ReorgDetector default

### DIFF
--- a/crates/extractor/src/lib.rs
+++ b/crates/extractor/src/lib.rs
@@ -415,9 +415,14 @@ pub struct ReorgDetector {
     head_number: BlockNumber,
 }
 
+impl Default for ReorgDetector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ReorgDetector {
     /// Create a new reorg detector
-    #[allow(clippy::new_without_default)]
     pub const fn new() -> Self {
         Self { head_number: 0 }
     }


### PR DESCRIPTION
## Summary
- implement `Default` for `ReorgDetector` to remove lint suppression

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6847f9bc459883288ea89ae08c8ca937