### PR TITLE
Add custom time range selector

### DIFF
--- a/dashboard/components/DashboardHeader.tsx
+++ b/dashboard/components/DashboardHeader.tsx
@@ -119,8 +119,12 @@ export const TimeRangeSelector: React.FC<TimeRangeSelectorProps> = ({
   isChanging,
 }) => {
   const presetRanges: TimeRange[] = ['15m', '1h', '3h', '6h', '12h', '24h'];
-  const [customValue, setCustomValue] = React.useState('1h');
-  const isCustom = !presetRanges.includes(currentTimeRange);
+
+const isCustom = !presetRanges.includes(currentTimeRange);
+const [customValue, setCustomValue] = React.useState(
+  isCustom ? currentTimeRange : '1h'
+);
+
 
   const handleSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const value = e.target.value;

--- a/dashboard/components/DashboardHeader.tsx
+++ b/dashboard/components/DashboardHeader.tsx
@@ -3,6 +3,7 @@ import { TimeRange } from '../types';
 import { RefreshCountdown } from './RefreshCountdown';
 import { TAIKO_PINK } from '../theme';
 import { isValidRefreshRate } from '../utils';
+import { isValidTimeRange } from '../utils/timeRange';
 import { useRouterNavigation } from '../hooks/useRouterNavigation';
 import { useErrorHandler } from '../hooks/useErrorHandler';
 import { showToast } from '../utils/toast';
@@ -117,27 +118,63 @@ export const TimeRangeSelector: React.FC<TimeRangeSelectorProps> = ({
   onTimeRangeChange,
   isChanging,
 }) => {
-  const ranges: TimeRange[] = ['15m', '1h', '24h'];
+  const presetRanges: TimeRange[] = ['15m', '1h', '3h', '6h', '12h', '24h'];
+  const [customValue, setCustomValue] = React.useState('1h');
+  const isCustom = !presetRanges.includes(currentTimeRange);
+
+  const handleSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const value = e.target.value;
+    if (value === 'custom') {
+      if (isValidTimeRange(customValue)) onTimeRangeChange(customValue);
+    } else {
+      onTimeRangeChange(value);
+    }
+  };
+
+  const applyCustom = () => {
+    if (isValidTimeRange(customValue)) {
+      onTimeRangeChange(customValue);
+    }
+  };
 
   return (
-    <div className="flex space-x-1 bg-gray-200 dark:bg-gray-700 p-0.5 rounded-md">
+    <div className="flex items-center space-x-1">
       {isChanging && (
         <div className="flex items-center px-2">
-          <div className="animate-spin rounded-full h-3 w-3 border-b-2 border-current opacity-50"></div>
+          <div className="animate-spin rounded-full h-3 w-3 border-b-2 border-current opacity-50" />
         </div>
       )}
-      {ranges.map((range) => (
-        <button
-          key={range}
-          onClick={() => !isChanging && onTimeRangeChange(range)}
-          disabled={isChanging}
-          className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors disabled:opacity-50
-            ${currentTimeRange === range ? 'bg-white dark:bg-gray-800 shadow-sm' : 'text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-600'}`}
-          style={currentTimeRange === range ? { color: TAIKO_PINK } : undefined}
-        >
-          {range}
-        </button>
-      ))}
+      <select
+        value={isCustom ? 'custom' : currentTimeRange}
+        onChange={handleSelect}
+        disabled={isChanging}
+        className="p-1 border rounded-md text-sm bg-white dark:bg-gray-800"
+      >
+        {presetRanges.map((r) => (
+          <option key={r} value={r}>
+            {r}
+          </option>
+        ))}
+        <option value="custom">Custom...</option>
+      </select>
+      {isCustom && (
+        <>
+          <input
+            type="text"
+            value={customValue}
+            onChange={(e) => setCustomValue(e.target.value)}
+            placeholder="e.g. 45m"
+            className="p-1 border rounded-md text-sm w-20 bg-white dark:bg-gray-800"
+          />
+          <button
+            onClick={applyCustom}
+            disabled={isChanging || !isValidTimeRange(customValue)}
+            className="px-2 py-1 text-sm rounded-md bg-gray-200 dark:bg-gray-700 disabled:opacity-50"
+          >
+            Apply
+          </button>
+        </>
+      )}
     </div>
   );
 };

--- a/dashboard/components/ProfitCalculator.tsx
+++ b/dashboard/components/ProfitCalculator.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { MetricData, TimeRange } from '../types';
 import { findMetricValue } from '../utils';
+import { rangeToHours } from '../utils/timeRange';
 import { useEthPrice } from '../services/priceService';
 
 interface ProfitCalculatorProps {
@@ -23,12 +24,7 @@ export const ProfitCalculator: React.FC<ProfitCalculatorProps> = ({
   const { data: ethPrice = 0, error: ethPriceError } = useEthPrice();
 
   const HOURS_IN_MONTH = 30 * 24;
-  const RANGE_HOURS: Record<TimeRange, number> = {
-    '15m': 0.25,
-    '1h': 1,
-    '24h': 24,
-  };
-  const hours = RANGE_HOURS[timeRange];
+  const hours = rangeToHours(timeRange);
 
   const scaledCloudCost = (cloudCost / HOURS_IN_MONTH) * hours;
   const scaledProverCost = (proverCost / HOURS_IN_MONTH) * hours;

--- a/dashboard/components/views/DashboardView.tsx
+++ b/dashboard/components/views/DashboardView.tsx
@@ -5,6 +5,7 @@ import { ChartsGrid } from '../layout/ChartsGrid';
 import { ProfitCalculator } from '../ProfitCalculator';
 import { ProfitabilityChart } from '../ProfitabilityChart';
 import { TimeRange, MetricData } from '../../types';
+import { rangeToHours } from '../../utils/timeRange';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
 interface DashboardViewProps {
@@ -47,11 +48,6 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const isEconomicsView = searchParams.get('view') === 'economics';
-  const hoursMap: Record<TimeRange, number> = {
-    '15m': 0.25,
-    '1h': 1,
-    '24h': 24,
-  };
 
   const visibleMetrics = React.useMemo(
     () =>
@@ -150,10 +146,10 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
           <>
             <ProfitCalculator metrics={metricsData.metrics} timeRange={timeRange} />
             <div className="mt-6">
-              <ProfitabilityChart
-                metrics={metricsData.metrics}
-                hours={hoursMap[timeRange]}
-              />
+            <ProfitabilityChart
+              metrics={metricsData.metrics}
+              hours={rangeToHours(timeRange)}
+            />
             </div>
           </>
         )}

--- a/dashboard/hooks/useTimeRangeSync.ts
+++ b/dashboard/hooks/useTimeRangeSync.ts
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { TimeRange } from '../types';
+import { isValidTimeRange } from '../utils/timeRange';
 
 const DEFAULT_TIME_RANGE: TimeRange = '1h';
-const VALID_TIME_RANGES: TimeRange[] = ['15m', '1h', '24h'];
 
 /**
  * Hook that synchronizes time range state with URL parameters to prevent navigation loops
@@ -16,9 +16,9 @@ export const useTimeRangeSync = () => {
   // Get initial time range from URL or use default
   const getInitialTimeRange = useCallback((): TimeRange => {
     const params = new URLSearchParams(location.search);
-    const urlRange = params.get('range') as TimeRange;
-    return urlRange && VALID_TIME_RANGES.includes(urlRange)
-      ? urlRange
+    const urlRange = params.get('range');
+    return urlRange && isValidTimeRange(urlRange)
+      ? (urlRange as TimeRange)
       : DEFAULT_TIME_RANGE;
   }, [location.search]);
 
@@ -28,7 +28,7 @@ export const useTimeRangeSync = () => {
   // Update time range and sync with URL
   const setTimeRange = useCallback(
     (newRange: TimeRange) => {
-      if (!VALID_TIME_RANGES.includes(newRange)) {
+      if (!isValidTimeRange(newRange)) {
         console.warn('Invalid time range:', newRange);
         return;
       }

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -128,10 +128,10 @@ export const fetchBatchPostingCadence = async (
   };
 };
 
-export const fetchActiveSequencerAddresses = async (): Promise<
-  RequestResult<string[]>
-> => {
-  const res = await fetchPreconfData();
+export const fetchActiveSequencerAddresses = async (
+  range: TimeRange = '1h',
+): Promise<RequestResult<string[]>> => {
+  const res = await fetchPreconfData(range);
   return {
     data: res.data?.candidates ?? null,
     badRequest: res.badRequest,
@@ -249,10 +249,10 @@ export interface PreconfData {
   next_operator?: string;
 }
 
-export const fetchPreconfData = async (): Promise<
-  RequestResult<PreconfData>
-> => {
-  const res = await fetchDashboardData('1h');
+export const fetchPreconfData = async (
+  range: TimeRange = '1h',
+): Promise<RequestResult<PreconfData>> => {
+  const res = await fetchDashboardData(range);
   return {
     data: res.data?.preconf_data ?? null,
     badRequest: res.badRequest,

--- a/dashboard/tests/apiService.test.ts
+++ b/dashboard/tests/apiService.test.ts
@@ -58,7 +58,7 @@ describe('apiService', () => {
 
   it('fetches active sequencer addresses from preconf', async () => {
     globalThis.fetch = mockFetch({ preconf_data: { candidates: ['a', 'b'] } });
-    const gateways = await fetchActiveSequencerAddresses();
+    const gateways = await fetchActiveSequencerAddresses('1h');
     expect(gateways.data).toStrictEqual(['a', 'b']);
   });
 

--- a/dashboard/tests/app.integration.test.ts
+++ b/dashboard/tests/app.integration.test.ts
@@ -26,7 +26,7 @@ import {
 import { createMetrics, hasBadRequest } from '../helpers';
 import type { MetricData } from '../types';
 
-type TimeRange = '15m' | '1h' | '24h';
+type TimeRange = string;
 
 type State = {
   metrics: MetricData[];

--- a/dashboard/tests/app.integration.test.ts
+++ b/dashboard/tests/app.integration.test.ts
@@ -253,7 +253,7 @@ async function fetchData(range: TimeRange, state: State, economics = false) {
     fetchBatchPostingCadence(range),
     fetchAvgProveTime(range),
     fetchAvgVerifyTime(range),
-    fetchPreconfData(),
+    fetchPreconfData(range),
     fetchL2Reorgs(range),
     fetchL2ReorgEvents(range),
     fetchSlashingEventCount(range),

--- a/dashboard/tests/dashboardHeader.test.ts
+++ b/dashboard/tests/dashboardHeader.test.ts
@@ -37,6 +37,7 @@ describe('DashboardHeader', () => {
     expect(html.includes('15m')).toBe(true);
     expect(html.includes('1h')).toBe(true);
     expect(html.includes('24h')).toBe(true);
+    expect(html.includes('Custom...')).toBe(true);
     expect(html.includes('Refresh')).toBe(true);
     expect(html.includes('Status')).toBe(true);
     expect(html.includes('All Sequencers')).toBe(true);

--- a/dashboard/types.ts
+++ b/dashboard/types.ts
@@ -1,4 +1,4 @@
-export type TimeRange = '15m' | '1h' | '24h';
+export type TimeRange = string;
 
 export interface TimeSeriesData {
   timestamp: number; // Unix timestamp (ms)

--- a/dashboard/utils/navigationUtils.ts
+++ b/dashboard/utils/navigationUtils.ts
@@ -1,4 +1,5 @@
 // Navigation utility functions for robust URL handling
+import { isValidTimeRange } from './timeRange';
 
 export const isValidUrl = (urlString: string): boolean => {
   try {
@@ -94,7 +95,7 @@ export const validateSearchParams = (params: URLSearchParams): boolean => {
     }
 
     const range = params.get('range');
-    if (range && !['15m', '1h', '24h'].includes(range)) {
+    if (range && !isValidTimeRange(range)) {
       console.warn('Invalid range parameter:', range);
       return false;
     }
@@ -132,7 +133,7 @@ export const cleanSearchParams = (params: URLSearchParams): URLSearchParams => {
       page: (v) => /^\d+$/.test(v),
       start: (v) => /^\d+$/.test(v),
       end: (v) => /^\d+$/.test(v),
-      range: (v) => ['15m', '1h', '24h'].includes(v),
+      range: (v) => isValidTimeRange(v),
       sequencer: (v) => /^[0-9a-zA-Z]+$/.test(v),
       address: (v) => /^[0-9a-zA-Z]+$/.test(v),
       table: (v) => /^[a-zA-Z0-9_-]+$/.test(v),

--- a/dashboard/utils/timeRange.ts
+++ b/dashboard/utils/timeRange.ts
@@ -1,0 +1,16 @@
+export const isValidTimeRange = (range: string): boolean => {
+  const match = range.trim().match(/^(\d+)([mh])$/i);
+  if (!match) return false;
+  const value = parseInt(match[1], 10);
+  if (value <= 0) return false;
+  const unit = match[2].toLowerCase();
+  const minutes = unit === 'h' ? value * 60 : value;
+  return minutes <= 24 * 60;
+};
+
+export const rangeToHours = (range: string): number => {
+  const match = range.trim().match(/^(\d+)([mh])$/i);
+  if (!match) return 1;
+  const value = parseInt(match[1], 10);
+  return match[2].toLowerCase() === 'h' ? value : value / 60;
+};


### PR DESCRIPTION
## Summary
- allow custom time ranges up to 24h
- parse/validate ranges with new helpers
- switch time range buttons to a dropdown with custom input
- adjust metrics code to handle custom ranges
- update tests

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_684bd777d0648328b5dc28012102b377