### PR TITLE
Add Hekla block explorer

### DIFF
--- a/dashboard/utils.ts
+++ b/dashboard/utils.ts
@@ -1,10 +1,16 @@
 import React from 'react';
 import { TAIKO_PINK } from './theme';
 
+const rawNetworkName =
+  ((import.meta as any).env.VITE_NETWORK_NAME as string | undefined) ??
+  ((import.meta as any).env.NETWORK_NAME as string | undefined);
+
 export const TAIKOSCAN_BASE =
   ((import.meta as any).env.VITE_TAIKOSCAN_BASE as string | undefined) ??
   ((import.meta as any).env.TAIKOSCAN_BASE as string | undefined) ??
-  'https://cb-blockscout-masaya.vercel.app/blocks';
+  (rawNetworkName?.toLowerCase() === 'hekla'
+    ? 'https://hekla.taikoscan.io'
+    : 'https://cb-blockscout-masaya.vercel.app/blocks');
 
 export const blockLink = (block: number): React.ReactElement =>
   React.createElement(


### PR DESCRIPTION
## Summary
- add network name check for block explorer URL
- default to hekla.taikoscan.io when network is `hekla`

## Testing
- `npm run lint:whitespace`
- `npm run check`
- `npm run test`
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_684fe1b3fbc48328bfeff71c08c86358