### PR TITLE
Fix time range parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,6 +741,7 @@ dependencies = [
  "runtime",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "tokio",
  "tower",
  "tower-http 0.5.2",

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -30,6 +30,7 @@ utoipa-swagger-ui.workspace = true
 tower = "0.5"
 url.workspace = true
 clickhouse = { package = "clickhouse", version = "0.13.3", features = ["native-tls", "test-util"] }
+serde_urlencoded = "0.7"
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary
- ensure negative timestamp params return 400
- add serde_urlencoded as a dev dependency for api crate
- test custom deserializer for negative values

## Testing
- `just lint`
- `just test`
- `just check-dashboard`
- `just test-dashboard`
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_684ff3d012a483288705107406d3723d