### PR TITLE
Add profit metrics endpoint and chart

### DIFF
--- a/crates/api-types/src/lib.rs
+++ b/crates/api-types/src/lib.rs
@@ -6,8 +6,8 @@
 
 use clickhouse_lib::{
     BatchBlobCountRow, BatchPostingTimeRow, BatchProveTimeRow, BatchVerifyTimeRow,
-    ForcedInclusionProcessedRow, L1BlockTimeRow, L1DataCostRow, L2BlockTimeRow, L2GasUsedRow,
-    L2ReorgRow, L2TpsRow, SlashingEventRow,
+    BlockFeeComponentRow, ForcedInclusionProcessedRow, L1BlockTimeRow, L1DataCostRow,
+    L2BlockTimeRow, L2GasUsedRow, L2ReorgRow, L2TpsRow, SlashingEventRow,
 };
 
 use axum::{Json, http::StatusCode, response::IntoResponse};
@@ -223,6 +223,13 @@ pub struct L2GasUsedResponse {
 pub struct L1DataCostResponse {
     /// Cost per block.
     pub blocks: Vec<L1DataCostRow>,
+}
+
+/// Fee components for each L2 block
+#[derive(Debug, Serialize, ToSchema)]
+pub struct FeeComponentsResponse {
+    /// Fee components per block
+    pub blocks: Vec<BlockFeeComponentRow>,
 }
 
 /// TPS values for each L2 block.

--- a/crates/clickhouse/src/models.rs
+++ b/crates/clickhouse/src/models.rs
@@ -226,6 +226,19 @@ pub struct L1DataCostRow {
     pub cost: u128,
 }
 
+/// Row representing the fee components for an L2 block
+#[derive(Debug, Row, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+pub struct BlockFeeComponentRow {
+    /// L2 block number
+    pub l2_block_number: u64,
+    /// Total priority fee for the block
+    pub priority_fee: u128,
+    /// 75% of the total base fee for the block
+    pub base_fee: u128,
+    /// L1 data posting cost associated with the block, if available
+    pub l1_data_cost: Option<u128>,
+}
+
 /// Row representing the transactions per second for an L2 block
 #[derive(Debug, Serialize, Deserialize, PartialEq, ToSchema)]
 pub struct L2TpsRow {

--- a/dashboard/components/views/DashboardView.tsx
+++ b/dashboard/components/views/DashboardView.tsx
@@ -81,11 +81,6 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
   const isEconomicsView = searchParams.get('view') === 'economics';
   const [cloudCost, setCloudCost] = useState(100);
   const [proverCost, setProverCost] = useState(100);
-  const hoursMap: Record<TimeRange, number> = {
-    '15m': 0.25,
-    '1h': 1,
-    '24h': 24,
-  };
 
   const visibleMetrics = React.useMemo(
     () =>
@@ -308,10 +303,10 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
             />
             <div className="mt-6">
             <ProfitabilityChart
-              metrics={metricsData.metrics}
-              hours={hoursMap[timeRange]}
+              timeRange={timeRange}
               cloudCost={cloudCost}
               proverCost={proverCost}
+              address={selectedSequencer || undefined}
             />
             </div>
           </>

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -589,6 +589,37 @@ export const fetchL2Fees = async (
 };
 
 
+export interface FeeComponent {
+  block: number;
+  priority: number;
+  base: number;
+  l1Cost: number | null;
+}
+
+export const fetchFeeComponents = async (
+  range: TimeRange,
+  address?: string,
+): Promise<RequestResult<FeeComponent[]>> => {
+  const url =
+    `${API_BASE}/l2-fee-components?range=${range}` +
+    (address ? `&address=${address}` : '');
+  const res = await fetchJson<{
+    blocks: { l2_block_number: number; priority_fee: number; base_fee: number; l1_data_cost: number | null }[];
+  }>(url);
+  return {
+    data: res.data
+      ? res.data.blocks.map((b) => ({
+          block: b.l2_block_number,
+          priority: b.priority_fee,
+          base: b.base_fee,
+          l1Cost: b.l1_data_cost ?? null,
+        }))
+      : null,
+    badRequest: res.badRequest,
+    error: res.error,
+  };
+};
+
 export const fetchL2Tps = async (
   range: TimeRange,
   address?: string,

--- a/dashboard/types.ts
+++ b/dashboard/types.ts
@@ -47,3 +47,10 @@ export interface ErrorResponse {
   status: number;
   detail: string;
 }
+
+export interface FeeComponent {
+  block: number;
+  priority: number;
+  base: number;
+  l1Cost: number | null;
+}


### PR DESCRIPTION
## Summary
- expose per-block fee components via `/l2-fee-components`
- fetch fee components in dashboard
- compute profit per block in `ProfitabilityChart`
- wire chart into economics view
- rename fee component structs for clarity

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_684bf68942088328bac9e48ba0ebdd12