### PR TITLE
Handle Tailscale without privileged mode

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -4,13 +4,27 @@
 set -e
 
 echo "🔗 Starting Tailscale daemon..."
-/app/tailscaled --state=/var/lib/tailscale/tailscaled.state --socket=/var/run/tailscale/tailscaled.sock &
+
+TS_STATE="/var/lib/tailscale/tailscaled.state"
+TS_SOCKET="/var/run/tailscale/tailscaled.sock"
+TS_OPTS=""
+
+if [ ! -c /dev/net/tun ]; then
+  echo "❗ /dev/net/tun not found, using userspace networking"
+  TS_OPTS="--tun=userspace-networking"
+fi
+
+/app/tailscaled --state=${TS_STATE} --socket=${TS_SOCKET} ${TS_OPTS} &
 
 # Wait a moment for tailscaled to start
 sleep 2
 
 echo "🌐 Connecting to Tailscale network..."
-/app/tailscale up --auth-key=${TAILSCALE_AUTHKEY} --hostname=taikoscope-hekla --accept-routes
+if [ -n "${TAILSCALE_AUTHKEY}" ]; then
+  /app/tailscale up --auth-key=${TAILSCALE_AUTHKEY} --hostname=taikoscope-hekla --accept-routes
+else
+  echo "⚠️  TAILSCALE_AUTHKEY not set. Skipping tailscale up."
+fi
 
 echo "✅ Tailscale connected. Starting Taikoscope..."
 exec /app/taikoscope

--- a/start.sh
+++ b/start.sh
@@ -26,5 +26,12 @@ else
   echo "⚠️  TAILSCALE_AUTHKEY not set. Skipping tailscale up."
 fi
 
-echo "✅ Tailscale connected. Starting Taikoscope..."
+
+if [ -n "${TAILSCALE_AUTHKEY}" ]; then
+  /app/tailscale up --auth-key=${TAILSCALE_AUTHKEY} --hostname=taikoscope-hekla --accept-routes
+  echo "✅ Tailscale connected. Starting Taikoscope..."
+else
+  echo "⚠️ Starting Taikoscope without Tailscale connection..."
+fi
+
 exec /app/taikoscope


### PR DESCRIPTION
## Summary
- support userspace networking in `start.sh`
- skip `tailscale up` when no auth key

## Testing
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_684bca363cfc8328a003a2859c024dd6