### PR TITLE
Display big numbers with commas

### DIFF
--- a/dashboard/config/tableConfig.ts
+++ b/dashboard/config/tableConfig.ts
@@ -151,7 +151,7 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
     ],
     mapData: (data) =>
       (data as Record<string, any>[]).map((d) => ({
-        value: d.value,
+        value: Number(d.value).toLocaleString(),
         timestamp: d.timestamp,
       })),
     urlKey: 'batch-posting-cadence',
@@ -169,6 +169,7 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
     mapData: (data) =>
       (data as Record<string, string | number>[]).map((d) => ({
         ...d,
+        name: Number(d.name).toLocaleString(),
         value: typeof d.value === 'number' ? d.value.toLocaleString() : d.value,
       })),
     chart: (data) => {
@@ -197,6 +198,7 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
     mapData: (data) =>
       (data as Record<string, string | number>[]).map((d) => ({
         ...d,
+        name: Number(d.name).toLocaleString(),
         value: typeof d.value === 'number' ? d.value.toLocaleString() : d.value,
       })),
     chart: (data) => {

--- a/dashboard/tests/utils.more.test.ts
+++ b/dashboard/tests/utils.more.test.ts
@@ -24,6 +24,12 @@ describe('utils additional', () => {
     expect(props.children).toBe('42');
   });
 
+  it('formats large block numbers with commas', () => {
+    const el = blockLink(1234567);
+    const props = (el as any).props;
+    expect(props.children).toBe('1,234,567');
+  });
+
   it('creates an address link element', () => {
     const el = addressLink('0xabc', 'foo');
     const html = renderToStaticMarkup(el);

--- a/dashboard/utils.ts
+++ b/dashboard/utils.ts
@@ -22,7 +22,7 @@ export const blockLink = (block: number): React.ReactElement =>
       className: 'font-semibold hover:underline',
       style: { color: TAIKO_PINK },
     },
-    String(block),
+    block.toLocaleString(),
   );
 
 export const addressLink = (


### PR DESCRIPTION
## Summary
- display thousand separators in block links
- format Batch ID fields with commas
- show batch IDs with commas in prove/verify tables
- test block link formatting

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6850203b9d7c83289a2ca4cccc8405cf