### PR TITLE
Use SWR for ETH price caching

### DIFF
--- a/dashboard/components/ProfitCalculator.tsx
+++ b/dashboard/components/ProfitCalculator.tsx
@@ -1,7 +1,7 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { MetricData } from '../types';
 import { findMetricValue } from '../utils';
-import { getEthPrice } from '../services/priceService';
+import { useEthPrice } from '../services/priceService';
 
 interface ProfitCalculatorProps {
   metrics: MetricData[];
@@ -15,20 +15,10 @@ export const ProfitCalculator: React.FC<ProfitCalculatorProps> = ({
 
   const [cloudCost, setCloudCost] = useState(0);
   const [proverCost, setProverCost] = useState(0);
-  const [ethPrice, setEthPrice] = useState(0);
-  const [ethPriceError, setEthPriceError] = useState(false);
-
-  useEffect(() => {
-    getEthPrice()
-      .then((p) => {
-        setEthPrice(p);
-        setEthPriceError(false);
-      })
-      .catch((err) => {
-        console.error('Failed to fetch ETH price', err);
-        setEthPriceError(true);
-      });
-  }, []);
+  const {
+    data: ethPrice = 0,
+    error: ethPriceError,
+  } = useEthPrice();
 
   const profit = fee * ethPrice - cloudCost - proverCost;
 

--- a/dashboard/services/priceService.ts
+++ b/dashboard/services/priceService.ts
@@ -1,48 +1,66 @@
-export const getEthPrice = async (): Promise<number> => {
-  const CACHE_KEY = 'ethPrice';
-  const oneHour = 3600_000;
+import useSWR from 'swr'
+import { useEffect } from 'react'
 
-  if (typeof localStorage !== 'undefined') {
-    const cached = localStorage.getItem(CACHE_KEY);
-    if (cached) {
-      try {
-        const { price, timestamp } = JSON.parse(cached) as {
-          price: number;
-          timestamp: number;
-        };
-        if (Date.now() - timestamp < oneHour && typeof price === 'number') {
-          return price;
+const CACHE_KEY = 'ethPrice'
+const API_URL =
+  'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd'
+
+export const getEthPrice = async (): Promise<number> => {
+  const res = await fetch(API_URL)
+  if (!res.ok) {
+    throw new Error(`Failed to fetch ETH price: ${res.status}`)
+  }
+
+  const data = await res.json()
+  const price = data?.ethereum?.usd
+  if (typeof price !== 'number') {
+    throw new Error('Invalid ETH price response format')
+  }
+
+  return price
+}
+
+export const useEthPrice = () => {
+  const fallbackData = typeof localStorage === 'undefined'
+    ? undefined
+    : (() => {
+        const cached = localStorage.getItem(CACHE_KEY)
+        if (cached) {
+          try {
+            const { price, timestamp } = JSON.parse(cached) as {
+              price: number
+              timestamp: number
+            }
+            if (
+              Date.now() - timestamp < 3600_000 &&
+              typeof price === 'number'
+            ) {
+              return price
+            }
+          } catch {
+            // ignore malformed cache
+          }
         }
+        return undefined
+      })()
+
+  const swr = useSWR<number>('ethPrice', getEthPrice, {
+    revalidateOnFocus: false,
+    fallbackData,
+  })
+
+  useEffect(() => {
+    if (typeof localStorage !== 'undefined' && swr.data !== undefined) {
+      try {
+        localStorage.setItem(
+          CACHE_KEY,
+          JSON.stringify({ price: swr.data, timestamp: Date.now() })
+        )
       } catch {
-        // ignore malformed cache
+        // ignore storage errors
       }
     }
-  }
+  }, [swr.data])
 
-  const res = await fetch(
-    'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd',
-  );
-  if (!res.ok) {
-    throw new Error(`Failed to fetch ETH price: ${res.status}`);
-  }
-  
-  const data = await res.json();
-  if (!data?.ethereum?.usd || typeof data.ethereum.usd !== 'number') {
-    throw new Error('Invalid ETH price response format');
-  }
-  
-  const price = data.ethereum.usd;
-
-  if (typeof localStorage !== 'undefined') {
-    try {
-      localStorage.setItem(
-        CACHE_KEY,
-        JSON.stringify({ price, timestamp: Date.now() }),
-      );
-    } catch {
-      // ignore storage errors
-    }
-  }
-
-  return price;
-};
+  return swr
+}

--- a/dashboard/tests/priceService.test.ts
+++ b/dashboard/tests/priceService.test.ts
@@ -1,89 +1,41 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { getEthPrice } from '../services/priceService.ts';
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { getEthPrice } from '../services/priceService.ts'
 
-const originalFetch = globalThis.fetch;
+const originalFetch = globalThis.fetch
 
 function mockFetch(price: number, ok = true) {
   return vi.fn(async () => ({
     ok,
     status: ok ? 200 : 500,
     json: async () => ({ ethereum: { usd: price } }),
-  })) as unknown as typeof fetch;
+  })) as unknown as typeof fetch
 }
 
 function mockFetchWithInvalidResponse() {
   return vi.fn(async () => ({
     ok: true,
     json: async () => ({ invalid: 'response' }),
-  })) as unknown as typeof fetch;
+  })) as unknown as typeof fetch
 }
 
-const store: Record<string, string> = {};
-
-beforeEach(() => {
-  globalThis.localStorage = {
-    getItem: (k: string) => (k in store ? store[k] : null),
-    setItem: (k: string, v: string) => {
-      store[k] = v;
-    },
-    removeItem: (k: string) => {
-      delete store[k];
-    },
-    clear: () => {
-      for (const k in store) delete store[k];
-    },
-    key: () => null,
-    length: 0,
-  } as Storage;
-});
-
 afterEach(() => {
-  globalThis.fetch = originalFetch;
-  for (const k in store) delete store[k];
-});
+  globalThis.fetch = originalFetch
+})
 
 describe('getEthPrice', () => {
-  it('caches price for one hour', async () => {
-    globalThis.fetch = mockFetch(2000);
-    const first = await getEthPrice();
-    expect(first).toBe(2000);
-    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
-
-    const second = await getEthPrice();
-    expect(second).toBe(2000);
-    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
-  });
-
-  it('refreshes after cache expiry', async () => {
-    store.ethPrice = JSON.stringify({ price: 1500, timestamp: Date.now() - 3600_001 });
-    globalThis.fetch = mockFetch(1800);
-    const price = await getEthPrice();
-    expect(price).toBe(1800);
-  });
+  it('fetches price successfully', async () => {
+    globalThis.fetch = mockFetch(2000)
+    const price = await getEthPrice()
+    expect(price).toBe(2000)
+  })
 
   it('handles fetch failure', async () => {
-    globalThis.fetch = mockFetch(0, false);
-    await expect(getEthPrice()).rejects.toThrow('Failed to fetch ETH price: 500');
-  });
+    globalThis.fetch = mockFetch(0, false)
+    await expect(getEthPrice()).rejects.toThrow('Failed to fetch ETH price: 500')
+  })
 
   it('handles invalid response format', async () => {
-    globalThis.fetch = mockFetchWithInvalidResponse();
-    await expect(getEthPrice()).rejects.toThrow('Invalid ETH price response format');
-  });
-
-  it('handles malformed cache data', async () => {
-    store.ethPrice = 'invalid json';
-    globalThis.fetch = mockFetch(2500);
-    const price = await getEthPrice();
-    expect(price).toBe(2500);
-    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
-  });
-
-  it('handles non-numeric price in cache', async () => {
-    store.ethPrice = JSON.stringify({ price: 'invalid', timestamp: Date.now() });
-    globalThis.fetch = mockFetch(3000);
-    const price = await getEthPrice();
-    expect(price).toBe(3000);
-    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
-  });
-});
+    globalThis.fetch = mockFetchWithInvalidResponse()
+    await expect(getEthPrice()).rejects.toThrow('Invalid ETH price response format')
+  })
+})


### PR DESCRIPTION
## Summary
- replace local price storage with `useSWR` hook
- display ETH price via new hook in ProfitCalculator
- simplify price service tests

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_684817a848a083288d7f513132a39353