### PR TITLE
Add block timestamp fields to charts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -773,6 +773,7 @@ name = "api-types"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "chrono",
  "clickhouse 0.1.0",
  "serde",
  "utoipa",
@@ -1214,9 +1215,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.26"
+version = "1.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956a5e21988b87f372569b66183b78babf23ebc2e744b733e4350a752c4dafac"
+checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
 dependencies = [
  "shlex",
 ]
@@ -1715,6 +1716,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 
 [[package]]
 name = "ecdsa"
@@ -2606,9 +2613,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.173"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "d8cfeafaffdbc32176b64fb251369d52ea9f0a8fbc6f8759edffef7b525d64bb"
 
 [[package]]
 name = "libm"
@@ -2655,9 +2662,9 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
+checksum = "2c592ad9fbc1b7838633b3ae55ce69b17d01150c72fcef229fbb819d39ee51ee"
 
 [[package]]
 name = "macro-string"
@@ -3010,9 +3017,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
+checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
 dependencies = [
  "memchr",
  "thiserror 2.0.12",
@@ -3290,6 +3297,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.103",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3543,9 +3570,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.27"
+version = "0.23.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
+checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
 dependencies = [
  "once_cell",
  "ring",
@@ -3615,6 +3642,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
 dependencies = [
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3790,15 +3829,16 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
+checksum = "bf65a400f8f66fb7b0552869ad70157166676db75ed8181f8104ea91cf9d0b42"
 dependencies = [
  "base64",
  "chrono",
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.9.0",
+ "schemars",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3808,9 +3848,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
+checksum = "81679d9ed988d5e9a5e6531dc3f2c28efbd639cbd1dfb628df08edea6004da77"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -3939,12 +3979,9 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
 
 [[package]]
 name = "smallvec"

--- a/crates/api-types/Cargo.toml
+++ b/crates/api-types/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 [dependencies]
 clickhouse_lib = { path = "../clickhouse", package = "clickhouse" }
 axum.workspace = true
+chrono.workspace = true
 
 serde.workspace = true
 utoipa.workspace = true

--- a/crates/api-types/src/lib.rs
+++ b/crates/api-types/src/lib.rs
@@ -11,6 +11,7 @@ use clickhouse_lib::{
 };
 
 use axum::{Json, http::StatusCode, response::IntoResponse};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
@@ -282,6 +283,8 @@ pub struct BlockTransactionsItem {
     pub txs: u32,
     /// Address of the sequencer that proposed the block.
     pub sequencer: String,
+    /// Timestamp of the block.
+    pub block_time: DateTime<Utc>,
 }
 
 /// Collection of block transaction counts.

--- a/crates/clickhouse/src/models.rs
+++ b/crates/clickhouse/src/models.rs
@@ -166,6 +166,8 @@ pub struct BlockTransactionRow {
     pub sequencer: AddressBytes,
     /// L2 block number
     pub l2_block_number: u64,
+    /// Timestamp of the L2 block
+    pub block_time: DateTime<Utc>,
     /// Number of transactions in the block
     pub sum_tx: u32,
 }
@@ -213,6 +215,8 @@ pub struct L2BlockTimeRow {
 pub struct L2GasUsedRow {
     /// L2 block number
     pub l2_block_number: u64,
+    /// Timestamp of the L2 block
+    pub block_time: DateTime<Utc>,
     /// Total gas used in the block
     pub gas_used: u64,
 }

--- a/dashboard/components/BlockTimeChart.tsx
+++ b/dashboard/components/BlockTimeChart.tsx
@@ -77,7 +77,11 @@ const BlockTimeChartComponent: React.FC<BlockTimeChartProps> = ({
           }}
         />
         <Tooltip
-          labelFormatter={(label: number) => `Block ${label.toLocaleString()}`}
+          labelFormatter={(label: number, payload) => {
+            const ts = payload?.[0]?.payload?.blockTime;
+            const timeStr = ts ? new Date(ts).toLocaleString() : '';
+            return `Block ${label.toLocaleString()} (${timeStr})`;
+          }}
           formatter={(value: number) => [
             formatInterval(
               seconds ? value : value / 1000,

--- a/dashboard/components/BlockTxChart.tsx
+++ b/dashboard/components/BlockTxChart.tsx
@@ -67,7 +67,11 @@ const BlockTxChartComponent: React.FC<BlockTxChartProps> = ({
           }}
         />
         <Tooltip
-          labelFormatter={(label: number) => `Block ${label.toLocaleString()}`}
+          labelFormatter={(label: number, payload) => {
+            const ts = payload?.[0]?.payload?.blockTime;
+            const timeStr = ts ? new Date(ts).toLocaleString() : '';
+            return `Block ${label.toLocaleString()} (${timeStr})`;
+          }}
           formatter={(value: number) => [value.toLocaleString(), 'txs']}
           contentStyle={{
             backgroundColor: 'rgba(255, 255, 255, 0.8)',

--- a/dashboard/components/GasUsedChart.tsx
+++ b/dashboard/components/GasUsedChart.tsx
@@ -63,7 +63,11 @@ const GasUsedChartComponent: React.FC<GasUsedChartProps> = ({
           }}
         />
         <Tooltip
-          labelFormatter={(label: number) => `Block ${label.toLocaleString()}`}
+          labelFormatter={(label: number, payload) => {
+            const ts = payload?.[0]?.payload?.blockTime;
+            const timeStr = ts ? new Date(ts).toLocaleString() : '';
+            return `Block ${label.toLocaleString()} (${timeStr})`;
+          }}
           formatter={(value: number) => [formatLargeNumber(value), 'gas']}
           contentStyle={{
             backgroundColor: 'rgba(255, 255, 255, 0.8)',

--- a/dashboard/tests/apiService.test.ts
+++ b/dashboard/tests/apiService.test.ts
@@ -65,46 +65,50 @@ describe('apiService', () => {
   it('transforms block times', async () => {
     globalThis.fetch = mockFetch({
       blocks: [
-        { l2_block_number: 1, ms_since_prev_block: 10 },
-        { l2_block_number: 2, ms_since_prev_block: 20 },
+        { l2_block_number: 1, block_time: '1970-01-01T00:00:01Z', ms_since_prev_block: 10 },
+        { l2_block_number: 2, block_time: '1970-01-01T00:00:02Z', ms_since_prev_block: 20 },
       ],
     });
     const blockTimes = await fetchL2BlockTimes('1h');
     expect(blockTimes.error).toBeNull();
-    expect(blockTimes.data).toStrictEqual([{ value: 2, timestamp: 0.02 }]);
+    expect(blockTimes.data).toStrictEqual([
+      { value: 2, timestamp: 0.02, blockTime: new Date('1970-01-01T00:00:02Z').getTime() },
+    ]);
   });
 
   it('transforms block times for 15m', async () => {
     globalThis.fetch = mockFetch({
       blocks: [
-        { l2_block_number: 1, ms_since_prev_block: 10 },
-        { l2_block_number: 2, ms_since_prev_block: 20 },
+        { l2_block_number: 1, block_time: '1970-01-01T00:00:01Z', ms_since_prev_block: 10 },
+        { l2_block_number: 2, block_time: '1970-01-01T00:00:02Z', ms_since_prev_block: 20 },
       ],
     });
     const blockTimes = await fetchL2BlockTimes('15m');
     expect(blockTimes.error).toBeNull();
-    expect(blockTimes.data).toStrictEqual([{ value: 2, timestamp: 0.02 }]);
+    expect(blockTimes.data).toStrictEqual([
+      { value: 2, timestamp: 0.02, blockTime: new Date('1970-01-01T00:00:02Z').getTime() },
+    ]);
   });
 
   it('transforms block transactions', async () => {
     globalThis.fetch = mockFetch({
-      blocks: [{ block: 1, txs: 3, sequencer: '0xabc' }],
+      blocks: [{ block: 1, txs: 3, sequencer: '0xabc', block_time: '1970-01-01T00:00:01Z' }],
     });
     const txs = await fetchBlockTransactions('1h');
     expect(txs.error).toBeNull();
     expect(txs.data).toStrictEqual([
-      { block: 1, txs: 3, sequencer: '0xabc' },
+      { block: 1, txs: 3, sequencer: '0xabc', blockTime: new Date('1970-01-01T00:00:01Z').getTime() },
     ]);
   });
 
   it('transforms block transactions for 15m', async () => {
     globalThis.fetch = mockFetch({
-      blocks: [{ block: 1, txs: 3, sequencer: '0xabc' }],
+      blocks: [{ block: 1, txs: 3, sequencer: '0xabc', block_time: '1970-01-01T00:00:01Z' }],
     });
     const txs = await fetchBlockTransactions('15m');
     expect(txs.error).toBeNull();
     expect(txs.data).toStrictEqual([
-      { block: 1, txs: 3, sequencer: '0xabc' },
+      { block: 1, txs: 3, sequencer: '0xabc', blockTime: new Date('1970-01-01T00:00:01Z').getTime() },
     ]);
   });
 

--- a/dashboard/tests/app.integration.test.ts
+++ b/dashboard/tests/app.integration.test.ts
@@ -90,14 +90,14 @@ const responses: Record<string, Record<string, unknown>> = {
   [`/v1/forced-inclusions?${q15m}`]: { events: [{ blob_hash: [3, 4] }] },
   [`/v1/l2-block-times?${q1h}`]: {
     blocks: [
-      { l2_block_number: 1, ms_since_prev_block: 1000 },
-      { l2_block_number: 2, ms_since_prev_block: 2000 },
+      { l2_block_number: 1, block_time: '1970-01-01T00:00:01Z', ms_since_prev_block: 1000 },
+      { l2_block_number: 2, block_time: '1970-01-01T00:00:02Z', ms_since_prev_block: 2000 },
     ],
   },
   [`/v1/l2-block-times?${q15m}`]: {
     blocks: [
-      { l2_block_number: 1, ms_since_prev_block: 1000 },
-      { l2_block_number: 2, ms_since_prev_block: 2000 },
+      { l2_block_number: 1, block_time: '1970-01-01T00:00:01Z', ms_since_prev_block: 1000 },
+      { l2_block_number: 2, block_time: '1970-01-01T00:00:02Z', ms_since_prev_block: 2000 },
     ],
   },
   [`/v1/l1-block-times?${q1h}`]: {
@@ -126,14 +126,14 @@ const responses: Record<string, Record<string, unknown>> = {
   },
   [`/v1/l2-gas-used?${q1h}`]: {
     blocks: [
-      { l2_block_number: 1, gas_used: 100 },
-      { l2_block_number: 2, gas_used: 150 },
+      { l2_block_number: 1, block_time: '1970-01-01T00:00:01Z', gas_used: 100 },
+      { l2_block_number: 2, block_time: '1970-01-01T00:00:02Z', gas_used: 150 },
     ],
   },
   [`/v1/l2-gas-used?${q15m}`]: {
     blocks: [
-      { l2_block_number: 1, gas_used: 100 },
-      { l2_block_number: 2, gas_used: 150 },
+      { l2_block_number: 1, block_time: '1970-01-01T00:00:01Z', gas_used: 100 },
+      { l2_block_number: 2, block_time: '1970-01-01T00:00:02Z', gas_used: 150 },
     ],
   },
   [`/v1/l2-fees?${q1h}`]: { priority_fee: 600, base_fee: 400 },

--- a/dashboard/types.ts
+++ b/dashboard/types.ts
@@ -3,6 +3,7 @@ export type TimeRange = string;
 export interface TimeSeriesData {
   timestamp: number; // Unix timestamp (ms)
   value: number;
+  blockTime?: number;
   name?: string; // For line charts with 'name' on x-axis (like batchId)
 }
 


### PR DESCRIPTION
## Summary
- expose block timestamps for l2 gas usage, block times and block transactions
- show block time in chart tooltips
- update dashboard service and tests

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68501ab2ca4083289e5392b402e9db9a