### PR TITLE
Ensure consistent time range across dashboard API calls

### DIFF
--- a/dashboard/utils/dataFetcher.ts
+++ b/dashboard/utils/dataFetcher.ts
@@ -1,5 +1,6 @@
 import { TimeRange } from '../types';
 import { getSequencerAddress } from '../sequencerConfig';
+import { normalizeTimeRange } from './timeRange';
 import {
   fetchDashboardData,
   fetchProveTimes,
@@ -51,6 +52,7 @@ export const fetchMainDashboardData = async (
   timeRange: TimeRange,
   selectedSequencer: string | null,
 ): Promise<MainDashboardData> => {
+  const normalizedRange = normalizeTimeRange(timeRange);
   const address = selectedSequencer
     ? getSequencerAddress(selectedSequencer)
     : undefined;
@@ -65,14 +67,14 @@ export const fetchMainDashboardData = async (
     blockTxRes,
     batchBlobCountsRes,
   ] = await Promise.all([
-    fetchDashboardData(timeRange, address),
-    fetchProveTimes(timeRange),
-    fetchVerifyTimes(timeRange),
-    fetchL2BlockTimes(timeRange, address),
-    fetchL2GasUsed(timeRange, address),
-    fetchSequencerDistribution(timeRange),
-    fetchAllBlockTransactions(timeRange, address),
-    fetchBatchBlobCounts(timeRange),
+    fetchDashboardData(normalizedRange, address),
+    fetchProveTimes(normalizedRange),
+    fetchVerifyTimes(normalizedRange),
+    fetchL2BlockTimes(normalizedRange, address),
+    fetchL2GasUsed(normalizedRange, address),
+    fetchSequencerDistribution(normalizedRange),
+    fetchAllBlockTransactions(normalizedRange, address),
+    fetchBatchBlobCounts(normalizedRange),
   ]);
 
   const data = dashboardRes.data;
@@ -117,13 +119,14 @@ export const fetchEconomicsData = async (
   timeRange: TimeRange,
   selectedSequencer: string | null,
 ): Promise<EconomicsData> => {
+  const normalizedRange = normalizeTimeRange(timeRange);
   const [l2FeesRes, l2BlockRes, l1BlockRes] = await Promise.all([
     fetchL2Fees(
-      timeRange,
+      normalizedRange,
       selectedSequencer ? getSequencerAddress(selectedSequencer) : undefined,
     ),
-    fetchL2HeadBlock(timeRange),
-    fetchL1HeadBlock(timeRange),
+    fetchL2HeadBlock(normalizedRange),
+    fetchL1HeadBlock(normalizedRange),
   ]);
 
   return {

--- a/dashboard/utils/timeRange.ts
+++ b/dashboard/utils/timeRange.ts
@@ -93,3 +93,27 @@ export const formatTimeRangeDisplay = (range: string): string => {
 
   return trimmed;
 };
+
+export const normalizeTimeRange = (
+  range: string,
+  now: number = Date.now(),
+): string => {
+  let start = now - 3600_000;
+  let end = now;
+
+  const trimmed = range.trim();
+  const preset = trimmed.match(/^(\d+)([mh])$/i);
+  if (preset) {
+    const value = parseInt(preset[1], 10);
+    const ms = value * (preset[2].toLowerCase() === 'h' ? 3_600_000 : 60_000);
+    start = now - ms;
+  } else {
+    const custom = trimmed.match(/^(\d+)-(\d+)$/);
+    if (custom) {
+      start = parseInt(custom[1], 10);
+      end = parseInt(custom[2], 10);
+    }
+  }
+
+  return `${start}-${end}`;
+};


### PR DESCRIPTION
## Summary
- add `normalizeTimeRange` helper for absolute ranges
- reuse the same normalized range in `fetchMainDashboardData` and `fetchEconomicsData`

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68500ad58990832892998967c6d420c7