### PR TITLE
Clarify fee logging

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -1091,7 +1091,7 @@ async fn l2_fees(
         )
     })?;
 
-    tracing::info!(?priority_fee, ?base_fee, "Returning L2 fees");
+    tracing::info!(?priority_fee, ?base_fee, ?l1_data_cost, "Returning L2 fees and L1 data cost");
     Ok(Json(L2FeesResponse { priority_fee, base_fee, l1_data_cost }))
 }
 


### PR DESCRIPTION
## Summary
- log all fee components being returned by the `/l2-fees` endpoint

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_684bfcc2f5488328b5c88691aea830cf