### PR TITLE
Add monitor startup logging

### DIFF
--- a/crates/network/src/public_rpc_monitor.rs
+++ b/crates/network/src/public_rpc_monitor.rs
@@ -13,6 +13,7 @@ use tracing::{error, info, warn};
 /// If it returns `true` or times out after five seconds, the check is retried
 /// after 15 seconds. Two consecutive negative results lead to an error log.
 pub fn spawn_public_rpc_monitor(url: Url) -> tokio::task::JoinHandle<()> {
+    info!(url = url.as_str(), "Spawning public rpc monitor");
     tokio::spawn(async move {
         let client = Client::new();
         let mut interval = tokio::time::interval(Duration::from_secs(60));


### PR DESCRIPTION
## Summary
- log each monitor as it is spawned in the driver
- log when the public RPC monitor task starts
- factor `spawn_monitors` into smaller helper functions

## Testing
- `just fmt`
- `just lint`
- `just test`
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_684bf57298e483289830d6df364efa73