### PR TITLE
Include L1 data cost in profit calculator

### DIFF
--- a/crates/clickhouse/src/reader.rs
+++ b/crates/clickhouse/src/reader.rs
@@ -1011,7 +1011,7 @@ impl ClickhouseReader {
             "SELECT h.l2_block_number, \
                     sum_priority_fee AS priority_fee, \
                     toUInt128(sum_base_fee * 3 / 4) AS base_fee, \
-                    dc.cost AS l1_data_cost \
+                    toNullable(dc.cost) AS l1_data_cost \
              FROM {db}.l2_head_events h \
              LEFT JOIN {db}.l1_data_costs dc \
                ON h.l2_block_number = dc.l1_block_number \

--- a/dashboard/components/ProfitCalculator.tsx
+++ b/dashboard/components/ProfitCalculator.tsx
@@ -66,18 +66,24 @@ export const ProfitCalculator: React.FC<ProfitCalculatorProps> = ({
           Monthly Cloud Cost ($)
           <input
             type="number"
+            min={0}
             className="p-1 border rounded-md"
             value={cloudCost}
-            onChange={(e) => onCloudCostChange(Number(e.target.value))}
+            onChange={(e) =>
+              onCloudCostChange(Math.max(0, Number(e.target.value)))
+            }
           />
         </label>
         <label className="flex flex-col text-sm">
           Prover Cost ($)
           <input
             type="number"
+            min={0}
             className="p-1 border rounded-md"
             value={proverCost}
-            onChange={(e) => onProverCostChange(Number(e.target.value))}
+            onChange={(e) =>
+              onProverCostChange(Math.max(0, Number(e.target.value)))
+            }
           />
         </label>
       </div>

--- a/dashboard/components/ProfitCalculator.tsx
+++ b/dashboard/components/ProfitCalculator.tsx
@@ -32,9 +32,11 @@ export const ProfitCalculator: React.FC<ProfitCalculatorProps> = ({
 }) => {
   const priorityStr = findMetricValue(metrics, 'priority fee');
   const baseStr = findMetricValue(metrics, 'base fee');
+  const l1DataCostStr = findMetricValue(metrics, 'l1 data cost');
   const priority = parseFloat(priorityStr.replace(/[^0-9.]/g, '')) || 0;
   const base = parseFloat(baseStr.replace(/[^0-9.]/g, '')) || 0;
-  const totalFee = priority + base;
+  const l1DataCost = parseFloat(l1DataCostStr.replace(/[^0-9.]/g, '')) || 0;
+  const totalFee = priority + base - l1DataCost;
 
   const { data: ethPrice = 0, error: ethPriceError } = useEthPrice();
 

--- a/dashboard/components/ProfitabilityChart.tsx
+++ b/dashboard/components/ProfitabilityChart.tsx
@@ -71,7 +71,7 @@ export const ProfitabilityChart: React.FC<ProfitabilityChartProps> = ({
         <YAxis
           stroke="#666666"
           fontSize={12}
-          domain={[0, 'auto']}
+          domain={['auto', 'auto']}
           tickFormatter={(v: number) => `$${v.toLocaleString()}`}
           label={{
             value: 'Profit (USD)',

--- a/dashboard/components/routes/TableRoute.tsx
+++ b/dashboard/components/routes/TableRoute.tsx
@@ -114,6 +114,7 @@ export const TableRoute: React.FC = () => {
         const res = await config.fetcher(range, ...fetcherArgs);
         if (currentFetchId !== fetchIdRef.current) return;
         let data = res.data || [];
+        const chartData = data;
         if (config.reverseOrder) {
           data = [...data].reverse();
         }
@@ -126,7 +127,7 @@ export const TableRoute: React.FC = () => {
         const mappedData = config.mapData
           ? config.mapData(data, extraParams)
           : data;
-        const chart = config.chart ? config.chart(data) : undefined;
+        const chart = config.chart ? config.chart(chartData) : undefined;
 
         if (currentFetchId === fetchIdRef.current) {
           setTableView({

--- a/dashboard/tests/profitCalculator.test.ts
+++ b/dashboard/tests/profitCalculator.test.ts
@@ -14,6 +14,7 @@ describe('ProfitCalculator', () => {
         metrics: [
           { title: 'Priority Fee', value: '0.6 ETH' },
           { title: 'Base Fee', value: '0.4 ETH' },
+          { title: 'L1 Data Cost', value: '0.1 ETH' },
         ],
         timeRange: '1h',
         cloudCost: 100,
@@ -22,6 +23,6 @@ describe('ProfitCalculator', () => {
         onProverCostChange: () => {},
       }),
     );
-    expect(html.includes('1,999')).toBe(true);
+    expect(html.includes('1,799')).toBe(true);
   });
 });

--- a/dashboard/tests/profitCalculator.test.ts
+++ b/dashboard/tests/profitCalculator.test.ts
@@ -25,4 +25,25 @@ describe('ProfitCalculator', () => {
     );
     expect(html.includes('1,799')).toBe(true);
   });
+
+  it('rejects negative values via min attribute', () => {
+    vi.spyOn(priceService, 'useEthPrice').mockReturnValue({
+      data: 2000,
+    } as any);
+    const html = renderToStaticMarkup(
+      React.createElement(ProfitCalculator, {
+        metrics: [
+          { title: 'Priority Fee', value: '0.6 ETH' },
+          { title: 'Base Fee', value: '0.4 ETH' },
+        ],
+        timeRange: '1h',
+        cloudCost: 0,
+        proverCost: 0,
+        onCloudCostChange: () => {},
+        onProverCostChange: () => {},
+      }),
+    );
+    const matches = html.match(/min="0"/g) ?? [];
+    expect(matches.length).toBe(2);
+  });
 });

--- a/dashboard/tests/profitabilityChart.test.ts
+++ b/dashboard/tests/profitabilityChart.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import * as swr from 'swr';
+vi.mock('swr', () => ({ default: vi.fn() }));
+import * as priceService from '../services/priceService';
+import { ProfitabilityChart } from '../components/ProfitabilityChart';
+
+// Helper data with negative profit
+const feeData = [
+  { block: 1, priority: 0, base: 0, l1Cost: 0 },
+];
+
+describe('ProfitabilityChart', () => {
+  it('renders when profit is negative', () => {
+    vi.mocked(swr.default).mockReturnValue({ data: { data: feeData } } as any);
+    vi.spyOn(priceService, 'useEthPrice').mockReturnValue({ data: 1 } as any);
+
+    const html = renderToStaticMarkup(
+      React.createElement(ProfitabilityChart, {
+        timeRange: '1h',
+        cloudCost: 1000,
+        proverCost: 1000,
+      })
+    );
+
+    expect(html).toContain('recharts-responsive-container');
+  });
+});


### PR DESCRIPTION
## Summary
- factor L1 data cost metric into `ProfitCalculator`
- update calculator test for new fee formula

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_684c027bb4f08328ba19c5851067fabd