### PR TITLE
Fix ascending order for Gas Used chart

### DIFF
--- a/dashboard/components/routes/TableRoute.tsx
+++ b/dashboard/components/routes/TableRoute.tsx
@@ -114,6 +114,7 @@ export const TableRoute: React.FC = () => {
         const res = await config.fetcher(range, ...fetcherArgs);
         if (currentFetchId !== fetchIdRef.current) return;
         let data = res.data || [];
+        const chartData = data;
         if (config.reverseOrder) {
           data = [...data].reverse();
         }
@@ -126,7 +127,7 @@ export const TableRoute: React.FC = () => {
         const mappedData = config.mapData
           ? config.mapData(data, extraParams)
           : data;
-        const chart = config.chart ? config.chart(data) : undefined;
+        const chart = config.chart ? config.chart(chartData) : undefined;
 
         if (currentFetchId === fetchIdRef.current) {
           setTableView({


### PR DESCRIPTION
## Summary
- ensure chart data is preserved in ascending order when table rows are reversed

## Testing
- `npm run check`
- `npm run lint:whitespace`
- `npm run test`
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_684bfe52ff848328bab83df39b218870