### PR TITLE
Add profitability chart

### DIFF
--- a/dashboard/components/ProfitabilityChart.tsx
+++ b/dashboard/components/ProfitabilityChart.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import { useEthPrice } from '../services/priceService';
+import { MetricData } from '../types';
+import { findMetricValue } from '../utils';
+
+interface ProfitabilityChartProps {
+  metrics: MetricData[];
+  hours: number; // hours represented by the metric values
+}
+
+export const ProfitabilityChart: React.FC<ProfitabilityChartProps> = ({
+  metrics,
+  hours,
+}) => {
+  const feeStr = findMetricValue(metrics, 'transaction fee');
+  const costStr = findMetricValue(metrics, 'cloud cost');
+  const l2TxFee = parseFloat(feeStr.replace(/[^0-9.]/g, '')) || null;
+  const cloudCost = parseFloat(costStr.replace(/[^0-9.]/g, '')) || null;
+  const { data: ethPrice = 0 } = useEthPrice();
+
+  if (l2TxFee == null || cloudCost == null || hours === 0) {
+    return (
+      <div className="flex items-center justify-center h-full text-gray-500">
+        No data available
+      </div>
+    );
+  }
+
+  const profitPerHour = (l2TxFee * ethPrice - cloudCost) / hours;
+
+  const data = Array.from({ length: 12 }, (_, i) => {
+    const month = i + 1;
+    const hoursInMonth = 30 * 24 * month;
+    return {
+      month,
+      profit: profitPerHour * hoursInMonth,
+    };
+  });
+
+  return (
+    <ResponsiveContainer width="100%" height={240}>
+      <LineChart
+        data={data}
+        margin={{ top: 5, right: 40, left: 20, bottom: 40 }}
+      >
+        <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
+        <XAxis
+          dataKey="month"
+          stroke="#666666"
+          fontSize={12}
+          label={{
+            value: 'Month',
+            position: 'insideBottom',
+            offset: -10,
+            fontSize: 10,
+            fill: '#666666',
+          }}
+        />
+        <YAxis
+          stroke="#666666"
+          fontSize={12}
+          domain={[0, 'auto']}
+          tickFormatter={(v: number) => `$${v.toFixed(0)}`}
+          label={{
+            value: 'Profit (USD)',
+            angle: -90,
+            position: 'insideLeft',
+            offset: -16,
+            fontSize: 10,
+            fill: '#666666',
+          }}
+        />
+        <Tooltip
+          labelFormatter={(v: number) => `Month ${v}`}
+          formatter={(value: number) => [`$${value.toFixed(2)}`, 'Profit']}
+          contentStyle={{
+            backgroundColor: 'rgba(255,255,255,0.8)',
+            borderColor: '#8884d8',
+          }}
+          labelStyle={{ color: '#333' }}
+        />
+        <Line
+          type="monotone"
+          dataKey="profit"
+          stroke="#8884d8"
+          strokeWidth={2}
+          dot={false}
+          name="Profit"
+        />
+      </LineChart>
+    </ResponsiveContainer>
+  );
+};

--- a/dashboard/components/views/DashboardView.tsx
+++ b/dashboard/components/views/DashboardView.tsx
@@ -3,6 +3,7 @@ import { ErrorDisplay } from '../layout/ErrorDisplay';
 import { MetricsGrid } from '../layout/MetricsGrid';
 import { ChartsGrid } from '../layout/ChartsGrid';
 import { ProfitCalculator } from '../ProfitCalculator';
+import { ProfitabilityChart } from '../ProfitabilityChart';
 import { TimeRange, MetricData } from '../../types';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
@@ -46,6 +47,11 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const isEconomicsView = searchParams.get('view') === 'economics';
+  const hoursMap: Record<TimeRange, number> = {
+    '15m': 0.25,
+    '1h': 1,
+    '24h': 24,
+  };
 
   const visibleMetrics = React.useMemo(
     () =>
@@ -75,10 +81,10 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
   const skeletonGroupCounts: Record<string, number> = isEconomicsView
     ? { 'Network Economics': 1 }
     : {
-        'Network Performance': 5,
-        'Network Health': 4,
-        Sequencers: 3,
-      };
+      'Network Performance': 5,
+      'Network Health': 4,
+      Sequencers: 3,
+    };
 
   const displayGroupName = useCallback(
     (group: string): string => {
@@ -141,7 +147,15 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
         />
 
         {isEconomicsView && (
-          <ProfitCalculator metrics={metricsData.metrics} timeRange={timeRange} />
+          <>
+            <ProfitCalculator metrics={metricsData.metrics} timeRange={timeRange} />
+            <div className="mt-6">
+              <ProfitabilityChart
+                metrics={metricsData.metrics}
+                hours={hoursMap[timeRange]}
+              />
+            </div>
+          </>
         )}
 
         {!isEconomicsView && (

--- a/dashboard/hooks/useDataFetcher.ts
+++ b/dashboard/hooks/useDataFetcher.ts
@@ -69,7 +69,7 @@ export const useDataFetcher = ({
         baseFee: data.baseFee,
         l2Block: data.l2Block,
         l1Block: data.l1Block,
-        cloudCost: null,
+        cloudCost: data.cloudCost,
       };
 
       const metrics = createMetrics(metricsInput);

--- a/dashboard/tests/dataFetcher.test.ts
+++ b/dashboard/tests/dataFetcher.test.ts
@@ -85,6 +85,7 @@ describe('dataFetcher', () => {
       fetchL2Fees: ok({ priority_fee: 1, base_fee: 2 }),
       fetchL2HeadBlock: ok(2),
       fetchL1HeadBlock: ok(3),
+      fetchCloudCost: ok(4),
     });
 
     const res = await fetchEconomicsData('1h', null);
@@ -92,7 +93,8 @@ describe('dataFetcher', () => {
     expect(res.baseFee).toBe(2);
     expect(res.l2Block).toBe(2);
     expect(res.l1Block).toBe(3);
-    expect(res.badRequestResults).toHaveLength(3);
+    expect(res.cloudCost).toBe(4);
+    expect(res.badRequestResults).toHaveLength(4);
   });
 
   it('resets isTimeRangeChanging on fetch error', async () => {

--- a/dashboard/utils/dataFetcher.ts
+++ b/dashboard/utils/dataFetcher.ts
@@ -12,6 +12,7 @@ import {
   fetchL2Fees,
   fetchL2HeadBlock,
   fetchL1HeadBlock,
+  fetchCloudCost,
 } from '../services/apiService';
 
 export interface MainDashboardData {
@@ -44,6 +45,7 @@ export interface EconomicsData {
   baseFee: number | null;
   l2Block: number | null;
   l1Block: number | null;
+  cloudCost: number | null;
   badRequestResults: any[];
 }
 
@@ -118,13 +120,14 @@ export const fetchEconomicsData = async (
   timeRange: TimeRange,
   selectedSequencer: string | null,
 ): Promise<EconomicsData> => {
-  const [l2FeesRes, l2BlockRes, l1BlockRes] = await Promise.all([
+  const [l2FeesRes, l2BlockRes, l1BlockRes, cloudCostRes] = await Promise.all([
     fetchL2Fees(
       timeRange,
       selectedSequencer ? getSequencerAddress(selectedSequencer) : undefined,
     ),
     fetchL2HeadBlock(timeRange),
     fetchL1HeadBlock(timeRange),
+    fetchCloudCost(timeRange),
   ]);
 
   return {
@@ -132,6 +135,7 @@ export const fetchEconomicsData = async (
     baseFee: l2FeesRes.data?.base_fee ?? null,
     l2Block: l2BlockRes.data,
     l1Block: l1BlockRes.data,
-    badRequestResults: [l2FeesRes, l2BlockRes, l1BlockRes],
+    cloudCost: cloudCostRes.data,
+    badRequestResults: [l2FeesRes, l2BlockRes, l1BlockRes, cloudCostRes],
   };
 };


### PR DESCRIPTION
## Summary
- extend Economics data fetching to include cloud costs
- track profitability over time with new chart component
- wire profitability chart into the dashboard
- update tests for new economics data

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_684930f2a53083288d76d6af16c32c1b