### PR TITLE
Log when monitors disabled

### DIFF
--- a/crates/driver/src/lib.rs
+++ b/crates/driver/src/lib.rs
@@ -61,6 +61,10 @@ impl Driver {
             ));
         }
 
+        if !opts.instatus.monitors_enabled {
+            info!("Instatus monitors disabled; no incidents will be reported");
+        }
+
         // init db client
         let clickhouse = ClickhouseWriter::new(
             opts.clickhouse.url.clone(),


### PR DESCRIPTION
## Summary
- log a single message when Instatus monitors are disabled

## Testing
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_684bc99b516c83288122b4a012754303