### PR TITLE
Add health check server to taikoscope

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3434,6 +3434,8 @@ checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 name = "runtime"
 version = "0.1.0"
 dependencies = [
+ "api-types",
+ "axum",
  "eyre",
  "futures",
  "tokio",

--- a/bin/taikoscope/src/main.rs
+++ b/bin/taikoscope/src/main.rs
@@ -32,7 +32,7 @@ async fn main() -> eyre::Result<()> {
 
     let health_addr: SocketAddr = format!("{}:{}", opts.api.host, opts.api.port).parse()?;
     tokio::spawn(async move {
-        if let Err(e) = health::serve(health_addr).await {
+        if let Err(e) = health::serve(health_addr, ShutdownSignal::new()).await {
             tracing::error!(error = %e, "Health server failed");
         }
     });

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -18,6 +18,7 @@ use clickhouse_lib::{AddressBytes, ClickhouseReader};
 use futures::stream::Stream;
 use hex::encode;
 use primitives::hardware::TOTAL_HARDWARE_COST_USD;
+use runtime::health;
 use std::{convert::Infallible, time::Duration as StdDuration};
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
@@ -177,7 +178,7 @@ fn _legacy_resolve_time_range(
     tag = "taikoscope"
 )]
 async fn health() -> Json<HealthResponse> {
-    Json(HealthResponse { status: "ok".to_owned() })
+    health::handler().await
 }
 
 #[utoipa::path(

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -10,6 +10,9 @@ repository.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "signal"] }
 tracing.workspace = true
 futures.workspace = true
+axum.workspace = true
+api-types = { path = "../api-types" }
+eyre.workspace = true
 
 [dev-dependencies]
 eyre.workspace = true

--- a/crates/runtime/src/health.rs
+++ b/crates/runtime/src/health.rs
@@ -5,13 +5,21 @@ use axum::{Json, Router, routing::get};
 use eyre::Result;
 use tracing::info;
 
+/// Health check handler returning `{ "status": "ok" }`.
+pub async fn handler() -> Json<HealthResponse> {
+    Json(HealthResponse { status: "ok".to_owned() })
+}
+
+/// Create a router exposing the `/health` endpoint.
+pub fn router() -> Router {
+    Router::new().route("/health", get(handler))
+}
+
 /// Start a simple health check server.
 ///
-/// The server listens on the provided address and exposes a `/health` endpoint
-/// returning `{ "status": "ok" }`.
+/// The server exposes a `/health` endpoint that returns `{ "status": "ok" }`.
 pub async fn serve(addr: SocketAddr) -> Result<()> {
-    let app = Router::new()
-        .route("/health", get(|| async { Json(HealthResponse { status: "ok".to_owned() }) }));
+    let app = router();
 
     info!("Starting health server on {}", addr);
     let listener = tokio::net::TcpListener::bind(addr).await?;

--- a/crates/runtime/src/health.rs
+++ b/crates/runtime/src/health.rs
@@ -1,0 +1,20 @@
+use std::net::SocketAddr;
+
+use api_types::HealthResponse;
+use axum::{Json, Router, routing::get};
+use eyre::Result;
+use tracing::info;
+
+/// Start a simple health check server.
+///
+/// The server listens on the provided address and exposes a `/health` endpoint
+/// returning `{ "status": "ok" }`.
+pub async fn serve(addr: SocketAddr) -> Result<()> {
+    let app = Router::new()
+        .route("/health", get(|| async { Json(HealthResponse { status: "ok".to_owned() }) }));
+
+    info!("Starting health server on {}", addr);
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    axum::serve(listener, app.into_make_service()).await?;
+    Ok(())
+}

--- a/crates/runtime/src/health.rs
+++ b/crates/runtime/src/health.rs
@@ -5,6 +5,8 @@ use axum::{Json, Router, routing::get};
 use eyre::Result;
 use tracing::info;
 
+use crate::shutdown::ShutdownSignal;
+
 /// Health check handler returning `{ "status": "ok" }`.
 pub async fn handler() -> Json<HealthResponse> {
     Json(HealthResponse { status: "ok".to_owned() })
@@ -18,11 +20,11 @@ pub fn router() -> Router {
 /// Start a simple health check server.
 ///
 /// The server exposes a `/health` endpoint that returns `{ "status": "ok" }`.
-pub async fn serve(addr: SocketAddr) -> Result<()> {
+pub async fn serve(addr: SocketAddr, shutdown: ShutdownSignal) -> Result<()> {
     let app = router();
 
     info!("Starting health server on {}", addr);
     let listener = tokio::net::TcpListener::bind(addr).await?;
-    axum::serve(listener, app.into_make_service()).await?;
+    axum::serve(listener, app.into_make_service()).with_graceful_shutdown(shutdown).await?;
     Ok(())
 }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1,6 +1,7 @@
 //! Runtime utilities for Taikoscope.
 #![allow(missing_docs)]
 
+pub mod health;
 pub mod rate_limiter;
 pub mod shutdown;
 


### PR DESCRIPTION
## Summary
- add small health server to runtime crate
- run health server in `taikoscope` binary
- wire runtime crate to new dependencies

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68494c2047b48328adc9da08c6148f5f