### PR TITLE
Set dashboard default auto refresh to 10 minutes

### DIFF
--- a/dashboard/tests/utils.more.test.ts
+++ b/dashboard/tests/utils.more.test.ts
@@ -53,7 +53,7 @@ describe('utils additional', () => {
     const prev = (globalThis as any).localStorage;
     // Ensure localStorage is undefined
     delete (globalThis as any).localStorage;
-    expect(loadRefreshRate()).toBe(60000);
+    expect(loadRefreshRate()).toBe(600000);
     if (prev !== undefined) (globalThis as any).localStorage = prev;
   });
 });

--- a/dashboard/tests/utils.test.ts
+++ b/dashboard/tests/utils.test.ts
@@ -141,11 +141,11 @@ describe('utils', () => {
       length: 0,
     } as Storage;
 
-    expect(loadRefreshRate()).toBe(60000);
-    saveRefreshRate(60000);
-    expect(store.refreshRate).toBe('60000');
+    expect(loadRefreshRate()).toBe(600000);
+    saveRefreshRate(600000);
+    expect(store.refreshRate).toBe('600000');
     store.refreshRate = '2000';
-    expect(loadRefreshRate()).toBe(60000);
+    expect(loadRefreshRate()).toBe(600000);
   });
 
   it('validates refresh rate', () => {

--- a/dashboard/utils.ts
+++ b/dashboard/utils.ts
@@ -126,18 +126,18 @@ export const bytesToHex = (bytes: number[]): string =>
   `0x${bytes.map((b) => b.toString(16).padStart(2, '0')).join('')}`;
 
 export const loadRefreshRate = (): number => {
-  if (typeof localStorage === 'undefined') return 60000;
+  if (typeof localStorage === 'undefined') return 600000;
   try {
     const stored = localStorage.getItem('refreshRate');
     const value = stored ? parseInt(stored, 10) : NaN;
     if (!Number.isFinite(value) || value < 60000) {
       localStorage.removeItem('refreshRate');
-      return 60000;
+      return 600000;
     }
     return value;
   } catch (err) {
     console.error('Failed to access localStorage:', err);
-    return 60000;
+    return 600000;
   }
 };
 


### PR DESCRIPTION
## Summary
- update dashboard utils to default refresh rate to 10 minutes
- adjust tests for new default refresh rate

## Testing
- `just fmt`
- `just lint`
- `just lint-dashboard`
- `just test`
- `just check-dashboard`
- `just test-dashboard`
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_684ad72a06188328ad3320535d631f8c