### PR TITLE
Log operator candidates

### DIFF
--- a/crates/driver/src/lib.rs
+++ b/crates/driver/src/lib.rs
@@ -378,6 +378,7 @@ impl Driver {
                 tracing::info!(
                     slot = header.slot,
                     block = header.number,
+                    candidates = ?c,
                     candidates_count = c.len(),
                     "Successfully retrieved operator candidates"
                 );


### PR DESCRIPTION
## Summary
- log addresses for operator candidates

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_684ad83eb8bc83288faef59a99af2a19