### PR TITLE
Add minimum constraints for ProfitCalculator inputs

### DIFF
--- a/dashboard/components/ProfitCalculator.tsx
+++ b/dashboard/components/ProfitCalculator.tsx
@@ -64,18 +64,24 @@ export const ProfitCalculator: React.FC<ProfitCalculatorProps> = ({
           Monthly Cloud Cost ($)
           <input
             type="number"
+            min={0}
             className="p-1 border rounded-md"
             value={cloudCost}
-            onChange={(e) => onCloudCostChange(Number(e.target.value))}
+            onChange={(e) =>
+              onCloudCostChange(Math.max(0, Number(e.target.value)))
+            }
           />
         </label>
         <label className="flex flex-col text-sm">
           Prover Cost ($)
           <input
             type="number"
+            min={0}
             className="p-1 border rounded-md"
             value={proverCost}
-            onChange={(e) => onProverCostChange(Number(e.target.value))}
+            onChange={(e) =>
+              onProverCostChange(Math.max(0, Number(e.target.value)))
+            }
           />
         </label>
       </div>

--- a/dashboard/tests/profitCalculator.test.ts
+++ b/dashboard/tests/profitCalculator.test.ts
@@ -24,4 +24,25 @@ describe('ProfitCalculator', () => {
     );
     expect(html.includes('1,999')).toBe(true);
   });
+
+  it('rejects negative values via min attribute', () => {
+    vi.spyOn(priceService, 'useEthPrice').mockReturnValue({
+      data: 2000,
+    } as any);
+    const html = renderToStaticMarkup(
+      React.createElement(ProfitCalculator, {
+        metrics: [
+          { title: 'Priority Fee', value: '0.6 ETH' },
+          { title: 'Base Fee', value: '0.4 ETH' },
+        ],
+        timeRange: '1h',
+        cloudCost: 0,
+        proverCost: 0,
+        onCloudCostChange: () => {},
+        onProverCostChange: () => {},
+      }),
+    );
+    const matches = html.match(/min="0"/g) ?? [];
+    expect(matches.length).toBe(2);
+  });
 });


### PR DESCRIPTION
## Summary
- enforce nonnegative input on ProfitCalculator fields
- test that inputs include `min="0"` to reject negative values

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_684c027137ac8328859151bf71da6fdc