### PR TITLE
Fix StrictMode double fetch

### DIFF
--- a/dashboard/index.tsx
+++ b/dashboard/index.tsx
@@ -13,16 +13,23 @@ if (!rootElement) {
 }
 
 const root = ReactDOM.createRoot(rootElement);
+
+const app = (
+  <ToastProvider>
+    <ErrorBoundary>
+      <ErrorProvider>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </ErrorProvider>
+    </ErrorBoundary>
+  </ToastProvider>
+);
+
 root.render(
-  <React.StrictMode>
-    <ToastProvider>
-      <ErrorBoundary>
-        <ErrorProvider>
-          <BrowserRouter>
-            <App />
-          </BrowserRouter>
-        </ErrorProvider>
-      </ErrorBoundary>
-    </ToastProvider>
-  </React.StrictMode>,
+  process.env.NODE_ENV === 'development' ? (
+    <React.StrictMode>{app}</React.StrictMode>
+  ) : (
+    app
+  ),
 );


### PR DESCRIPTION
## Summary
- conditionally wrap App with React.StrictMode only during development

This ensures routes like `/table/l2-tps` mount once in production, issuing only a single GET request.

## Testing
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_684803b1f9008328aeadbe784ae0009a