### PR TITLE
Add RPC health monitor tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2782,6 +2782,7 @@ dependencies = [
  "tokio",
  "tokio-retry",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -20,6 +20,8 @@ futures.workspace = true
 
 [dev-dependencies]
 mockito.workspace = true
+tokio = { workspace = true, features = ["test-util"] }
+url.workspace = true
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary
- add unit tests for network public RPC monitor
- enable tokio test-util and url dev deps
- update lockfile

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_684bd25634048328aa487967b7672f50