### PR TITLE
Fix Sequencer table links

### DIFF
--- a/dashboard/config/tableConfig.ts
+++ b/dashboard/config/tableConfig.ts
@@ -20,8 +20,8 @@ import {
   fetchSequencerDistribution,
   fetchL2Tps,
 } from '../services/apiService';
-import { getSequencerName } from '../sequencerConfig';
-import { bytesToHex, blockLink } from '../utils';
+import { getSequencerName, getSequencerAddress } from '../sequencerConfig';
+import { bytesToHex, blockLink, addressLink } from '../utils';
 import { TAIKO_PINK } from '../theme';
 import React from 'react';
 
@@ -267,6 +267,10 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
     mapData: (data) =>
       (data as any[]).map((d) => ({
         ...d,
+        name: addressLink(
+          getSequencerAddress(d.name as string) ?? (d.name as string),
+          d.name as string,
+        ),
         tps: d.tps != null ? d.tps.toFixed(2) : 'N/A',
       })),
     supportsPagination: true,

--- a/dashboard/tests/sequencerDistMap.test.ts
+++ b/dashboard/tests/sequencerDistMap.test.ts
@@ -9,6 +9,12 @@ describe('sequencer-dist mapData', () => {
     expect(rows[0].tps).toBe('0.00');
   });
 
+  it('wraps the sequencer name in a link', () => {
+    const rows = mapData([{ name: 'foo', value: 1, tps: 1 }]);
+    const el = rows[0].name as any;
+    expect(el.type).toBe('a');
+  });
+
   it('handles missing TPS as N/A', () => {
     const rows = mapData([{ name: 'foo', value: 1, tps: null }]);
     expect(rows[0].tps).toBe('N/A');

--- a/dashboard/tests/utils.more.test.ts
+++ b/dashboard/tests/utils.more.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
 import {
   blockLink,
+  addressLink,
   formatTime,
   computeIntervalFlags,
   shouldShowMinutes,
@@ -21,6 +22,17 @@ describe('utils additional', () => {
     expect(props.target).toBe('_blank');
     expect(props.rel).toBe('noopener noreferrer');
     expect(props.children).toBe('42');
+  });
+
+  it('creates an address link element', () => {
+    const el = addressLink('0xabc', 'foo');
+    const html = renderToStaticMarkup(el);
+    expect(html).toContain('href');
+    const props = (el as any).props;
+    expect(props.href.endsWith('/address/0xabc')).toBe(true);
+    expect(props.children).toBe('foo');
+    expect(props.target).toBe('_blank');
+    expect(props.rel).toBe('noopener noreferrer');
   });
 
   it('formats time in UTC', () => {

--- a/dashboard/utils.ts
+++ b/dashboard/utils.ts
@@ -25,6 +25,22 @@ export const blockLink = (block: number): React.ReactElement =>
     String(block),
   );
 
+export const addressLink = (
+  address: string,
+  text?: string,
+): React.ReactElement =>
+  React.createElement(
+    'a',
+    {
+      href: `${TAIKOSCAN_BASE}/address/${address}`,
+      target: '_blank',
+      rel: 'noopener noreferrer',
+      className: 'font-semibold hover:underline',
+      style: { color: TAIKO_PINK },
+    },
+    text ?? address,
+  );
+
 export const formatDecimal = (value: number): string => {
   const decimals = Math.abs(value) >= 10 ? 1 : 2;
   return value.toFixed(decimals);


### PR DESCRIPTION
## Summary
- link sequencer addresses to Taikoscan
- test address link helper
- verify sequencer distribution map includes address links

## Testing
- `just check-dashboard`
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_684fff1f2d9883288ed2f32f9b651945