### PR TITLE
Simplify block head polling

### DIFF
--- a/dashboard/hooks/useBlockData.ts
+++ b/dashboard/hooks/useBlockData.ts
@@ -1,32 +1,33 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useCallback } from 'react';
+import useSWR from 'swr';
 import { fetchL1HeadNumber, fetchL2HeadNumber } from '../services/apiService';
 import { MetricData } from '../types';
 
 export const useBlockData = () => {
-  const [l2HeadBlock, setL2HeadBlock] = useState<string>('0');
-  const [l1HeadBlock, setL1HeadBlock] = useState<string>('0');
-  const pollId = useRef<ReturnType<typeof setInterval> | null>(null);
+  const {
+    data: l1,
+    mutate: mutateL1,
+  } = useSWR('l1-head-number', fetchL1HeadNumber, {
+    refreshInterval: 60000,
+    revalidateOnFocus: false,
+    refreshWhenHidden: false,
+  });
+
+  const {
+    data: l2,
+    mutate: mutateL2,
+  } = useSWR('l2-head-number', fetchL2HeadNumber, {
+    refreshInterval: 60000,
+    revalidateOnFocus: false,
+    refreshWhenHidden: false,
+  });
+
+  const l1HeadBlock = l1?.data != null ? l1.data.toLocaleString() : '0';
+  const l2HeadBlock = l2?.data != null ? l2.data.toLocaleString() : '0';
 
   const updateBlockHeads = useCallback(async () => {
-    try {
-      const [l1, l2] = await Promise.all([
-        fetchL1HeadNumber(),
-        fetchL2HeadNumber(),
-      ]);
-
-      if (l1.data !== null) {
-        const value = l1.data.toLocaleString();
-        setL1HeadBlock(value);
-      }
-
-      if (l2.data !== null) {
-        const value = l2.data.toLocaleString();
-        setL2HeadBlock(value);
-      }
-    } catch (error) {
-      console.error('Failed to update block heads:', error);
-    }
-  }, []);
+    await Promise.all([mutateL1(), mutateL2()]);
+  }, [mutateL1, mutateL2]);
 
   const updateMetricsWithBlockHeads = useCallback(
     (metrics: MetricData[]): MetricData[] => {
@@ -43,37 +44,6 @@ export const useBlockData = () => {
     [l1HeadBlock, l2HeadBlock],
   );
 
-  useEffect(() => {
-    const startPolling = () => {
-      pollId.current = setInterval(() => {
-        if (document.visibilityState === 'visible') {
-          void updateBlockHeads();
-        }
-      }, 60000);
-    };
-
-    if (document.visibilityState === 'visible') {
-      void updateBlockHeads();
-      startPolling();
-    }
-
-    const onVisibilityChange = () => {
-      if (document.visibilityState === 'visible') {
-        void updateBlockHeads();
-        if (!pollId.current) startPolling();
-      } else if (pollId.current) {
-        clearInterval(pollId.current);
-        pollId.current = null;
-      }
-    };
-
-    document.addEventListener('visibilitychange', onVisibilityChange);
-
-    return () => {
-      if (pollId.current) clearInterval(pollId.current);
-      document.removeEventListener('visibilitychange', onVisibilityChange);
-    };
-  }, [updateBlockHeads]);
 
   return {
     l2HeadBlock,


### PR DESCRIPTION
## Summary
- simplify `useBlockData` by leveraging SWR refreshInterval

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6848179b22a48328a01ba51868885275