### PR TITLE
Display two metrics per row on mobile

### DIFF
--- a/dashboard/components/MetricCard.tsx
+++ b/dashboard/components/MetricCard.tsx
@@ -22,7 +22,7 @@ export const MetricCard: React.FC<MetricCardProps> = ({
 
   return (
     <div
-      className={`bg-white dark:bg-gray-800 p-4 rounded-lg border border-gray-200 dark:border-gray-700 transition-shadow duration-200 ${isAddress ? 'min-w-0 w-full sm:col-span-2 md:col-span-2 lg:col-span-2 xl:col-span-2 2xl:col-span-2' : ''} ${className ?? ''}`.trim()}
+      className={`bg-white dark:bg-gray-800 p-4 rounded-lg border border-gray-200 dark:border-gray-700 transition-shadow duration-200 ${isAddress ? 'min-w-0 w-full col-span-2 sm:col-span-2 md:col-span-2 lg:col-span-2 xl:col-span-2 2xl:col-span-2' : ''} ${className ?? ''}`.trim()}
     >
       <div className="relative">
         <h3 className="text-sm font-medium text-gray-500 dark:text-gray-400 truncate pr-8">

--- a/dashboard/components/layout/MetricsGrid.tsx
+++ b/dashboard/components/layout/MetricsGrid.tsx
@@ -30,9 +30,9 @@ export const MetricsGrid: React.FC<MetricsGridProps> = ({
 }) => {
   const displayedGroupOrder = groupOrder;
   const regularGrid =
-    'grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 gap-4 md:gap-6';
+    'grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 gap-4 md:gap-6';
   const economicsGrid =
-    'grid grid-cols-1 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-2 2xl:grid-cols-2 gap-4 md:gap-6';
+    'grid grid-cols-2 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-2 2xl:grid-cols-2 gap-4 md:gap-6';
   const chartsGrid = 'grid grid-cols-1 lg:grid-cols-2 gap-4 md:gap-6 mt-4';
 
   return (

--- a/dashboard/tests/metricCard.test.ts
+++ b/dashboard/tests/metricCard.test.ts
@@ -14,7 +14,7 @@ describe('MetricCard', () => {
     );
     expect(
       htmlAddress.includes(
-        'min-w-0 w-full sm:col-span-2 md:col-span-2 lg:col-span-2 xl:col-span-2 2xl:col-span-2',
+        'min-w-0 w-full col-span-2 sm:col-span-2 md:col-span-2 lg:col-span-2 xl:col-span-2 2xl:col-span-2',
       ),
     ).toBe(true);
     expect(htmlAddress.includes('text-base break-all')).toBe(true);


### PR DESCRIPTION
## Summary
- tweak metric grid breakpoints to show 2 columns by default
- adjust MetricCard address width rules
- update tests

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_684c4388fcf483288529c859868099ca