### PR TITLE
Fix sequencer address text overflow

### DIFF
--- a/dashboard/components/MetricCard.tsx
+++ b/dashboard/components/MetricCard.tsx
@@ -39,7 +39,7 @@ export const MetricCard: React.FC<MetricCardProps> = ({
         )}
       </div>
       <p
-        className={`mt-1 font-semibold text-gray-900 dark:text-gray-100 ${isAddress ? 'text-base sm:text-lg break-all' : `text-2xl${isShortValue ? '' : ' whitespace-nowrap overflow-hidden text-ellipsis'}`}`}
+        className={`mt-1 font-semibold text-gray-900 dark:text-gray-100 ${isAddress ? 'text-base break-all' : `text-2xl${isShortValue ? '' : ' whitespace-nowrap overflow-hidden text-ellipsis'}`}`}
       >
         {value}
       </p>

--- a/dashboard/tests/metricCard.test.ts
+++ b/dashboard/tests/metricCard.test.ts
@@ -17,7 +17,7 @@ describe('MetricCard', () => {
         'min-w-0 w-full sm:col-span-2 md:col-span-2 lg:col-span-2 xl:col-span-2 2xl:col-span-2',
       ),
     ).toBe(true);
-    expect(htmlAddress.includes('text-base sm:text-lg break-all')).toBe(true);
+    expect(htmlAddress.includes('text-base break-all')).toBe(true);
   });
 
   it('renders normal values', () => {


### PR DESCRIPTION
## Summary
- reduce font size for Ethereum addresses to avoid overflow on small screens
- update MetricCard tests

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_684ae161918483289f2e9080475f5c9c