### PR TITLE
Handle ETH price fetch failures gracefully

### DIFF
--- a/dashboard/components/ProfitCalculator.tsx
+++ b/dashboard/components/ProfitCalculator.tsx
@@ -41,6 +41,7 @@ export const ProfitCalculator: React.FC<ProfitCalculatorProps> = ({
   const totalFee = priority + base - l1DataCost;
 
   const { data: ethPrice = 0, error: ethPriceError } = useEthPrice();
+  const priceUnavailable = ethPriceError || !ethPrice;
 
   const HOURS_IN_MONTH = 30 * 24;
   const hours = rangeToHours(timeRange);
@@ -92,7 +93,7 @@ export const ProfitCalculator: React.FC<ProfitCalculatorProps> = ({
       <p className="mt-3 text-sm">
         Profit ({formatTimeRangeLabel(timeRange)}):{' '}
         <span className="font-semibold">${formatProfit(profit)}</span>
-        {ethPriceError && (
+        {priceUnavailable && (
           <span className="text-red-500 ml-2 text-xs">
             (ETH price unavailable)
           </span>

--- a/dashboard/components/ProfitabilityChart.tsx
+++ b/dashboard/components/ProfitabilityChart.tsx
@@ -32,11 +32,20 @@ export const ProfitabilityChart: React.FC<ProfitabilityChartProps> = ({
   );
   const feeData: FeeComponent[] | null = feeRes?.data ?? null;
   const { data: ethPrice = 0 } = useEthPrice();
+  const priceUnavailable = !ethPrice;
 
   if (!feeData || feeData.length === 0) {
     return (
       <div className="flex items-center justify-center h-full text-gray-500">
         No data available
+      </div>
+    );
+  }
+
+  if (priceUnavailable) {
+    return (
+      <div className="flex items-center justify-center h-full text-gray-500">
+        ETH price unavailable
       </div>
     );
   }
@@ -54,7 +63,10 @@ export const ProfitabilityChart: React.FC<ProfitabilityChartProps> = ({
 
   return (
     <ResponsiveContainer width="100%" height={240}>
-      <LineChart data={data} margin={{ top: 5, right: 40, left: 20, bottom: 40 }}>
+      <LineChart
+        data={data}
+        margin={{ top: 5, right: 40, left: 20, bottom: 40 }}
+      >
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis
           dataKey="block"

--- a/dashboard/services/priceService.ts
+++ b/dashboard/services/priceService.ts
@@ -1,66 +1,67 @@
-import useSWR from 'swr'
-import { useEffect } from 'react'
+import useSWR from 'swr';
+import { useEffect } from 'react';
 
-const CACHE_KEY = 'ethPrice'
+const CACHE_KEY = 'ethPrice';
 const API_URL =
-  'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd'
+  'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd';
 
 export const getEthPrice = async (): Promise<number> => {
-  const res = await fetch(API_URL)
-  if (!res.ok) {
-    throw new Error(`Failed to fetch ETH price: ${res.status}`)
-  }
+  try {
+    const res = await fetch(API_URL);
+    if (!res.ok) {
+      return 0;
+    }
 
-  const data = await res.json()
-  const price = data?.ethereum?.usd
-  if (typeof price !== 'number') {
-    throw new Error('Invalid ETH price response format')
+    const data = await res.json();
+    const price = data?.ethereum?.usd;
+    return typeof price === 'number' ? price : 0;
+  } catch {
+    return 0;
   }
-
-  return price
-}
+};
 
 export const useEthPrice = () => {
-  const fallbackData = typeof localStorage === 'undefined'
-    ? undefined
-    : (() => {
-        const cached = localStorage.getItem(CACHE_KEY)
-        if (cached) {
-          try {
-            const { price, timestamp } = JSON.parse(cached) as {
-              price: number
-              timestamp: number
+  const fallbackData =
+    typeof localStorage === 'undefined'
+      ? undefined
+      : (() => {
+          const cached = localStorage.getItem(CACHE_KEY);
+          if (cached) {
+            try {
+              const { price, timestamp } = JSON.parse(cached) as {
+                price: number;
+                timestamp: number;
+              };
+              if (
+                Date.now() - timestamp < 3600_000 &&
+                typeof price === 'number'
+              ) {
+                return price;
+              }
+            } catch {
+              // ignore malformed cache
             }
-            if (
-              Date.now() - timestamp < 3600_000 &&
-              typeof price === 'number'
-            ) {
-              return price
-            }
-          } catch {
-            // ignore malformed cache
           }
-        }
-        return undefined
-      })()
+          return undefined;
+        })();
 
   const swr = useSWR<number>('ethPrice', getEthPrice, {
     revalidateOnFocus: false,
     fallbackData,
-  })
+  });
 
   useEffect(() => {
     if (typeof localStorage !== 'undefined' && swr.data !== undefined) {
       try {
         localStorage.setItem(
           CACHE_KEY,
-          JSON.stringify({ price: swr.data, timestamp: Date.now() })
-        )
+          JSON.stringify({ price: swr.data, timestamp: Date.now() }),
+        );
       } catch {
         // ignore storage errors
       }
     }
-  }, [swr.data])
+  }, [swr.data]);
 
-  return swr
-}
+  return swr;
+};

--- a/dashboard/tests/priceService.test.ts
+++ b/dashboard/tests/priceService.test.ts
@@ -1,41 +1,43 @@
-import { describe, it, expect, afterEach, vi } from 'vitest'
-import { getEthPrice } from '../services/priceService.ts'
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { getEthPrice } from '../services/priceService.ts';
 
-const originalFetch = globalThis.fetch
+const originalFetch = globalThis.fetch;
 
 function mockFetch(price: number, ok = true) {
   return vi.fn(async () => ({
     ok,
     status: ok ? 200 : 500,
     json: async () => ({ ethereum: { usd: price } }),
-  })) as unknown as typeof fetch
+  })) as unknown as typeof fetch;
 }
 
 function mockFetchWithInvalidResponse() {
   return vi.fn(async () => ({
     ok: true,
     json: async () => ({ invalid: 'response' }),
-  })) as unknown as typeof fetch
+  })) as unknown as typeof fetch;
 }
 
 afterEach(() => {
-  globalThis.fetch = originalFetch
-})
+  globalThis.fetch = originalFetch;
+});
 
 describe('getEthPrice', () => {
   it('fetches price successfully', async () => {
-    globalThis.fetch = mockFetch(2000)
-    const price = await getEthPrice()
-    expect(price).toBe(2000)
-  })
+    globalThis.fetch = mockFetch(2000);
+    const price = await getEthPrice();
+    expect(price).toBe(2000);
+  });
 
-  it('handles fetch failure', async () => {
-    globalThis.fetch = mockFetch(0, false)
-    await expect(getEthPrice()).rejects.toThrow('Failed to fetch ETH price: 500')
-  })
+  it('returns 0 on fetch failure', async () => {
+    globalThis.fetch = mockFetch(0, false);
+    const price = await getEthPrice();
+    expect(price).toBe(0);
+  });
 
-  it('handles invalid response format', async () => {
-    globalThis.fetch = mockFetchWithInvalidResponse()
-    await expect(getEthPrice()).rejects.toThrow('Invalid ETH price response format')
-  })
-})
+  it('returns 0 for invalid response format', async () => {
+    globalThis.fetch = mockFetchWithInvalidResponse();
+    const price = await getEthPrice();
+    expect(price).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- return 0 from `getEthPrice` on network error or invalid response
- show message in ProfitCalculator and ProfitabilityChart when price unavailable
- update unit tests for new behavior

## Testing
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_684fcd813e4c83288f667dca7a47c56a