### PR TITLE
Make time range display readable

### DIFF
--- a/dashboard/components/layout/ChartsGrid.tsx
+++ b/dashboard/components/layout/ChartsGrid.tsx
@@ -2,6 +2,7 @@ import React, { lazy } from 'react';
 import { ChartCard } from '../ChartCard';
 import { TAIKO_PINK } from '../../theme';
 import { TimeRange, TimeSeriesData, PieChartDataItem } from '../../types';
+import { formatTimeRangeDisplay } from '../../utils/timeRange';
 import type {
   BlockTransaction,
   BatchBlobCount,
@@ -164,7 +165,7 @@ export const ChartsGrid: React.FC<ChartsGridProps> = ({
           <div className="flex items-center space-x-2">
             <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-blue-600 dark:border-blue-400"></div>
             <span className="text-sm text-blue-800 dark:text-blue-200">
-              Updating data for {timeRange} time range...
+              Updating data for {formatTimeRangeDisplay(timeRange)} time range...
             </span>
           </div>
         </div>

--- a/dashboard/components/layout/MetricsGrid.tsx
+++ b/dashboard/components/layout/MetricsGrid.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { MetricCard } from '../MetricCard';
 import { MetricCardSkeleton } from '../MetricCardSkeleton';
 import { MetricData, TimeRange } from '../../types';
+import { formatTimeRangeDisplay } from '../../utils/timeRange';
 
 interface MetricsGridProps {
   isLoading: boolean;
@@ -42,7 +43,7 @@ export const MetricsGrid: React.FC<MetricsGridProps> = ({
           <div className="flex items-center space-x-2">
             <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-blue-600 dark:border-blue-400"></div>
             <span className="text-sm text-blue-800 dark:text-blue-200">
-              Updating data for {timeRange} time range...
+              Updating data for {formatTimeRangeDisplay(timeRange)} time range...
             </span>
           </div>
         </div>

--- a/dashboard/utils/timeRange.ts
+++ b/dashboard/utils/timeRange.ts
@@ -63,3 +63,33 @@ export const timeRangeToQuery = (range: string): string => {
   params.set('created[lte]', String(end));
   return params.toString();
 };
+
+export const formatTimeRangeDisplay = (range: string): string => {
+  const trimmed = range.trim();
+  const preset = trimmed.match(/^(\d+)([mh])$/i);
+  if (preset) {
+    const value = parseInt(preset[1], 10);
+    const unit = preset[2].toLowerCase() === 'h' ? 'hour' : 'minute';
+    const plural = value === 1 ? '' : 's';
+    return `last ${value} ${unit}${plural}`;
+  }
+
+  const custom = trimmed.match(/^(\d+)-(\d+)$/);
+  if (custom) {
+    const start = parseInt(custom[1], 10);
+    const end = parseInt(custom[2], 10);
+    if (!Number.isNaN(start) && !Number.isNaN(end)) {
+      const startDate = new Date(start);
+      const endDate = new Date(end);
+      const sameDay = startDate.toDateString() === endDate.toDateString();
+      const fmt = (d: Date) => `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')} ${d.getHours().toString().padStart(2, '0')}:${d.getMinutes().toString().padStart(2, '0')}`;
+      if (sameDay) {
+        const fmtTime = (d: Date) => `${d.getHours().toString().padStart(2, '0')}:${d.getMinutes().toString().padStart(2, '0')}`;
+        return `${fmt(startDate)}-${fmtTime(endDate)}`;
+      }
+      return `${fmt(startDate)}-${fmt(endDate)}`;
+    }
+  }
+
+  return trimmed;
+};


### PR DESCRIPTION
## Summary
- add `formatTimeRangeDisplay` helper
- show human readable time range while charts/metrics update

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68500e6164b483289f4ca71a720c4734