### PR TITLE
Add dashboard header description

### DIFF
--- a/dashboard/components/DashboardHeader.tsx
+++ b/dashboard/components/DashboardHeader.tsx
@@ -27,6 +27,8 @@ const NETWORK_NAME =
   rawNetworkName.slice(1).toLowerCase();
 const SHOW_CUSTOM_TIME_PICKER = rawNetworkName.toLowerCase() !== 'hekla';
 const DASHBOARD_TITLE = `Taikoscope ${NETWORK_NAME}`;
+const DASHBOARD_DESCRIPTION =
+  'Key metrics and charts for the Taiko network.';
 
 interface DashboardHeaderProps {
   timeRange: TimeRange;
@@ -74,6 +76,9 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({
           {/* Updated Taiko Pink */}
           {DASHBOARD_TITLE}
         </h1>
+        <p className="text-sm text-gray-600 dark:text-gray-300">
+          {DASHBOARD_DESCRIPTION}
+        </p>
       </div>
       <div className="flex flex-wrap items-center gap-2 mt-4 md:mt-0 justify-center md:justify-end">
         {/* Economics view is still supported via URL parameters, but the

--- a/dashboard/tests/dashboardHeader.test.ts
+++ b/dashboard/tests/dashboardHeader.test.ts
@@ -34,6 +34,9 @@ describe('DashboardHeader', () => {
       ),
     );
     expect(html.includes('Taikoscope Masaya')).toBe(true);
+    expect(html.includes('Key metrics and charts for the Taiko network.')).toBe(
+      true,
+    );
     expect(html.includes('1h')).toBe(true);
     expect(html.includes('Refresh')).toBe(true);
     expect(html.includes('Status')).toBe(true);


### PR DESCRIPTION
## Summary
- show a short description under the dashboard title
- update header tests

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68500b3ada748328985a445997447dcc