### PR TITLE
Fix unknown sequencer display

### DIFF
--- a/dashboard/sequencerConfig.ts
+++ b/dashboard/sequencerConfig.ts
@@ -12,7 +12,7 @@ export const SEQUENCER_ADDRESS_BY_NAME: Record<string, string> =
   Object.fromEntries(SEQUENCER_PAIRS.map(([addr, name]) => [name, addr]));
 
 export const getSequencerName = (address: string): string =>
-  SEQUENCER_NAME_BY_ADDRESS[address.toLowerCase()] ?? 'Unknown';
+  SEQUENCER_NAME_BY_ADDRESS[address.toLowerCase()] ?? address;
 
 export const getSequencerAddress = (name: string): string | undefined =>
   SEQUENCER_ADDRESS_BY_NAME[name];

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -430,14 +430,11 @@ export const fetchSequencerDistribution = async (
   }>(url);
   return {
     data: res.data
-      ? res.data.sequencers.map((s) => {
-        const name = getSequencerName(s.address);
-        return {
-          name: name === 'Unknown' ? s.address : name,
+      ? res.data.sequencers.map((s) => ({
+          name: getSequencerName(s.address),
           value: s.blocks,
           tps: s.tps,
-        };
-      })
+        }))
       : null,
     badRequest: res.badRequest,
     error: res.error,

--- a/dashboard/tests/apiService.test.ts
+++ b/dashboard/tests/apiService.test.ts
@@ -93,7 +93,7 @@ describe('apiService', () => {
     const txs = await fetchBlockTransactions('1h');
     expect(txs.error).toBeNull();
     expect(txs.data).toStrictEqual([
-      { block: 1, txs: 3, sequencer: 'Unknown' },
+      { block: 1, txs: 3, sequencer: '0xabc' },
     ]);
   });
 
@@ -104,7 +104,7 @@ describe('apiService', () => {
     const txs = await fetchBlockTransactions('15m');
     expect(txs.error).toBeNull();
     expect(txs.data).toStrictEqual([
-      { block: 1, txs: 3, sequencer: 'Unknown' },
+      { block: 1, txs: 3, sequencer: '0xabc' },
     ]);
   });
 

--- a/dashboard/tests/sequencerConfig.test.ts
+++ b/dashboard/tests/sequencerConfig.test.ts
@@ -9,7 +9,7 @@ describe('getSequencerName', () => {
     expect(getSequencerName(addressA)).toBe('Chainbound A');
   });
 
-  it('returns "Unknown" for unmapped address', () => {
-    expect(getSequencerName(unknown)).toBe('Unknown');
+  it('returns the address for unmapped address', () => {
+    expect(getSequencerName(unknown)).toBe(unknown);
   });
 });

--- a/dashboard/utils/metricsCreator.ts
+++ b/dashboard/utils/metricsCreator.ts
@@ -76,10 +76,7 @@ export const createMetrics = (data: MetricInputData): MetricData[] => [
     title: 'Current Sequencer',
     value:
       data.currentOperator != null
-        ? (() => {
-            const name = getSequencerName(data.currentOperator);
-            return name === 'Unknown' ? data.currentOperator : name;
-          })()
+        ? getSequencerName(data.currentOperator)
         : 'N/A',
     group: 'Sequencers',
   },
@@ -87,10 +84,7 @@ export const createMetrics = (data: MetricInputData): MetricData[] => [
     title: 'Next Sequencer',
     value:
       data.nextOperator != null
-        ? (() => {
-            const name = getSequencerName(data.nextOperator);
-            return name === 'Unknown' ? data.nextOperator : name;
-          })()
+        ? getSequencerName(data.nextOperator)
         : 'N/A',
     group: 'Sequencers',
   },


### PR DESCRIPTION
## Summary
- fall back to address for unknown sequencer names
- clean up metrics to use new helper
- update tests to match the new behavior

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_684ffebcb1fc8328a1480d33997141e4