### PR TITLE
Add log for public rpc monitor

### DIFF
--- a/crates/driver/src/lib.rs
+++ b/crates/driver/src/lib.rs
@@ -262,6 +262,7 @@ impl Driver {
     /// [`IncidentClient`].
     fn spawn_monitors(&self) {
         if let Some(url) = &self.public_rpc_url {
+            tracing::info!(url = url.as_str(), "public rpc monitor enabled");
             public_rpc_monitor::spawn_public_rpc_monitor(url.clone());
         }
 


### PR DESCRIPTION
## Summary
- log when the public RPC monitor starts

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_684fd68cce748328ab362f0ce3836bd1