### PR TITLE
Move performance/health metrics

### DIFF
--- a/dashboard/components/layout/ChartsGrid.tsx
+++ b/dashboard/components/layout/ChartsGrid.tsx
@@ -71,33 +71,6 @@ export const ChartsGrid: React.FC<ChartsGridProps> = ({
   const networkPerformanceCharts = (
     <>
       <ChartCard
-        title="Prove Time"
-        onMore={() => onOpenTable('prove-time', timeRange)}
-        loading={isLoading}
-      >
-        <BatchProcessChart
-          key={timeRange}
-          data={chartsData.secondsToProveData}
-          lineColor={TAIKO_PINK}
-        />
-      </ChartCard>
-      <ChartCard
-        title="Verify Time"
-        onMore={() => onOpenTable('verify-time', timeRange)}
-        loading={isLoading}
-      >
-        <BatchProcessChart
-          key={timeRange}
-          data={chartsData.secondsToVerifyData}
-          lineColor="#5DA5DA"
-        />
-      </ChartCard>
-    </>
-  );
-
-  const networkHealthCharts = (
-    <>
-      <ChartCard
         title="Gas Used Per Block"
         onMore={() => onOpenTable('l2-gas-used', timeRange)}
         loading={isLoading}
@@ -117,6 +90,33 @@ export const ChartsGrid: React.FC<ChartsGridProps> = ({
           key={timeRange}
           data={chartsData.blockTxData}
           lineColor="#4E79A7"
+        />
+      </ChartCard>
+    </>
+  );
+
+  const networkHealthCharts = (
+    <>
+      <ChartCard
+        title="Prove Time"
+        onMore={() => onOpenTable('prove-time', timeRange)}
+        loading={isLoading}
+      >
+        <BatchProcessChart
+          key={timeRange}
+          data={chartsData.secondsToProveData}
+          lineColor={TAIKO_PINK}
+        />
+      </ChartCard>
+      <ChartCard
+        title="Verify Time"
+        onMore={() => onOpenTable('verify-time', timeRange)}
+        loading={isLoading}
+      >
+        <BatchProcessChart
+          key={timeRange}
+          data={chartsData.secondsToVerifyData}
+          lineColor="#5DA5DA"
         />
       </ChartCard>
       <ChartCard

--- a/dashboard/components/views/DashboardView.tsx
+++ b/dashboard/components/views/DashboardView.tsx
@@ -109,8 +109,8 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
   const skeletonGroupCounts: Record<string, number> = isEconomicsView
     ? { 'Network Economics': 1 }
     : {
-      'Network Performance': 5,
-      'Network Health': 4,
+      'Network Performance': 3,
+      'Network Health': 5,
       Sequencers: 3,
     };
 
@@ -157,33 +157,6 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
 
     const performance = [
       <ChartCard
-        key="prove"
-        title="Prove Time"
-        onMore={() => onOpenTable('prove-time', timeRange)}
-        loading={isLoadingData}
-      >
-        <BatchProcessChart
-          key={timeRange}
-          data={chartsData.secondsToProveData}
-          lineColor={TAIKO_PINK}
-        />
-      </ChartCard>,
-      <ChartCard
-        key="verify"
-        title="Verify Time"
-        onMore={() => onOpenTable('verify-time', timeRange)}
-        loading={isLoadingData}
-      >
-        <BatchProcessChart
-          key={`${timeRange}-v`}
-          data={chartsData.secondsToVerifyData}
-          lineColor="#5DA5DA"
-        />
-      </ChartCard>,
-    ];
-
-    const health = [
-      <ChartCard
         key="gas"
         title="Gas Used Per Block"
         onMore={() => onOpenTable('l2-gas-used', timeRange)}
@@ -205,6 +178,33 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
           key={`${timeRange}-t`}
           data={chartsData.blockTxData}
           lineColor="#4E79A7"
+        />
+      </ChartCard>,
+    ];
+
+    const health = [
+      <ChartCard
+        key="prove"
+        title="Prove Time"
+        onMore={() => onOpenTable('prove-time', timeRange)}
+        loading={isLoadingData}
+      >
+        <BatchProcessChart
+          key={timeRange}
+          data={chartsData.secondsToProveData}
+          lineColor={TAIKO_PINK}
+        />
+      </ChartCard>,
+      <ChartCard
+        key="verify"
+        title="Verify Time"
+        onMore={() => onOpenTable('verify-time', timeRange)}
+        loading={isLoadingData}
+      >
+        <BatchProcessChart
+          key={`${timeRange}-v`}
+          data={chartsData.secondsToVerifyData}
+          lineColor="#5DA5DA"
         />
       </ChartCard>,
       <ChartCard

--- a/dashboard/tests/helpers.test.ts
+++ b/dashboard/tests/helpers.test.ts
@@ -53,9 +53,9 @@ describe('helpers', () => {
     expect(metrics[2].value).toBe('N/A');
     expect(metrics[2].group).toBe('Network Performance');
     expect(metrics[3].value).toBe('1.20s');
-    expect(metrics[3].group).toBe('Network Performance');
+    expect(metrics[3].group).toBe('Network Health');
     expect(metrics[4].value).toBe('N/A');
-    expect(metrics[4].group).toBe('Network Performance');
+    expect(metrics[4].group).toBe('Network Health');
     expect(metrics[5].value).toBe('2');
     expect(metrics[5].group).toBe('Sequencers');
     expect(metrics[6].value).toBe('0xabc');
@@ -92,8 +92,8 @@ describe('helpers', () => {
     expect(metricsAllNull[0].group).toBe('Network Performance');
     expect(metricsAllNull[1].group).toBe('Network Performance');
     expect(metricsAllNull[2].group).toBe('Network Performance');
-    expect(metricsAllNull[3].group).toBe('Network Performance');
-    expect(metricsAllNull[4].group).toBe('Network Performance');
+    expect(metricsAllNull[3].group).toBe('Network Health');
+    expect(metricsAllNull[4].group).toBe('Network Health');
     expect(metricsAllNull[5].group).toBe('Sequencers');
     expect(metricsAllNull[6].group).toBe('Sequencers');
     expect(metricsAllNull[7].group).toBe('Sequencers');

--- a/dashboard/utils/metricsCreator.ts
+++ b/dashboard/utils/metricsCreator.ts
@@ -48,7 +48,7 @@ export const createMetrics = (data: MetricInputData): MetricData[] => [
       data.avgProve != null && data.avgProve > 0
         ? formatSeconds(data.avgProve / 1000)
         : 'N/A',
-    group: 'Network Performance',
+    group: 'Network Health',
   },
   {
     title: React.createElement(
@@ -65,7 +65,7 @@ export const createMetrics = (data: MetricInputData): MetricData[] => [
       data.avgVerify != null && data.avgVerify > 0
         ? formatSeconds(data.avgVerify / 1000)
         : 'N/A',
-    group: 'Network Performance',
+    group: 'Network Health',
   },
   {
     title: 'Active Sequencers',


### PR DESCRIPTION
## Summary
- swap metric groups for charts showing prove/verify times
- move gas usage and tx count charts to performance group
- adjust skeleton placeholders and tests for new group mapping

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_684beed0c7f48328b6f1b534627b4dbc