### PR TITLE
Improve dashboard layout with metric & chart groups

### DIFF
--- a/dashboard/components/layout/MetricsGrid.tsx
+++ b/dashboard/components/layout/MetricsGrid.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { MetricCard } from '../MetricCard';
 import { MetricCardSkeleton } from '../MetricCardSkeleton';
-import { MetricData } from '../../types';
+import { MetricData, TimeRange } from '../../types';
 
 interface MetricsGridProps {
   isLoading: boolean;
@@ -11,6 +11,9 @@ interface MetricsGridProps {
   displayGroupName: (group: string) => string;
   onMetricAction: (title: string) => (() => void) | undefined;
   economicsView?: boolean;
+  groupedCharts?: Record<string, React.ReactNode[]>;
+  isTimeRangeChanging?: boolean;
+  timeRange?: TimeRange;
 }
 
 export const MetricsGrid: React.FC<MetricsGridProps> = ({
@@ -21,15 +24,29 @@ export const MetricsGrid: React.FC<MetricsGridProps> = ({
   displayGroupName,
   onMetricAction,
   economicsView,
+  groupedCharts,
+  isTimeRangeChanging,
+  timeRange,
 }) => {
   const displayedGroupOrder = groupOrder;
   const regularGrid =
     'grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 gap-4 md:gap-6';
   const economicsGrid =
     'grid grid-cols-1 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-2 2xl:grid-cols-2 gap-4 md:gap-6';
+  const chartsGrid = 'grid grid-cols-1 lg:grid-cols-2 gap-4 md:gap-6 mt-4';
 
   return (
     <>
+      {isTimeRangeChanging && timeRange && (
+        <div className="mb-4 p-3 bg-blue-50 dark:bg-blue-900/20 rounded-lg border border-blue-200 dark:border-blue-800">
+          <div className="flex items-center space-x-2">
+            <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-blue-600 dark:border-blue-400"></div>
+            <span className="text-sm text-blue-800 dark:text-blue-200">
+              Updating data for {timeRange} time range...
+            </span>
+          </div>
+        </div>
+      )}
       {(isLoading ? Object.keys(skeletonGroupCounts) : displayedGroupOrder).map(
         (group) =>
           isLoading ? (
@@ -46,6 +63,11 @@ export const MetricsGrid: React.FC<MetricsGridProps> = ({
                   ),
                 )}
               </div>
+              {groupedCharts?.[group] && groupedCharts[group].length > 0 && (
+                <div className={chartsGrid}>{groupedCharts[group].map((c, i) => (
+                  <React.Fragment key={`${group}-c-${i}`}>{c}</React.Fragment>
+                ))}</div>
+              )}
             </React.Fragment>
           ) : groupedMetrics[group] && groupedMetrics[group].length > 0 ? (
             <React.Fragment key={group}>
@@ -68,6 +90,11 @@ export const MetricsGrid: React.FC<MetricsGridProps> = ({
                   />
                 ))}
               </div>
+              {groupedCharts?.[group] && groupedCharts[group].length > 0 && (
+                <div className={chartsGrid}>{groupedCharts[group].map((c, i) => (
+                  <React.Fragment key={`${group}-c-${i}`}>{c}</React.Fragment>
+                ))}</div>
+              )}
             </React.Fragment>
           ) : null,
       )}


### PR DESCRIPTION
## Summary
- support charts within `MetricsGrid`
- consolidate layout so metrics and charts show in grouped sections

## Testing
- `just lint`
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_684bd7e5ac2c83288b395cbb4f57096e