### PR TITLE
Update profit calc for L1 data cost

### DIFF
--- a/dashboard/components/ProfitCalculator.tsx
+++ b/dashboard/components/ProfitCalculator.tsx
@@ -32,9 +32,13 @@ export const ProfitCalculator: React.FC<ProfitCalculatorProps> = ({
 }) => {
   const priorityStr = findMetricValue(metrics, 'priority fee');
   const baseStr = findMetricValue(metrics, 'base fee');
+  const l1DataCostStr = findMetricValue(metrics, 'l1 data cost');
+
   const priority = parseFloat(priorityStr.replace(/[^0-9.]/g, '')) || 0;
   const base = parseFloat(baseStr.replace(/[^0-9.]/g, '')) || 0;
-  const totalFee = priority + base;
+  const l1DataCost = parseFloat(l1DataCostStr.replace(/[^0-9.]/g, '')) || 0;
+
+  const totalFee = priority + base - l1DataCost;
 
   const { data: ethPrice = 0, error: ethPriceError } = useEthPrice();
 

--- a/dashboard/tests/profitCalculator.test.ts
+++ b/dashboard/tests/profitCalculator.test.ts
@@ -14,6 +14,7 @@ describe('ProfitCalculator', () => {
         metrics: [
           { title: 'Priority Fee', value: '0.6 ETH' },
           { title: 'Base Fee', value: '0.4 ETH' },
+          { title: 'L1 Data Cost', value: '0.1 ETH' },
         ],
         timeRange: '1h',
         cloudCost: 100,
@@ -22,7 +23,7 @@ describe('ProfitCalculator', () => {
         onProverCostChange: () => {},
       }),
     );
-    expect(html.includes('1,999')).toBe(true);
+    expect(html.includes('1,799')).toBe(true);
   });
 
   it('rejects negative values via min attribute', () => {


### PR DESCRIPTION
## Summary
- include `L1 Data Cost` when computing profit
- update tests for new calculation

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_684c1cf6adc0832887a3bd63b1d556ff