### PR TITLE
Prefill economics calc costs

### DIFF
--- a/dashboard/components/ProfitCalculator.tsx
+++ b/dashboard/components/ProfitCalculator.tsx
@@ -13,8 +13,8 @@ export const ProfitCalculator: React.FC<ProfitCalculatorProps> = ({
   const feeStr = findMetricValue(metrics, 'transaction fee');
   const fee = parseFloat(feeStr.replace(/[^0-9.]/g, '')) || 0;
 
-  const [cloudCost, setCloudCost] = useState(0);
-  const [proverCost, setProverCost] = useState(0);
+  const [cloudCost, setCloudCost] = useState(100);
+  const [proverCost, setProverCost] = useState(100);
   const {
     data: ethPrice = 0,
     error: ethPriceError,


### PR DESCRIPTION
## Summary
- prefill $100 for server and prover costs in the profit calculator

## Testing
- `npm run check`
- `npm run test`
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_684930471e2c8328963316182c8b304a