### PR TITLE
Fix DataTable pagination reset

### DIFF
--- a/dashboard/components/DataTable.tsx
+++ b/dashboard/components/DataTable.tsx
@@ -59,8 +59,13 @@ export const DataTable: React.FC<DataTableProps> = ({
 }) => {
   const [page, setPage] = React.useState(0);
 
+  const prevRowsLength = React.useRef(rows.length);
+
   React.useEffect(() => {
-    setPage(0);
+    if (rows.length !== prevRowsLength.current) {
+      setPage(0);
+    }
+    prevRowsLength.current = rows.length;
   }, [rows]);
 
   React.useEffect(() => {


### PR DESCRIPTION
## Summary
- avoid page index reset when row data updates without changing length

## Testing
- `npm run lint:whitespace`
- `npm run check`
- `npm run test`
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6847f89525648328b6d828ffa75cb189