### PR TITLE
Add toggle for Instatus monitors

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ API_HOST=127.0.0.1
 API_PORT=3000
 RATE_LIMIT_MAX_REQUESTS=1000
 RATE_LIMIT_PERIOD_SECS=60
+INSTATUS_MONITORS_ENABLED=true
 ```
 
 These variables map to the configuration structs defined in


### PR DESCRIPTION
## Summary
- add `INSTATUS_MONITORS_ENABLED` flag to configuration
- skip monitor startup if monitors are disabled
- document the new environment variable
- update config tests

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68492f1596408328b2ab427c2e3cac9c