### PR TITLE
Rename Instatus component options

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -56,18 +56,18 @@ pub struct InstatusOpts {
     /// Instatus page ID
     #[clap(long, env = "INSTATUS_PAGE_ID", default_value = "")]
     pub page_id: String,
-    /// Instatus component ID for batch proposals monitor
-    #[clap(long, env = "INSTATUS_BATCH_COMPONENT_ID", default_value = "")]
-    pub batch_component_id: String,
-    /// Instatus component ID for batch proof timeout monitor
-    #[clap(long, env = "INSTATUS_BATCH_PROOF_TIMEOUT_COMPONENT_ID", default_value = "")]
-    pub batch_proof_timeout_component_id: String,
-    /// Instatus component ID for batch verify timeout monitor
-    #[clap(long, env = "INSTATUS_BATCH_VERIFY_TIMEOUT_COMPONENT_ID", default_value = "")]
-    pub batch_verify_timeout_component_id: String,
-    /// Instatus component ID for L2 head monitor
-    #[clap(long, env = "INSTATUS_L2_COMPONENT_ID", default_value = "")]
-    pub l2_component_id: String,
+    /// Instatus component ID for batch submission monitor
+    #[clap(long, env = "INSTATUS_BATCH_SUBMISSION_COMPONENT_ID", default_value = "")]
+    pub batch_submission_component_id: String,
+    /// Instatus component ID for proof submission timeout monitor
+    #[clap(long, env = "INSTATUS_PROOF_SUBMISSION_COMPONENT_ID", default_value = "")]
+    pub proof_submission_component_id: String,
+    /// Instatus component ID for proof verification timeout monitor
+    #[clap(long, env = "INSTATUS_PROOF_VERIFICATION_COMPONENT_ID", default_value = "")]
+    pub proof_verification_component_id: String,
+    /// Instatus component ID for transaction sequencing monitor
+    #[clap(long, env = "INSTATUS_TRANSACTION_SEQUENCING_COMPONENT_ID", default_value = "")]
+    pub transaction_sequencing_component_id: String,
     /// Instatus monitor poll interval in seconds
     #[clap(long, env = "INSTATUS_MONITOR_POLL_INTERVAL_SECS", default_value = "30")]
     pub monitor_poll_interval_secs: u64,
@@ -86,10 +86,10 @@ impl InstatusOpts {
     pub fn enabled(&self) -> bool {
         !(self.api_key.is_empty() ||
             self.page_id.is_empty() ||
-            self.batch_component_id.is_empty() ||
-            self.batch_proof_timeout_component_id.is_empty() ||
-            self.batch_verify_timeout_component_id.is_empty() ||
-            self.l2_component_id.is_empty())
+            self.batch_submission_component_id.is_empty() ||
+            self.proof_submission_component_id.is_empty() ||
+            self.proof_verification_component_id.is_empty() ||
+            self.transaction_sequencing_component_id.is_empty())
     }
 }
 
@@ -188,13 +188,13 @@ mod tests {
             "key",
             "--page-id",
             "page",
-            "--batch-component-id",
+            "--batch-submission-component-id",
             "batch",
-            "--batch-proof-timeout-component-id",
+            "--proof-submission-component-id",
             "proof",
-            "--batch-verify-timeout-component-id",
+            "--proof-verification-component-id",
             "verify",
-            "--l2-component-id",
+            "--transaction-sequencing-component-id",
             "l2",
             "--api-host",
             "127.0.0.1",

--- a/crates/driver/src/lib.rs
+++ b/crates/driver/src/lib.rs
@@ -34,10 +34,10 @@ pub struct Driver {
     extractor: Extractor,
     reorg: ReorgDetector,
     incident_client: IncidentClient,
-    instatus_batch_component_id: String,
-    instatus_batch_proof_timeout_component_id: String,
-    instatus_batch_verify_timeout_component_id: String,
-    instatus_l2_component_id: String,
+    instatus_batch_submission_component_id: String,
+    instatus_proof_submission_component_id: String,
+    instatus_proof_verification_component_id: String,
+    instatus_transaction_sequencing_component_id: String,
     instatus_monitor_poll_interval_secs: u64,
     instatus_monitor_threshold_secs: u64,
     batch_proof_timeout_secs: u64,
@@ -90,12 +90,14 @@ impl Driver {
             return Err(eyre::eyre!("missing Instatus configuration"));
         }
 
-        let instatus_batch_component_id = opts.instatus.batch_component_id.clone();
-        let instatus_batch_proof_timeout_component_id =
-            opts.instatus.batch_proof_timeout_component_id.clone();
-        let instatus_batch_verify_timeout_component_id =
-            opts.instatus.batch_verify_timeout_component_id.clone();
-        let instatus_l2_component_id = opts.instatus.l2_component_id.clone();
+        let instatus_batch_submission_component_id =
+            opts.instatus.batch_submission_component_id.clone();
+        let instatus_proof_submission_component_id =
+            opts.instatus.proof_submission_component_id.clone();
+        let instatus_proof_verification_component_id =
+            opts.instatus.proof_verification_component_id.clone();
+        let instatus_transaction_sequencing_component_id =
+            opts.instatus.transaction_sequencing_component_id.clone();
         let incident_client =
             IncidentClient::new(opts.instatus.api_key.clone(), opts.instatus.page_id.clone());
 
@@ -105,10 +107,10 @@ impl Driver {
             extractor,
             reorg: ReorgDetector::new(),
             incident_client,
-            instatus_batch_component_id,
-            instatus_batch_proof_timeout_component_id,
-            instatus_batch_verify_timeout_component_id,
-            instatus_l2_component_id,
+            instatus_batch_submission_component_id,
+            instatus_proof_submission_component_id,
+            instatus_proof_verification_component_id,
+            instatus_transaction_sequencing_component_id,
             instatus_monitor_poll_interval_secs: opts.instatus.monitor_poll_interval_secs,
             instatus_monitor_threshold_secs: opts.instatus.monitor_threshold_secs,
             batch_proof_timeout_secs: opts.instatus.batch_proof_timeout_secs,
@@ -233,7 +235,7 @@ impl Driver {
         InstatusL1Monitor::new(
             self.clickhouse_reader.clone(),
             self.incident_client.clone(),
-            self.instatus_batch_component_id.clone(),
+            self.instatus_batch_submission_component_id.clone(),
             Duration::from_secs(self.instatus_monitor_threshold_secs),
             Duration::from_secs(self.instatus_monitor_poll_interval_secs),
         )
@@ -242,7 +244,7 @@ impl Driver {
         InstatusMonitor::new(
             self.clickhouse_reader.clone(),
             self.incident_client.clone(),
-            self.instatus_l2_component_id.clone(),
+            self.instatus_transaction_sequencing_component_id.clone(),
             Duration::from_secs(self.instatus_monitor_threshold_secs),
             Duration::from_secs(self.instatus_monitor_poll_interval_secs),
         )
@@ -251,7 +253,7 @@ impl Driver {
         BatchProofTimeoutMonitor::new(
             self.clickhouse_reader.clone(),
             self.incident_client.clone(),
-            self.instatus_batch_proof_timeout_component_id.clone(),
+            self.instatus_proof_submission_component_id.clone(),
             Duration::from_secs(self.batch_proof_timeout_secs),
             Duration::from_secs(60),
         )
@@ -260,7 +262,7 @@ impl Driver {
         BatchVerifyTimeoutMonitor::new(
             self.clickhouse_reader.clone(),
             self.incident_client.clone(),
-            self.instatus_batch_verify_timeout_component_id.clone(),
+            self.instatus_proof_verification_component_id.clone(),
             Duration::from_secs(self.batch_proof_timeout_secs),
             Duration::from_secs(60),
         )
@@ -585,10 +587,10 @@ mod tests {
             instatus: InstatusOpts {
                 api_key: "key".into(),
                 page_id: "page".into(),
-                batch_component_id: "batch".into(),
-                batch_proof_timeout_component_id: "proof".into(),
-                batch_verify_timeout_component_id: "verify".into(),
-                l2_component_id: "l2".into(),
+                batch_submission_component_id: "batch".into(),
+                proof_submission_component_id: "proof".into(),
+                proof_verification_component_id: "verify".into(),
+                transaction_sequencing_component_id: "l2".into(),
                 monitor_poll_interval_secs: 30,
                 monitor_threshold_secs: 96,
                 batch_proof_timeout_secs: 999,


### PR DESCRIPTION
## Summary
- rename Instatus component IDs to match dashboard terminology
- update driver usage and tests

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6849373ba21483288c456cfbae3b9f1a