### PR TITLE
Fix Sequencer Distribution table sorting

### DIFF
--- a/dashboard/components/DataTable.tsx
+++ b/dashboard/components/DataTable.tsx
@@ -39,6 +39,8 @@ interface DataTableProps {
   useClientSidePagination?: boolean;
   totalRecords?: number;
   timeRange?: string;
+  defaultSortBy?: string;
+  defaultSortDirection?: 'asc' | 'desc';
 }
 
 export const DataTable: React.FC<DataTableProps> = ({
@@ -57,10 +59,14 @@ export const DataTable: React.FC<DataTableProps> = ({
   useClientSidePagination = false,
   totalRecords,
   timeRange,
+  defaultSortBy,
+  defaultSortDirection,
 }) => {
   const [page, setPage] = React.useState(0);
-  const [sortBy, setSortBy] = React.useState<string>('');
-  const [sortDirection, setSortDirection] = React.useState<'asc' | 'desc'>('asc');
+  const [sortBy, setSortBy] = React.useState<string>(defaultSortBy ?? '');
+  const [sortDirection, setSortDirection] = React.useState<'asc' | 'desc'>(
+    defaultSortDirection ?? 'asc',
+  );
 
   const prevRowsLength = React.useRef(rows.length);
 

--- a/dashboard/components/views/TableView.tsx
+++ b/dashboard/components/views/TableView.tsx
@@ -42,6 +42,8 @@ export const TableView: React.FC<TableViewProps> = ({
       useClientSidePagination={tableView.useClientSidePagination}
       totalRecords={tableView.totalRecords}
       timeRange={tableView.timeRange}
+      defaultSortBy={tableView.defaultSortBy}
+      defaultSortDirection={tableView.defaultSortDirection}
     />
   );
 };

--- a/dashboard/hooks/useTableActions.ts
+++ b/dashboard/hooks/useTableActions.ts
@@ -36,6 +36,8 @@ export interface TableViewState {
   allRows?: Record<string, React.ReactNode | string | number>[];
   useClientSidePagination?: boolean;
   totalRecords?: number;
+  defaultSortBy?: string;
+  defaultSortDirection?: 'asc' | 'desc';
 }
 
 export const useTableActions = (
@@ -86,6 +88,8 @@ export const useTableActions = (
       allRows?: Record<string, React.ReactNode | string | number>[],
       useClientSidePagination?: boolean,
       totalRecords?: number,
+      defaultSortBy?: string,
+      defaultSortDirection?: 'asc' | 'desc',
     ) => {
       setTableView({
         title,
@@ -102,6 +106,8 @@ export const useTableActions = (
         allRows,
         useClientSidePagination,
         totalRecords,
+        defaultSortBy,
+        defaultSortDirection,
       });
       setTableLoading(false);
     },
@@ -283,6 +289,11 @@ export const useTableActions = (
         (r) => openSequencerDistributionTable(r, 0),
         refreshSeqDist,
         undefined,
+        undefined,
+        undefined,
+        undefined,
+        'value',
+        'desc',
       );
     },
     [


### PR DESCRIPTION
## Summary
- allow DataTable to specify default sort column and direction
- expose default sort props from TableViewState
- open Sequencer Distribution table sorted by blocks descending

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68503e72f2d88328ad70497954c93a3e