### PR TITLE
Display unknown sequencer addresses

### DIFF
--- a/dashboard/tests/helpers.test.ts
+++ b/dashboard/tests/helpers.test.ts
@@ -58,7 +58,7 @@ describe('helpers', () => {
     expect(metrics[4].group).toBe('Network Performance');
     expect(metrics[5].value).toBe('2');
     expect(metrics[5].group).toBe('Sequencers');
-    expect(metrics[6].value).toBe('Unknown');
+    expect(metrics[6].value).toBe('0xabc');
     expect(metrics[6].group).toBe('Sequencers');
     expect(metrics[7].value).toBe('N/A');
     expect(metrics[7].group).toBe('Sequencers');

--- a/dashboard/utils/metricsCreator.ts
+++ b/dashboard/utils/metricsCreator.ts
@@ -76,14 +76,22 @@ export const createMetrics = (data: MetricInputData): MetricData[] => [
     title: 'Current Sequencer',
     value:
       data.currentOperator != null
-        ? getSequencerName(data.currentOperator)
+        ? (() => {
+            const name = getSequencerName(data.currentOperator);
+            return name === 'Unknown' ? data.currentOperator : name;
+          })()
         : 'N/A',
     group: 'Sequencers',
   },
   {
     title: 'Next Sequencer',
     value:
-      data.nextOperator != null ? getSequencerName(data.nextOperator) : 'N/A',
+      data.nextOperator != null
+        ? (() => {
+            const name = getSequencerName(data.nextOperator);
+            return name === 'Unknown' ? data.nextOperator : name;
+          })()
+        : 'N/A',
     group: 'Sequencers',
   },
   {


### PR DESCRIPTION
## Summary
- show sequencer address when name is unknown in metrics
- update helper test expectation

## Testing
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_684ad6f5742c83288cb12c7feb7bb458