### PR TITLE
Remove dashmap from API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -734,7 +734,6 @@ dependencies = [
  "chrono",
  "clickhouse 0.1.0",
  "clickhouse 0.13.3",
- "dashmap",
  "eyre",
  "futures",
  "hex",

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -23,7 +23,6 @@ serde.workspace = true
 serde_json.workspace = true
 tower-http.workspace = true
 futures.workspace = true
-dashmap.workspace = true
 utoipa.workspace = true
 utoipa-swagger-ui.workspace = true
 


### PR DESCRIPTION
## Summary
- remove unused `dashmap` dependency in `api`

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_684fcd42ba648328b1c23ab2b7ba38e1