### PR TITLE
Remove cloud cost metric

### DIFF
--- a/dashboard/tests/helpers.test.ts
+++ b/dashboard/tests/helpers.test.ts
@@ -72,12 +72,10 @@ describe('helpers', () => {
     expect(metrics[11].group).toBe('Network Economics');
     expect(metrics[12].value).toBe('1.00 ETH');
     expect(metrics[12].group).toBe('Network Economics');
-    expect(metrics[13].value).toBe('$90.00');
-    expect(metrics[13].group).toBe('Network Economics');
-    expect(metrics[14].value).toBe('100');
+    expect(metrics[13].value).toBe('100');
+    expect(metrics[13].group).toBe('Block Information');
+    expect(metrics[14].value).toBe('50');
     expect(metrics[14].group).toBe('Block Information');
-    expect(metrics[15].value).toBe('50');
-    expect(metrics[15].group).toBe('Block Information');
   });
 
   it('detects bad requests', () => {
@@ -104,9 +102,8 @@ describe('helpers', () => {
     expect(metricsAllNull[10].group).toBe('Network Health');
     expect(metricsAllNull[11].group).toBe('Network Economics');
     expect(metricsAllNull[12].group).toBe('Network Economics');
-    expect(metricsAllNull[13].group).toBe('Network Economics');
+    expect(metricsAllNull[13].group).toBe('Block Information');
     expect(metricsAllNull[14].group).toBe('Block Information');
-    expect(metricsAllNull[15].group).toBe('Block Information');
   });
 
   it('handles all successful requests', () => {

--- a/dashboard/tests/metricsCreator.test.ts
+++ b/dashboard/tests/metricsCreator.test.ts
@@ -26,7 +26,7 @@ describe('metricsCreator', () => {
       l1Block: 50,
     });
 
-    expect(metrics).toHaveLength(16);
+    expect(metrics).toHaveLength(15);
     expect(metrics[0].value).toBe('1.23');
 
     const verifyMetric = metrics.find((m) => React.isValidElement(m.title));

--- a/dashboard/utils/metricsCreator.ts
+++ b/dashboard/utils/metricsCreator.ts
@@ -113,11 +113,6 @@ export const createMetrics = (data: MetricInputData): MetricData[] => [
     group: 'Network Economics',
   },
   {
-    title: 'Estimated Cloud Cost',
-    value: data.cloudCost != null ? `$${data.cloudCost.toFixed(2)}` : 'N/A',
-    group: 'Network Economics',
-  },
-  {
     title: 'L2 Block',
     value: data.l2Block != null ? data.l2Block.toLocaleString() : 'N/A',
     group: 'Block Information',


### PR DESCRIPTION
## Summary
- remove `Estimated Cloud Cost` metric from dashboard metrics
- adjust dashboard tests

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_684983901a048328976167b042b31170