### PR TITLE
Add comma formatting for dashboard numbers

### DIFF
--- a/dashboard/config/tableConfig.ts
+++ b/dashboard/config/tableConfig.ts
@@ -71,7 +71,7 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
       (data as L2ReorgEvent[]).map((e) => ({
         timestamp: new Date(e.timestamp).toLocaleString(),
         l2_block_number: blockLink(e.l2_block_number),
-        depth: e.depth,
+        depth: e.depth.toLocaleString(),
       })),
     urlKey: 'reorgs',
     reverseOrder: true,
@@ -135,8 +135,8 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
     mapData: (data) =>
       (data as Record<string, any>[]).map((d) => ({
         block: blockLink(d.block as number),
-        batch: d.batch,
-        blobs: d.blobs,
+        batch: d.batch.toLocaleString(),
+        blobs: d.blobs.toLocaleString(),
       })),
     urlKey: 'blobs-per-batch',
   },
@@ -166,7 +166,11 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
       { key: 'name', label: 'Batch' },
       { key: 'value', label: 'Seconds' },
     ],
-    mapData: (data) => data as Record<string, string | number>[],
+    mapData: (data) =>
+      (data as Record<string, string | number>[]).map((d) => ({
+        ...d,
+        value: typeof d.value === 'number' ? d.value.toLocaleString() : d.value,
+      })),
     chart: (data) => {
       const BatchProcessChart = React.lazy(() =>
         import('../components/BatchProcessChart').then((m) => ({
@@ -190,7 +194,11 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
       { key: 'name', label: 'Batch' },
       { key: 'value', label: 'Seconds' },
     ],
-    mapData: (data) => data as Record<string, string | number>[],
+    mapData: (data) =>
+      (data as Record<string, string | number>[]).map((d) => ({
+        ...d,
+        value: typeof d.value === 'number' ? d.value.toLocaleString() : d.value,
+      })),
     chart: (data) => {
       const BatchProcessChart = React.lazy(() =>
         import('../components/BatchProcessChart').then((m) => ({
@@ -216,11 +224,13 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
       { key: 'sequencer', label: 'Sequencer' },
     ],
     mapData: (data) =>
-      (data as { block: number; txs: number; sequencer: string }[]).map((d) => ({
-        block: blockLink(d.block),
-        txs: d.txs,
-        sequencer: d.sequencer,
-      })),
+      (data as { block: number; txs: number; sequencer: string }[]).map(
+        (d) => ({
+          block: blockLink(d.block),
+          txs: d.txs.toLocaleString(),
+          sequencer: d.sequencer,
+        }),
+      ),
     urlKey: 'block-tx',
   },
 

--- a/dashboard/tests/utils.test.ts
+++ b/dashboard/tests/utils.test.ts
@@ -10,6 +10,7 @@ import {
   findMetricValue,
   formatSequencerTooltip,
   formatLargeNumber,
+  formatWithCommas,
   formatEth,
   bytesToHex,
   loadRefreshRate,
@@ -118,6 +119,11 @@ describe('utils', () => {
     expect(formatLargeNumber(1500)).toBe('1.5K');
     expect(formatLargeNumber(15_000_000)).toBe('15M');
     expect(formatLargeNumber(50)).toBe('50');
+  });
+
+  it('formats numbers with commas', () => {
+    expect(formatWithCommas(1234567)).toBe('1,234,567');
+    expect(formatWithCommas(50)).toBe('50');
   });
 
   it('formats ETH amounts', () => {

--- a/dashboard/utils.ts
+++ b/dashboard/utils.ts
@@ -66,6 +66,9 @@ export const formatLargeNumber = (value: number): string => {
   return value.toLocaleString();
 };
 
+export const formatWithCommas = (value: number): string =>
+  value.toLocaleString();
+
 export const formatEth = (wei: number): string =>
   `${formatDecimal(wei / 1e18)} ETH`;
 

--- a/dashboard/utils/metricsCreator.ts
+++ b/dashboard/utils/metricsCreator.ts
@@ -1,6 +1,11 @@
 import React from 'react';
 import { type MetricData } from '../types';
-import { formatSeconds, formatDecimal, formatEth } from '../utils';
+import {
+  formatSeconds,
+  formatDecimal,
+  formatEth,
+  formatWithCommas,
+} from '../utils';
 import { getSequencerName } from '../sequencerConfig';
 
 export interface MetricInputData {
@@ -69,7 +74,10 @@ export const createMetrics = (data: MetricInputData): MetricData[] => [
   },
   {
     title: 'Active Sequencers',
-    value: data.activeGateways != null ? data.activeGateways.toString() : 'N/A',
+    value:
+      data.activeGateways != null
+        ? formatWithCommas(data.activeGateways)
+        : 'N/A',
     group: 'Sequencers',
   },
   {
@@ -83,25 +91,25 @@ export const createMetrics = (data: MetricInputData): MetricData[] => [
   {
     title: 'Next Sequencer',
     value:
-      data.nextOperator != null
-        ? getSequencerName(data.nextOperator)
-        : 'N/A',
+      data.nextOperator != null ? getSequencerName(data.nextOperator) : 'N/A',
     group: 'Sequencers',
   },
   {
     title: 'L2 Reorgs',
-    value: data.l2Reorgs != null ? data.l2Reorgs.toString() : 'N/A',
+    value: data.l2Reorgs != null ? formatWithCommas(data.l2Reorgs) : 'N/A',
     group: 'Network Health',
   },
   {
     title: 'Slashing Events',
-    value: data.slashings != null ? data.slashings.toString() : 'N/A',
+    value: data.slashings != null ? formatWithCommas(data.slashings) : 'N/A',
     group: 'Network Health',
   },
   {
     title: 'Forced Inclusions',
     value:
-      data.forcedInclusions != null ? data.forcedInclusions.toString() : 'N/A',
+      data.forcedInclusions != null
+        ? formatWithCommas(data.forcedInclusions)
+        : 'N/A',
     group: 'Network Health',
   },
   {
@@ -116,8 +124,7 @@ export const createMetrics = (data: MetricInputData): MetricData[] => [
   },
   {
     title: 'L1 Data Cost',
-    value:
-      data.l1DataCost != null ? formatEth(data.l1DataCost) : 'N/A',
+    value: data.l1DataCost != null ? formatEth(data.l1DataCost) : 'N/A',
     group: 'Network Economics',
   },
   {


### PR DESCRIPTION
## Summary
- add `formatWithCommas` utility for consistent comma-separated numbers
- use comma formatting in metrics and table data
- test the new formatter

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68500d3605dc8328ac8ca604d7234886