### PR TITLE
Unify data cost endpoint

### DIFF
--- a/crates/api-types/src/lib.rs
+++ b/crates/api-types/src/lib.rs
@@ -172,6 +172,8 @@ pub struct L2FeesResponse {
     pub priority_fee: Option<u128>,
     /// 75% of the sum of base fees for the range.
     pub base_fee: Option<u128>,
+    /// Total L1 data posting cost for the range.
+    pub l1_data_cost: Option<u128>,
 }
 
 /// Estimated cloud infrastructure cost in USD.

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -570,6 +570,7 @@ export const fetchAvgL2Tps = async (
 export interface L2FeesResponse {
   priority_fee: number | null;
   base_fee: number | null;
+  l1_data_cost: number | null;
 }
 
 export const fetchL2Fees = async (
@@ -587,24 +588,6 @@ export const fetchL2Fees = async (
   };
 };
 
-export interface L1DataCost {
-  block: number;
-  cost: number;
-}
-
-export const fetchL1DataCost = async (
-  range: TimeRange,
-): Promise<RequestResult<L1DataCost[]>> => {
-  const url = `${API_BASE}/l1-data-cost?range=${range}`;
-  const res = await fetchJson<{ blocks: { l1_block_number: number; cost: number }[] }>(url);
-  return {
-    data: res.data
-      ? res.data.blocks.map((b) => ({ block: b.l1_block_number, cost: b.cost }))
-      : null,
-    badRequest: res.badRequest,
-    error: res.error,
-  };
-};
 
 export const fetchL2Tps = async (
   range: TimeRange,

--- a/dashboard/tests/dataFetcher.test.ts
+++ b/dashboard/tests/dataFetcher.test.ts
@@ -82,10 +82,9 @@ describe('dataFetcher', () => {
 
   it('fetches economics data', async () => {
     setAll({
-      fetchL2Fees: ok({ priority_fee: 1, base_fee: 2 }),
+      fetchL2Fees: ok({ priority_fee: 1, base_fee: 2, l1_data_cost: 4 }),
       fetchL2HeadBlock: ok(2),
       fetchL1HeadBlock: ok(3),
-      fetchL1DataCost: ok([{ block: 1, cost: 4 }]),
     });
 
     const res = await fetchEconomicsData('1h', null);
@@ -94,7 +93,7 @@ describe('dataFetcher', () => {
     expect(res.l2Block).toBe(2);
     expect(res.l1Block).toBe(3);
     expect(res.l1DataCost).toBe(4);
-    expect(res.badRequestResults).toHaveLength(4);
+    expect(res.badRequestResults).toHaveLength(3);
   });
 
   it('resets isTimeRangeChanging on fetch error', async () => {

--- a/dashboard/utils/dataFetcher.ts
+++ b/dashboard/utils/dataFetcher.ts
@@ -12,7 +12,6 @@ import {
   fetchL2Fees,
   fetchL2HeadBlock,
   fetchL1HeadBlock,
-  fetchL1DataCost,
 } from '../services/apiService';
 
 export interface MainDashboardData {
@@ -118,25 +117,21 @@ export const fetchEconomicsData = async (
   timeRange: TimeRange,
   selectedSequencer: string | null,
 ): Promise<EconomicsData> => {
-  const [l2FeesRes, l2BlockRes, l1BlockRes, l1CostRes] = await Promise.all([
+  const [l2FeesRes, l2BlockRes, l1BlockRes] = await Promise.all([
     fetchL2Fees(
       timeRange,
       selectedSequencer ? getSequencerAddress(selectedSequencer) : undefined,
     ),
     fetchL2HeadBlock(timeRange),
     fetchL1HeadBlock(timeRange),
-    fetchL1DataCost(timeRange),
   ]);
 
   return {
     priorityFee: l2FeesRes.data?.priority_fee ?? null,
     baseFee: l2FeesRes.data?.base_fee ?? null,
-    l1DataCost:
-      l1CostRes.data && l1CostRes.data.length > 0
-        ? l1CostRes.data[l1CostRes.data.length - 1].cost
-        : null,
+    l1DataCost: l2FeesRes.data?.l1_data_cost ?? null,
     l2Block: l2BlockRes.data,
     l1Block: l1BlockRes.data,
-    badRequestResults: [l2FeesRes, l2BlockRes, l1BlockRes, l1CostRes],
+    badRequestResults: [l2FeesRes, l2BlockRes, l1BlockRes],
   };
 };


### PR DESCRIPTION
## Summary
- include L1 data cost in `l2-fees` API response
- aggregate total cost in ClickHouse reader
- drop obsolete `/l1-data-cost` endpoint and client calls
- adjust dashboard code and tests

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_684bf54582ec83288a8675c4e03ca366