### PR TITLE
feat(dashboard): scale profit calc by time range

### DIFF
--- a/dashboard/components/views/DashboardView.tsx
+++ b/dashboard/components/views/DashboardView.tsx
@@ -140,7 +140,9 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
           economicsView={isEconomicsView}
         />
 
-        {isEconomicsView && <ProfitCalculator metrics={metricsData.metrics} />}
+        {isEconomicsView && (
+          <ProfitCalculator metrics={metricsData.metrics} timeRange={timeRange} />
+        )}
 
         {!isEconomicsView && (
           <ChartsGrid

--- a/dashboard/tests/profitCalculator.test.ts
+++ b/dashboard/tests/profitCalculator.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { ProfitCalculator } from '../components/ProfitCalculator';
+import * as priceService from '../services/priceService';
+
+describe('ProfitCalculator', () => {
+  it('calculates profit for time range', () => {
+    vi
+      .spyOn(priceService, 'useEthPrice')
+      .mockReturnValue({ data: 2000 } as any);
+    const html = renderToStaticMarkup(
+      React.createElement(ProfitCalculator, {
+        metrics: [{ title: 'L2 Transaction Fee', value: '1 ETH' }],
+        timeRange: '1h',
+      }),
+    );
+    expect(html.includes('1999.72')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- scale ProfitCalculator costs by selected time range
- pass time range from DashboardView
- add ProfitCalculator unit test

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_684933e8ee9c8328be5d2cc9932943e9