### PR TITLE
Add view reset logic

### DIFF
--- a/crates/clickhouse/src/lib.rs
+++ b/crates/clickhouse/src/lib.rs
@@ -31,7 +31,7 @@ pub use writer::ClickhouseWriter;
 pub use models::*;
 
 // Re-export schema constants
-pub use schema::{TABLE_SCHEMAS, TABLES};
+pub use schema::{TABLE_SCHEMAS, TABLES, VIEWS};
 
 // Re-export byte wrappers
 pub use types::{AddressBytes, HashBytes};

--- a/crates/clickhouse/src/schema.rs
+++ b/crates/clickhouse/src/schema.rs
@@ -25,6 +25,16 @@ pub const TABLES: &[&str] = &[
     "l1_data_costs",
 ];
 
+/// Names of all materialized views
+pub const VIEWS: &[&str] = &[
+    "batch_prove_times_mv",
+    "batch_verify_times_mv",
+    "hourly_avg_prove_times_mv",
+    "hourly_avg_verify_times_mv",
+    "daily_avg_prove_times_mv",
+    "daily_avg_verify_times_mv",
+];
+
 /// Schema definitions for tables
 pub const TABLE_SCHEMAS: &[TableSchema] = &[
     TableSchema {


### PR DESCRIPTION
## Summary
- manage ClickHouse views via new `VIEWS` constant
- drop views when database reset is requested
- recreate views via migrations
- test `init_db(true)` drops materialized views

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_684fce00884883289207766b82671958