### PR TITLE
Fix profit chart

### DIFF
--- a/dashboard/components/ProfitabilityChart.tsx
+++ b/dashboard/components/ProfitabilityChart.tsx
@@ -16,12 +16,14 @@ interface ProfitabilityChartProps {
   metrics: MetricData[];
   hours: number; // hours represented by the metric values
   cloudCost: number; // monthly cloud cost from calculator
+  proverCost: number; // monthly prover cost from calculator
 }
 
 export const ProfitabilityChart: React.FC<ProfitabilityChartProps> = ({
   metrics,
   hours,
   cloudCost,
+  proverCost,
 }) => {
   const priorityStr = findMetricValue(metrics, 'priority fee');
   const baseStr = findMetricValue(metrics, 'base fee');
@@ -29,6 +31,7 @@ export const ProfitabilityChart: React.FC<ProfitabilityChartProps> = ({
   const baseFee = parseFloat(baseStr.replace(/[^0-9.]/g, '')) || null;
   const HOURS_IN_MONTH = 30 * 24;
   const scaledCloudCost = (cloudCost / HOURS_IN_MONTH) * hours;
+  const scaledProverCost = (proverCost / HOURS_IN_MONTH) * hours;
   const l2TxFee =
     priorityFee != null && baseFee != null ? priorityFee + baseFee : null;
   const { data: ethPrice = 0 } = useEthPrice();
@@ -41,7 +44,8 @@ export const ProfitabilityChart: React.FC<ProfitabilityChartProps> = ({
     );
   }
 
-  const profitPerHour = (l2TxFee * ethPrice - scaledCloudCost) / hours;
+  const profitPerHour =
+    (l2TxFee * ethPrice - scaledCloudCost - scaledProverCost) / hours;
 
   const data = Array.from({ length: 12 }, (_, i) => {
     const month = i + 1;

--- a/dashboard/components/views/DashboardView.tsx
+++ b/dashboard/components/views/DashboardView.tsx
@@ -307,11 +307,12 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
               onProverCostChange={setProverCost}
             />
             <div className="mt-6">
-              <ProfitabilityChart
-                metrics={metricsData.metrics}
-                hours={hoursMap[timeRange]}
-                cloudCost={cloudCost}
-              />
+            <ProfitabilityChart
+              metrics={metricsData.metrics}
+              hours={hoursMap[timeRange]}
+              cloudCost={cloudCost}
+              proverCost={proverCost}
+            />
             </div>
           </>
         )}


### PR DESCRIPTION
## Summary
- add prover cost to profitability chart calculation
- pass prover cost through dashboard view

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_684bf0179380832886cdd308876175e5