### PR TITLE
Add L1 data cost metric

### DIFF
--- a/dashboard/components/views/DashboardView.tsx
+++ b/dashboard/components/views/DashboardView.tsx
@@ -113,7 +113,7 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
     : ['Network Performance', 'Network Health', 'Sequencers', 'Other'];
 
   const skeletonGroupCounts: Record<string, number> = isEconomicsView
-    ? { 'Network Economics': 1 }
+    ? { 'Network Economics': 3 }
     : {
       'Network Performance': 5,
       'Network Health': 4,

--- a/dashboard/hooks/useDataFetcher.ts
+++ b/dashboard/hooks/useDataFetcher.ts
@@ -67,6 +67,7 @@ export const useDataFetcher = ({
         forcedInclusions: null,
         priorityFee: data.priorityFee,
         baseFee: data.baseFee,
+        l1DataCost: data.l1DataCost,
         l2Block: data.l2Block,
         l1Block: data.l1Block,
       };
@@ -99,6 +100,7 @@ export const useDataFetcher = ({
       forcedInclusions: data.forcedInclusions,
       priorityFee: data.priorityFee,
       baseFee: data.baseFee,
+      l1DataCost: null,
       l2Block: data.l2Block,
       l1Block: data.l1Block,
     };

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -587,6 +587,25 @@ export const fetchL2Fees = async (
   };
 };
 
+export interface L1DataCost {
+  block: number;
+  cost: number;
+}
+
+export const fetchL1DataCost = async (
+  range: TimeRange,
+): Promise<RequestResult<L1DataCost[]>> => {
+  const url = `${API_BASE}/l1-data-cost?range=${range}`;
+  const res = await fetchJson<{ blocks: { l1_block_number: number; cost: number }[] }>(url);
+  return {
+    data: res.data
+      ? res.data.blocks.map((b) => ({ block: b.l1_block_number, cost: b.cost }))
+      : null,
+    badRequest: res.badRequest,
+    error: res.error,
+  };
+};
+
 export const fetchL2Tps = async (
   range: TimeRange,
   address?: string,

--- a/dashboard/tests/dataFetcher.test.ts
+++ b/dashboard/tests/dataFetcher.test.ts
@@ -85,6 +85,7 @@ describe('dataFetcher', () => {
       fetchL2Fees: ok({ priority_fee: 1, base_fee: 2 }),
       fetchL2HeadBlock: ok(2),
       fetchL1HeadBlock: ok(3),
+      fetchL1DataCost: ok([{ block: 1, cost: 4 }]),
     });
 
     const res = await fetchEconomicsData('1h', null);
@@ -92,7 +93,8 @@ describe('dataFetcher', () => {
     expect(res.baseFee).toBe(2);
     expect(res.l2Block).toBe(2);
     expect(res.l1Block).toBe(3);
-    expect(res.badRequestResults).toHaveLength(3);
+    expect(res.l1DataCost).toBe(4);
+    expect(res.badRequestResults).toHaveLength(4);
   });
 
   it('resets isTimeRangeChanging on fetch error', async () => {

--- a/dashboard/tests/helpers.test.ts
+++ b/dashboard/tests/helpers.test.ts
@@ -17,6 +17,7 @@ const metrics = createMetrics({
   l1Block: 50,
   priorityFee: 41e18,
   baseFee: 1e18,
+  l1DataCost: 2e18,
 });
 
 const results = [
@@ -40,6 +41,7 @@ const metricsAllNull = createMetrics({
   nextOperator: null,
   priorityFee: null,
   baseFee: null,
+  l1DataCost: null,
 });
 
 describe('helpers', () => {
@@ -70,10 +72,12 @@ describe('helpers', () => {
     expect(metrics[11].group).toBe('Network Economics');
     expect(metrics[12].value).toBe('1.00 ETH');
     expect(metrics[12].group).toBe('Network Economics');
-    expect(metrics[13].value).toBe('100');
-    expect(metrics[13].group).toBe('Block Information');
-    expect(metrics[14].value).toBe('50');
+    expect(metrics[13].value).toBe('2.00 ETH');
+    expect(metrics[13].group).toBe('Network Economics');
+    expect(metrics[14].value).toBe('100');
     expect(metrics[14].group).toBe('Block Information');
+    expect(metrics[15].value).toBe('50');
+    expect(metrics[15].group).toBe('Block Information');
   });
 
   it('detects bad requests', () => {
@@ -100,8 +104,9 @@ describe('helpers', () => {
     expect(metricsAllNull[10].group).toBe('Network Health');
     expect(metricsAllNull[11].group).toBe('Network Economics');
     expect(metricsAllNull[12].group).toBe('Network Economics');
-    expect(metricsAllNull[13].group).toBe('Block Information');
+    expect(metricsAllNull[13].group).toBe('Network Economics');
     expect(metricsAllNull[14].group).toBe('Block Information');
+    expect(metricsAllNull[15].group).toBe('Block Information');
   });
 
   it('handles all successful requests', () => {

--- a/dashboard/tests/metricsCreator.test.ts
+++ b/dashboard/tests/metricsCreator.test.ts
@@ -21,11 +21,12 @@ describe('metricsCreator', () => {
       forcedInclusions: 3,
       priorityFee: 40e18,
       baseFee: 2e18,
+      l1DataCost: 3e18,
       l2Block: 100,
       l1Block: 50,
     });
 
-    expect(metrics).toHaveLength(15);
+    expect(metrics).toHaveLength(16);
     expect(metrics[0].value).toBe('1.23');
 
     const verifyMetric = metrics.find((m) => React.isValidElement(m.title));
@@ -57,6 +58,7 @@ describe('metricsCreator', () => {
       forcedInclusions: null,
       priorityFee: null,
       baseFee: null,
+      l1DataCost: null,
       l2Block: null,
       l1Block: null,
     });

--- a/dashboard/utils/dataFetcher.ts
+++ b/dashboard/utils/dataFetcher.ts
@@ -12,6 +12,7 @@ import {
   fetchL2Fees,
   fetchL2HeadBlock,
   fetchL1HeadBlock,
+  fetchL1DataCost,
 } from '../services/apiService';
 
 export interface MainDashboardData {
@@ -41,6 +42,7 @@ export interface MainDashboardData {
 export interface EconomicsData {
   priorityFee: number | null;
   baseFee: number | null;
+  l1DataCost: number | null;
   l2Block: number | null;
   l1Block: number | null;
   badRequestResults: any[];
@@ -116,20 +118,25 @@ export const fetchEconomicsData = async (
   timeRange: TimeRange,
   selectedSequencer: string | null,
 ): Promise<EconomicsData> => {
-  const [l2FeesRes, l2BlockRes, l1BlockRes] = await Promise.all([
+  const [l2FeesRes, l2BlockRes, l1BlockRes, l1CostRes] = await Promise.all([
     fetchL2Fees(
       timeRange,
       selectedSequencer ? getSequencerAddress(selectedSequencer) : undefined,
     ),
     fetchL2HeadBlock(timeRange),
     fetchL1HeadBlock(timeRange),
+    fetchL1DataCost(timeRange),
   ]);
 
   return {
     priorityFee: l2FeesRes.data?.priority_fee ?? null,
     baseFee: l2FeesRes.data?.base_fee ?? null,
+    l1DataCost:
+      l1CostRes.data && l1CostRes.data.length > 0
+        ? l1CostRes.data[l1CostRes.data.length - 1].cost
+        : null,
     l2Block: l2BlockRes.data,
     l1Block: l1BlockRes.data,
-    badRequestResults: [l2FeesRes, l2BlockRes, l1BlockRes],
+    badRequestResults: [l2FeesRes, l2BlockRes, l1BlockRes, l1CostRes],
   };
 };

--- a/dashboard/utils/metricsCreator.ts
+++ b/dashboard/utils/metricsCreator.ts
@@ -19,6 +19,7 @@ export interface MetricInputData {
   l1Block: number | null;
   priorityFee: number | null;
   baseFee: number | null;
+  l1DataCost?: number | null;
 }
 
 export const createMetrics = (data: MetricInputData): MetricData[] => [
@@ -117,6 +118,12 @@ export const createMetrics = (data: MetricInputData): MetricData[] => [
   {
     title: 'Base Fee',
     value: data.baseFee != null ? formatEth(data.baseFee) : 'N/A',
+    group: 'Network Economics',
+  },
+  {
+    title: 'L1 Data Cost',
+    value:
+      data.l1DataCost != null ? formatEth(data.l1DataCost) : 'N/A',
     group: 'Network Economics',
   },
   {


### PR DESCRIPTION
## Summary
- fetch L1 data cost from API
- surface l1-data-cost in the dashboard metrics
- update economics view skeleton counts
- adjust tests for new metric

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_684bf118ab908328b0afef84029b51cb