### PR TITLE
Add L1 data posting cost tracking

### DIFF
--- a/crates/api-types/src/lib.rs
+++ b/crates/api-types/src/lib.rs
@@ -6,8 +6,8 @@
 
 use clickhouse_lib::{
     BatchBlobCountRow, BatchPostingTimeRow, BatchProveTimeRow, BatchVerifyTimeRow,
-    ForcedInclusionProcessedRow, L1BlockTimeRow, L2BlockTimeRow, L2GasUsedRow, L2ReorgRow,
-    L2TpsRow, SlashingEventRow,
+    ForcedInclusionProcessedRow, L1BlockTimeRow, L1DataCostRow, L2BlockTimeRow, L2GasUsedRow,
+    L2ReorgRow, L2TpsRow, SlashingEventRow,
 };
 
 use axum::{Json, http::StatusCode, response::IntoResponse};
@@ -212,6 +212,13 @@ pub struct L2BlockTimesResponse {
 pub struct L2GasUsedResponse {
     /// Gas usage for each L2 block.
     pub blocks: Vec<L2GasUsedRow>,
+}
+
+/// L1 data posting cost per block.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct L1DataCostResponse {
+    /// Cost per block.
+    pub blocks: Vec<L1DataCostRow>,
 }
 
 /// TPS values for each L2 block.

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -53,6 +53,7 @@ pub const MAX_BLOCK_TRANSACTIONS_LIMIT: u64 = u64::MAX;
         l1_block_times,
         l2_block_times,
         l2_gas_used,
+        l1_data_cost,
         l2_tps,
         sequencer_distribution,
         sequencer_blocks,
@@ -78,6 +79,7 @@ pub const MAX_BLOCK_TRANSACTIONS_LIMIT: u64 = u64::MAX;
             L1BlockTimesResponse,
             L2BlockTimesResponse,
             L2GasUsedResponse,
+            L1DataCostResponse,
             L2TpsResponse,
             SequencerDistributionResponse,
             SequencerDistributionItem,
@@ -822,6 +824,42 @@ async fn l2_gas_used(
 
 #[utoipa::path(
     get,
+    path = "/l1-data-cost",
+    params(
+        RangeQuery
+    ),
+    responses(
+        (status = 200, description = "L1 data posting cost", body = L1DataCostResponse),
+        (status = 500, description = "Database error", body = ErrorResponse)
+    ),
+    tag = "taikoscope"
+)]
+async fn l1_data_cost(
+    Query(params): Query<RangeQuery>,
+    State(state): State<ApiState>,
+) -> Result<Json<L1DataCostResponse>, ErrorResponse> {
+    validate_time_range(&params.time_range)?;
+    let has_time_range = has_time_range_params(&params.time_range);
+    validate_range_exclusivity(has_time_range, false)?;
+
+    let time_range = resolve_time_range_enum(&params.range, &params.time_range);
+    let rows = match state.client.get_l1_data_costs(time_range).await {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::error!("Failed to get L1 data cost: {}", e);
+            return Err(ErrorResponse::new(
+                "database-error",
+                "Database error",
+                StatusCode::INTERNAL_SERVER_ERROR,
+                e.to_string(),
+            ));
+        }
+    };
+    Ok(Json(L1DataCostResponse { blocks: rows }))
+}
+
+#[utoipa::path(
+    get,
     path = "/l2-tps",
     params(
         RangeQuery
@@ -1167,6 +1205,7 @@ pub fn router(state: ApiState) -> Router {
         .route("/l1-block-times", get(l1_block_times))
         .route("/l2-block-times", get(l2_block_times))
         .route("/l2-gas-used", get(l2_gas_used))
+        .route("/l1-data-cost", get(l1_data_cost))
         .route("/l2-tps", get(l2_tps))
         .route("/tps", get(l2_tps))
         .route("/sequencer-distribution", get(sequencer_distribution))
@@ -1525,6 +1564,27 @@ mod tests {
         assert_eq!(
             body,
             json!({ "blocks": [ { "l2_block_number": 0, "gas_used": 0 }, { "l2_block_number": 1, "gas_used": 42 } ] })
+        );
+    }
+
+    #[derive(Serialize, Row)]
+    struct L1DataCostRowTest {
+        l1_block_number: u64,
+        cost: u128,
+    }
+
+    #[tokio::test]
+    async fn l1_data_cost_endpoint() {
+        let mock = Mock::new();
+        mock.add(handlers::provide(vec![
+            L1DataCostRowTest { l1_block_number: 1, cost: 10 },
+            L1DataCostRowTest { l1_block_number: 2, cost: 20 },
+        ]));
+        let app = build_app(mock.url());
+        let body = send_request(app, "/l1-data-cost?range=1h").await;
+        assert_eq!(
+            body,
+            json!({ "blocks": [ { "l1_block_number": 1, "cost": 10 }, { "l1_block_number": 2, "cost": 20 } ] })
         );
     }
 

--- a/crates/clickhouse/migrations/001_create_tables.sql
+++ b/crates/clickhouse/migrations/001_create_tables.sql
@@ -79,3 +79,10 @@ CREATE TABLE IF NOT EXISTS ${DB}.slashing_events (
 ) ENGINE = MergeTree()
 ORDER BY (l1_block_number, validator_addr);
 
+CREATE TABLE IF NOT EXISTS ${DB}.l1_data_costs (
+    l1_block_number UInt64,
+    cost UInt128,
+    inserted_at DateTime64(3) DEFAULT now64()
+) ENGINE = MergeTree()
+ORDER BY (l1_block_number);
+

--- a/crates/clickhouse/src/models.rs
+++ b/crates/clickhouse/src/models.rs
@@ -217,6 +217,15 @@ pub struct L2GasUsedRow {
     pub gas_used: u64,
 }
 
+/// Row representing the total L1 data posting cost for a block
+#[derive(Debug, Row, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+pub struct L1DataCostRow {
+    /// L1 block number
+    pub l1_block_number: u64,
+    /// Total cost in wei for data posting transactions
+    pub cost: u128,
+}
+
 /// Row representing the transactions per second for an L2 block
 #[derive(Debug, Serialize, Deserialize, PartialEq, ToSchema)]
 pub struct L2TpsRow {

--- a/crates/clickhouse/src/reader.rs
+++ b/crates/clickhouse/src/reader.rs
@@ -14,8 +14,8 @@ use url::Url;
 use crate::{
     models::{
         BatchBlobCountRow, BatchPostingTimeRow, BatchProveTimeRow, BatchVerifyTimeRow,
-        BlockTransactionRow, ForcedInclusionProcessedRow, L1BlockTimeRow, L2BlockTimeRow,
-        L2GasUsedRow, L2ReorgRow, L2TpsRow, PreconfData, SequencerBlockRow,
+        BlockTransactionRow, ForcedInclusionProcessedRow, L1BlockTimeRow, L1DataCostRow,
+        L2BlockTimeRow, L2GasUsedRow, L2ReorgRow, L2TpsRow, PreconfData, SequencerBlockRow,
         SequencerDistributionRow, SlashingEventRow,
     },
     types::AddressBytes,
@@ -943,6 +943,32 @@ impl ClickhouseReader {
         Ok(rows
             .into_iter()
             .map(|r| L2GasUsedRow { l2_block_number: r.l2_block_number, gas_used: r.gas_used })
+            .collect())
+    }
+
+    /// Get the L1 data posting cost for each block within the given range
+    pub async fn get_l1_data_costs(&self, range: TimeRange) -> Result<Vec<L1DataCostRow>> {
+        #[derive(Row, Deserialize)]
+        struct RawRow {
+            l1_block_number: u64,
+            cost: u128,
+        }
+
+        let query = format!(
+            "SELECT l1_block_number, cost \
+             FROM {db}.l1_data_costs \
+             WHERE l1_block_number IN (\
+                 SELECT l1_block_number FROM {db}.l1_head_events \
+                 WHERE block_ts >= toUnixTimestamp(now64() - INTERVAL {interval})) \
+             ORDER BY l1_block_number ASC",
+            interval = range.interval(),
+            db = self.db_name,
+        );
+
+        let rows = self.execute::<RawRow>(&query).await?;
+        Ok(rows
+            .into_iter()
+            .map(|r| L1DataCostRow { l1_block_number: r.l1_block_number, cost: r.cost })
             .collect())
     }
 

--- a/crates/clickhouse/src/schema.rs
+++ b/crates/clickhouse/src/schema.rs
@@ -22,6 +22,7 @@ pub const TABLES: &[&str] = &[
     "forced_inclusion_processed",
     "verified_batches",
     "slashing_events",
+    "l1_data_costs",
 ];
 
 /// Schema definitions for tables
@@ -106,5 +107,12 @@ pub const TABLE_SCHEMAS: &[TableSchema] = &[
                  validator_addr FixedString(20),
                  inserted_at DateTime64(3) DEFAULT now64()",
         order_by: "l1_block_number, validator_addr",
+    },
+    TableSchema {
+        name: "l1_data_costs",
+        columns: "l1_block_number UInt64,
+                 cost UInt128,
+                 inserted_at DateTime64(3) DEFAULT now64()",
+        order_by: "l1_block_number",
     },
 ];

--- a/crates/clickhouse/src/writer.rs
+++ b/crates/clickhouse/src/writer.rs
@@ -151,8 +151,8 @@ fn validate_migration_name(name: &str) -> bool {
 use crate::{
     L1Header,
     models::{
-        BatchRow, ForcedInclusionProcessedRow, L1HeadEvent, L2HeadEvent, L2ReorgInsertRow,
-        PreconfData, ProvedBatchRow, VerifiedBatchRow,
+        BatchRow, ForcedInclusionProcessedRow, L1DataCostRow, L1HeadEvent, L2HeadEvent,
+        L2ReorgInsertRow, PreconfData, ProvedBatchRow, VerifiedBatchRow,
     },
     schema::{TABLE_SCHEMAS, TABLES, TableSchema},
     types::{AddressBytes, HashBytes},
@@ -315,6 +315,16 @@ impl ClickhouseWriter {
         let client = self.base.clone();
         let mut insert = client.insert("l2_head_events")?;
         insert.write(event).await?;
+        insert.end().await?;
+        Ok(())
+    }
+
+    /// Insert L1 data posting cost
+    pub async fn insert_l1_data_cost(&self, block_number: u64, cost: u128) -> Result<()> {
+        let client = self.base.clone();
+        let row = L1DataCostRow { l1_block_number: block_number, cost };
+        let mut insert = client.insert("l1_data_costs")?;
+        insert.write(&row).await?;
         insert.end().await?;
         Ok(())
     }
@@ -628,6 +638,21 @@ mod tests {
             rows,
             vec![ForcedInclusionProcessedRow { blob_hash: HashBytes::from([5u8; 32]) }]
         );
+    }
+
+    #[tokio::test]
+    async fn insert_l1_data_cost_writes_expected_row() {
+        let mock = Mock::new();
+        let ctl = mock.add(handlers::record::<L1DataCostRow>());
+
+        let url = Url::parse(mock.url()).unwrap();
+        let writer =
+            ClickhouseWriter::new(url, "db".to_owned(), "user".into(), "pass".into()).unwrap();
+
+        writer.insert_l1_data_cost(10, 42).await.unwrap();
+
+        let rows: Vec<L1DataCostRow> = ctl.collect().await;
+        assert_eq!(rows, vec![L1DataCostRow { l1_block_number: 10, cost: 42 }]);
     }
 
     #[test]

--- a/crates/driver/src/lib.rs
+++ b/crates/driver/src/lib.rs
@@ -32,6 +32,7 @@ pub struct Driver {
     clickhouse: ClickhouseWriter,
     clickhouse_reader: ClickhouseReader,
     extractor: Extractor,
+    inbox_address: Address,
     reorg: ReorgDetector,
     incident_client: IncidentClient,
     instatus_batch_component_id: String,
@@ -103,6 +104,7 @@ impl Driver {
             clickhouse,
             clickhouse_reader,
             extractor,
+            inbox_address: opts.taiko_addresses.inbox_address,
             reorg: ReorgDetector::new(),
             incident_client,
             instatus_batch_component_id,
@@ -364,6 +366,19 @@ impl Driver {
             tracing::error!(header_number = header.number, err = %e, "Failed to insert L1 header");
         } else {
             info!(header_number = header.number, "Inserted L1 header");
+        }
+
+        match self.extractor.get_l1_data_posting_cost(header.hash, self.inbox_address).await {
+            Ok(cost) => {
+                if let Err(e) = self.clickhouse.insert_l1_data_cost(header.number, cost).await {
+                    tracing::error!(block_number = header.number, err = %e, "Failed to insert L1 data cost");
+                } else {
+                    info!(block_number = header.number, cost, "Inserted L1 data cost");
+                }
+            }
+            Err(e) => {
+                tracing::error!(block_number = header.number, err = %e, "Failed to fetch L1 data cost");
+            }
         }
 
         let opt_candidates = match self.extractor.get_operator_candidates_for_current_epoch().await

--- a/crates/extractor/src/lib.rs
+++ b/crates/extractor/src/lib.rs
@@ -432,7 +432,7 @@ impl Extractor {
             if let Some(h) = tx.blob_versioned_hashes() {
                 if !h.is_empty() && tx.to() == Some(inbox) {
                     total = total
-                        .saturating_add(receipt.gas_used() as u128 * receipt.effective_gas_price());
+                        .saturating_add((receipt.gas_used() as u128).saturating_mul(receipt.effective_gas_price()));
                 }
             }
         }

--- a/crates/extractor/src/lib.rs
+++ b/crates/extractor/src/lib.rs
@@ -431,8 +431,16 @@ impl Extractor {
         for (tx, receipt) in txs.into_iter().zip(receipts.into_iter()) {
             if let Some(h) = tx.blob_versioned_hashes() {
                 if !h.is_empty() && tx.to() == Some(inbox) {
+                    // Regular gas cost
+                    let gas_cost = (receipt.gas_used() as u128)
+                        .saturating_mul(receipt.effective_gas_price());
+                    
+                    // Blob data fee calculation
+                    let blob_data_fee = calculate_blob_fee_from_receipt(&receipt);
+                    
                     total = total
-                        .saturating_add((receipt.gas_used() as u128).saturating_mul(receipt.effective_gas_price()));
+                        .saturating_add(gas_cost)
+                        .saturating_add(blob_data_fee);
                 }
             }
         }

--- a/crates/primitives/src/blob_fee.rs
+++ b/crates/primitives/src/blob_fee.rs
@@ -1,0 +1,91 @@
+use alloy_network_primitives::ReceiptResponse;
+
+/// Returns the total fee paid for blobs in the given receipt.
+/// If the receipt is _not_ a blob-carrying transaction, `0` is returned.
+pub fn calculate_blob_fee_from_receipt<R: ReceiptResponse>(receipt: &R) -> u128 {
+    match (receipt.blob_gas_used(), receipt.blob_gas_price()) {
+        (Some(gas_used), Some(price)) => (gas_used as u128).saturating_mul(price),
+        _ => 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::{Address, B256, BlockHash, TxHash, address};
+
+    #[derive(Debug, Clone, Copy)]
+    struct TestReceipt {
+        blob_gas: Option<u64>,
+        blob_price: Option<u128>,
+    }
+
+    impl ReceiptResponse for TestReceipt {
+        fn contract_address(&self) -> Option<Address> {
+            None
+        }
+        fn status(&self) -> bool {
+            true
+        }
+        fn block_hash(&self) -> Option<BlockHash> {
+            None
+        }
+        fn block_number(&self) -> Option<u64> {
+            None
+        }
+        fn transaction_hash(&self) -> TxHash {
+            TxHash::ZERO
+        }
+        fn transaction_index(&self) -> Option<u64> {
+            None
+        }
+        fn gas_used(&self) -> u64 {
+            0
+        }
+        fn effective_gas_price(&self) -> u128 {
+            0
+        }
+        fn blob_gas_used(&self) -> Option<u64> {
+            self.blob_gas
+        }
+        fn blob_gas_price(&self) -> Option<u128> {
+            self.blob_price
+        }
+        fn from(&self) -> Address {
+            address!("0x0000000000000000000000000000000000000000")
+        }
+        fn to(&self) -> Option<Address> {
+            None
+        }
+        fn cumulative_gas_used(&self) -> u64 {
+            0
+        }
+        fn state_root(&self) -> Option<B256> {
+            None
+        }
+    }
+
+    #[test]
+    fn test_blob_fee_calculation() {
+        let receipt = TestReceipt { blob_gas: Some(100), blob_price: Some(10) };
+        assert_eq!(calculate_blob_fee_from_receipt(&receipt), 1000);
+    }
+
+    #[test]
+    fn test_no_blob_fee() {
+        let receipt = TestReceipt { blob_gas: None, blob_price: Some(10) };
+        assert_eq!(calculate_blob_fee_from_receipt(&receipt), 0);
+
+        let receipt = TestReceipt { blob_gas: Some(100), blob_price: None };
+        assert_eq!(calculate_blob_fee_from_receipt(&receipt), 0);
+
+        let receipt = TestReceipt { blob_gas: None, blob_price: None };
+        assert_eq!(calculate_blob_fee_from_receipt(&receipt), 0);
+    }
+
+    #[test]
+    fn test_saturating_mul() {
+        let receipt = TestReceipt { blob_gas: Some(u64::MAX), blob_price: Some(u128::MAX) };
+        assert_eq!(calculate_blob_fee_from_receipt(&receipt), u128::MAX);
+    }
+}

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -1,4 +1,6 @@
 //! Core primitives for the Taikoscope project.
+/// Blob fee calculations
+pub mod blob_fee;
 /// Block analytics helpers
 pub mod block_stats;
 /// Hardware cost estimates


### PR DESCRIPTION
## Summary
- track L1 data posting cost per block
- expose new `/l1-data-cost` API endpoint
- support saving cost in ClickHouse
- compute data posting cost from L1 blocks

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_684922df78f883288768d46a31a7bc6d