### PR TITLE
Fix Gas Used table formatting

### DIFF
--- a/dashboard/config/tableConfig.ts
+++ b/dashboard/config/tableConfig.ts
@@ -239,7 +239,11 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
       { key: 'value', label: 'Block Number' },
       { key: 'timestamp', label: 'Gas Used' },
     ],
-    mapData: (data) => data as Record<string, string | number>[],
+    mapData: (data) =>
+      (data as { value: number; timestamp: number }[]).map((d) => ({
+        value: d.value.toLocaleString(),
+        timestamp: d.timestamp.toLocaleString(),
+      })),
     chart: (data) => {
       const GasUsedChart = React.lazy(() =>
         import('../components/GasUsedChart').then((m) => ({

--- a/dashboard/tests/l2GasUsedMap.test.ts
+++ b/dashboard/tests/l2GasUsedMap.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { TABLE_CONFIGS } from '../config/tableConfig';
+
+describe('l2-gas-used mapData', () => {
+  const mapData = TABLE_CONFIGS['l2-gas-used'].mapData!;
+
+  it('formats block number and gas used with locale commas', () => {
+    const rows = mapData([{ value: 1660970, timestamp: 268542 }]);
+    expect(rows[0].value).toBe('1,660,970');
+    expect(rows[0].timestamp).toBe('268,542');
+  });
+});


### PR DESCRIPTION
## Summary
- add comma formatting for Gas Used table numbers
- test mapData formatting for l2-gas-used

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_684ffe004a3883288ded9a84d55a9db7