### PR TITLE
Fix mobile chart padding

### DIFF
--- a/dashboard/components/AdvancedDataTable.tsx
+++ b/dashboard/components/AdvancedDataTable.tsx
@@ -219,7 +219,7 @@ export const AdvancedDataTable: React.FC<AdvancedDataTableProps> = ({
     searchTerm || Object.values(filters).some((v) => v) || sortBy;
 
   return (
-    <div className="bg-white dark:bg-gray-900 text-gray-800 dark:text-gray-100 p-4 md:p-6 lg:p-8">
+    <div className="bg-white dark:bg-gray-900 text-gray-800 dark:text-gray-100 p-2 sm:p-4 md:p-6 lg:p-8">
       {/* Header */}
       <div className="flex flex-col md:flex-row justify-between items-start md:items-center mb-6 space-y-4 md:space-y-0">
         <div className="flex items-center space-x-4">

--- a/dashboard/components/DashboardFooter.tsx
+++ b/dashboard/components/DashboardFooter.tsx
@@ -10,7 +10,7 @@ export const DashboardFooter: React.FC<DashboardFooterProps> = ({
   l2HeadBlock,
   l1HeadBlock,
 }) => (
-  <footer className="mt-8 px-4 py-6 md:px-6 lg:px-8 border-t border-gray-200 dark:border-gray-700">
+  <footer className="mt-8 px-2 sm:px-4 md:px-6 lg:px-8 py-6 border-t border-gray-200 dark:border-gray-700">
     <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-center md:text-left">
       <div>
         <span className="text-sm text-gray-500 dark:text-gray-400">

--- a/dashboard/components/layout/DashboardLayout.tsx
+++ b/dashboard/components/layout/DashboardLayout.tsx
@@ -28,7 +28,7 @@ export const DashboardLayout: React.FC = () => {
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100 flex flex-col">
-      <main className="flex-grow px-4 py-6 md:px-6 lg:px-8">
+      <main className="flex-grow px-2 sm:px-4 md:px-6 lg:px-8 py-6">
         <Outlet
           context={{
             timeRange,

--- a/dashboard/components/views/DashboardView.tsx
+++ b/dashboard/components/views/DashboardView.tsx
@@ -268,7 +268,7 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
 
   return (
     <div
-      className="bg-white dark:bg-gray-900 text-gray-800 dark:text-gray-100 p-4 md:p-6 lg:p-8"
+      className="bg-white dark:bg-gray-900 text-gray-800 dark:text-gray-100 p-2 sm:p-4 md:p-6 lg:p-8"
       style={{ fontFamily: "'Inter', sans-serif" }}
     >
       <ErrorDisplay


### PR DESCRIPTION
## Summary
- reduce padding around charts on small screens to remove excess whitespace

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_684c43bd2d388328ba4d52ca61db6891