### PR TITLE
Fix mobile header layout

### DIFF
--- a/dashboard/components/DashboardHeader.tsx
+++ b/dashboard/components/DashboardHeader.tsx
@@ -74,7 +74,7 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({
           {DASHBOARD_TITLE}
         </h1>
       </div>
-      <div className="flex items-center space-x-2 mt-4 md:mt-0">
+      <div className="flex flex-wrap items-center gap-2 mt-4 md:mt-0 justify-center md:justify-end">
         {/* Economics view is still supported via URL parameters, but the
             navigation button is hidden. */}
         <a


### PR DESCRIPTION
## Summary
- wrap header buttons on mobile so they take up less horizontal space

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_684c4334f68083289dc773e5b9db39b1