### PR TITLE
Apply no-install-recommends for base stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 FROM rust:1.87-bookworm AS base
 
 # Install build dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     git \
     libssl-dev \

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -6,7 +6,7 @@
 FROM rust:1.87-bookworm AS base
 
 # Install build dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     git \
     libssl-dev \


### PR DESCRIPTION
## Summary
- keep apt from installing recommended packages in base image

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_684bd2d292cc8328acc90e261b3fe8de