### PR TITLE
Fix table route dependencies

### DIFF
--- a/dashboard/components/routes/TableRoute.tsx
+++ b/dashboard/components/routes/TableRoute.tsx
@@ -135,8 +135,7 @@ export const TableRoute: React.FC = () => {
     searchParams,
     currentTimeRange,
     selectedSequencer,
-    chartsData,
-    metricsData,
+    metricsData.setErrorMessage,
   ]);
 
   const handleBack = () => {

--- a/dashboard/hooks/useDashboardController.ts
+++ b/dashboard/hooks/useDashboardController.ts
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import { useMetricsData } from './useMetricsData';
 import { useChartsData } from './useChartsData';
 import { useBlockData } from './useBlockData';
@@ -75,9 +76,9 @@ export const useDashboardController = () => {
   };
 
   // Create a TPS table opener that uses the generic table function
-  const openTpsTable = () => {
-    openGenericTable('l2-tps', timeRange);
-  };
+  const openTpsTable = useCallback(() => {
+    openGenericTable('l2-tps');
+  }, [openGenericTable]);
 
   return {
     // State

--- a/dashboard/hooks/useTableActions.ts
+++ b/dashboard/hooks/useTableActions.ts
@@ -121,7 +121,9 @@ export const useTableActions = (
 
       if (onTableRoute) {
         setTableLoading(true);
-        setTimeRange(range);
+        if (range !== timeRange) {
+          setTimeRange(range);
+        }
       }
 
       setTableUrl(config.urlKey, { range, ...extraParams });


### PR DESCRIPTION
## Summary
- stabilize TableRoute effect dependencies
- avoid redundant time range updates in openGenericTable
- memoize openTpsTable callback

## Testing
- `npm run lint`
- `npm run check`
- `npm run test`
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_68481208f27c83289eb95c71178ede36