### PR TITLE
fix: handle zero TPS in sequencer distribution

### DIFF
--- a/dashboard/config/tableConfig.ts
+++ b/dashboard/config/tableConfig.ts
@@ -267,7 +267,7 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
     mapData: (data) =>
       (data as any[]).map((d) => ({
         ...d,
-        tps: d.tps ? d.tps.toFixed(2) : 'N/A',
+        tps: d.tps != null ? d.tps.toFixed(2) : 'N/A',
       })),
     supportsPagination: true,
     urlKey: 'sequencer-dist',

--- a/dashboard/tests/sequencerDistMap.test.ts
+++ b/dashboard/tests/sequencerDistMap.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { TABLE_CONFIGS } from '../config/tableConfig';
+
+describe('sequencer-dist mapData', () => {
+  const mapData = TABLE_CONFIGS['sequencer-dist'].mapData!;
+
+  it('formats zero TPS correctly', () => {
+    const rows = mapData([{ name: 'foo', value: 1, tps: 0 }]);
+    expect(rows[0].tps).toBe('0.00');
+  });
+
+  it('handles missing TPS as N/A', () => {
+    const rows = mapData([{ name: 'foo', value: 1, tps: null }]);
+    expect(rows[0].tps).toBe('N/A');
+  });
+});


### PR DESCRIPTION
## Summary
- allow 0 TPS values in tableConfig mapData
- add test for sequencer distribution table mapping

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_684fcd8be03083289472690bf75ade01