### PR TITLE
fix api unwrap panic

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -1354,7 +1354,7 @@ fn aggregate_l2_block_times(rows: Vec<L2BlockTimeRow>) -> Vec<L2BlockTimeRow> {
         .into_iter()
         .map(|(g, mut rs)| {
             rs.sort_by_key(|r| r.l2_block_number);
-            let last_time = rs.last().map(|r| r.block_time).unwrap();
+            let last_time = rs.last().map(|r| r.block_time).unwrap_or_default();
             let (sum, count) = rs
                 .iter()
                 .filter_map(|r| r.ms_since_prev_block)


### PR DESCRIPTION
## Summary
- avoid unwrap panic when aggregating L2 block times

## Testing
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_684ff2cb228883289d40ce3c5b35a98c