### PR TITLE
Fix negative profit chart domain

### DIFF
--- a/dashboard/components/ProfitabilityChart.tsx
+++ b/dashboard/components/ProfitabilityChart.tsx
@@ -71,7 +71,7 @@ export const ProfitabilityChart: React.FC<ProfitabilityChartProps> = ({
         <YAxis
           stroke="#666666"
           fontSize={12}
-          domain={[0, 'auto']}
+          domain={['auto', 'auto']}
           tickFormatter={(v: number) => `$${v.toLocaleString()}`}
           label={{
             value: 'Profit (USD)',

--- a/dashboard/tests/profitabilityChart.test.ts
+++ b/dashboard/tests/profitabilityChart.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import * as swr from 'swr';
+vi.mock('swr', () => ({ default: vi.fn() }));
+import * as priceService from '../services/priceService';
+import { ProfitabilityChart } from '../components/ProfitabilityChart';
+
+// Helper data with negative profit
+const feeData = [
+  { block: 1, priority: 0, base: 0, l1Cost: 0 },
+];
+
+describe('ProfitabilityChart', () => {
+  it('renders when profit is negative', () => {
+    vi.mocked(swr.default).mockReturnValue({ data: { data: feeData } } as any);
+    vi.spyOn(priceService, 'useEthPrice').mockReturnValue({ data: 1 } as any);
+
+    const html = renderToStaticMarkup(
+      React.createElement(ProfitabilityChart, {
+        timeRange: '1h',
+        cloudCost: 1000,
+        proverCost: 1000,
+      })
+    );
+
+    expect(html).toContain('recharts-responsive-container');
+  });
+});


### PR DESCRIPTION
## Summary
- show negative profit values in ProfitabilityChart
- add regression test for negative profit data

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_684c0277f5e08328b9644258d7895887