### PR TITLE
Fix time range sync loops

### DIFF
--- a/dashboard/hooks/useTimeRangeSync.ts
+++ b/dashboard/hooks/useTimeRangeSync.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { TimeRange } from '../types';
 
@@ -24,6 +24,9 @@ export const useTimeRangeSync = () => {
 
   const [timeRange, setTimeRangeState] =
     useState<TimeRange>(getInitialTimeRange);
+
+  // Track the last processed URL to avoid redundant state updates
+  const prevSearchRef = useRef(location.search);
 
   // Update time range and sync with URL
   const setTimeRange = useCallback(
@@ -55,6 +58,9 @@ export const useTimeRangeSync = () => {
 
   // Sync state when URL changes (e.g., browser back/forward)
   useEffect(() => {
+    if (prevSearchRef.current === location.search) return;
+
+    prevSearchRef.current = location.search;
     const urlRange = getInitialTimeRange();
     if (urlRange !== timeRange) {
       setTimeRangeState(urlRange);


### PR DESCRIPTION
## Summary
- track previous URL in `useTimeRangeSync`
- avoid redundant state updates when the range doesn't change

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_684802cac38483288b5ef8e9b264bd34