### PR TITLE
Add sorting to sequencer distribution table

### DIFF
--- a/dashboard/config/tableConfig.ts
+++ b/dashboard/config/tableConfig.ts
@@ -28,6 +28,7 @@ import React from 'react';
 export interface TableColumn {
   key: string;
   label: string;
+  sortable?: boolean;
 }
 
 export interface TableConfig {
@@ -261,8 +262,8 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
     fetcher: fetchSequencerDistribution,
     columns: [
       { key: 'name', label: 'Sequencer' },
-      { key: 'value', label: 'Blocks' },
-      { key: 'tps', label: 'TPS' },
+      { key: 'value', label: 'Blocks', sortable: true },
+      { key: 'tps', label: 'TPS', sortable: true },
     ],
     mapData: (data) =>
       (data as any[]).map((d) => ({

--- a/dashboard/hooks/useTableActions.ts
+++ b/dashboard/hooks/useTableActions.ts
@@ -10,13 +10,13 @@ import { fetchBlockTransactions } from '../services/apiService';
 export interface TableViewState {
   title: string;
   description?: React.ReactNode;
-  columns: { key: string; label: string }[];
+  columns: { key: string; label: string; sortable?: boolean }[];
   rows: Record<string, React.ReactNode | string | number>[];
   onRowClick?: (row: Record<string, React.ReactNode | string | number>) => void;
   extraAction?: { label: string; onClick: () => void };
   extraTable?: {
     title: string;
-    columns: { key: string; label: string }[];
+    columns: { key: string; label: string; sortable?: boolean }[];
     rows: Record<string, React.ReactNode | string | number>[];
     onRowClick?: (
       row: Record<string, React.ReactNode | string | number>,
@@ -233,11 +233,10 @@ export const useTableActions = (
       openTable(
         'Sequencer Distribution',
         'Breakdown of blocks proposed by each sequencer.',
-        [
-          { key: 'name', label: 'Sequencer' },
-          { key: 'value', label: 'Blocks' },
-        ],
-        (distRes.data || []) as unknown as Record<
+        TABLE_CONFIGS['sequencer-dist'].columns,
+        (TABLE_CONFIGS['sequencer-dist'].mapData
+          ? TABLE_CONFIGS['sequencer-dist'].mapData!(distRes.data)
+          : (distRes.data || [])) as unknown as Record<
           string,
           React.ReactNode | string | number
         >[],


### PR DESCRIPTION
## Summary
- make DataTable columns sortable
- enable Blocks and TPS sorting for the sequencer distribution table
- show sortable columns in sequencer distribution table view

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_684fff44d3488328b9715240c6022c1d