### PR TITLE
Add sequencer filtering to economics view

### DIFF
--- a/dashboard/hooks/useDataFetcher.ts
+++ b/dashboard/hooks/useDataFetcher.ts
@@ -74,7 +74,11 @@ export const useDataFetcher = ({
 
       const metrics = createMetrics(metricsInput);
 
-      return { metrics, chartData: null, anyBadRequest };
+      return {
+        metrics,
+        chartData: { sequencerDist: data.sequencerDist },
+        anyBadRequest,
+      };
     }
 
     const data = await fetchMainDashboardData(timeRange, selectedSequencer);

--- a/dashboard/tests/dataFetcher.test.ts
+++ b/dashboard/tests/dataFetcher.test.ts
@@ -85,6 +85,7 @@ describe('dataFetcher', () => {
       fetchL2Fees: ok({ priority_fee: 1, base_fee: 2, l1_data_cost: 4 }),
       fetchL2HeadBlock: ok(2),
       fetchL1HeadBlock: ok(3),
+      fetchSequencerDistribution: ok([{ name: 'foo', value: 1, tps: null }]),
     });
 
     const res = await fetchEconomicsData('1h', null);
@@ -93,7 +94,8 @@ describe('dataFetcher', () => {
     expect(res.l2Block).toBe(2);
     expect(res.l1Block).toBe(3);
     expect(res.l1DataCost).toBe(4);
-    expect(res.badRequestResults).toHaveLength(3);
+    expect(res.sequencerDist[0].name).toBe('foo');
+    expect(res.badRequestResults).toHaveLength(4);
   });
 
   it('resets isTimeRangeChanging on fetch error', async () => {

--- a/dashboard/utils/dataFetcher.ts
+++ b/dashboard/utils/dataFetcher.ts
@@ -45,6 +45,11 @@ export interface EconomicsData {
   l1DataCost: number | null;
   l2Block: number | null;
   l1Block: number | null;
+  sequencerDist: {
+    name: string;
+    value: number;
+    tps: number | null;
+  }[];
   badRequestResults: any[];
 }
 
@@ -120,13 +125,14 @@ export const fetchEconomicsData = async (
   selectedSequencer: string | null,
 ): Promise<EconomicsData> => {
   const normalizedRange = normalizeTimeRange(timeRange);
-  const [l2FeesRes, l2BlockRes, l1BlockRes] = await Promise.all([
+  const [l2FeesRes, l2BlockRes, l1BlockRes, sequencerDistRes] = await Promise.all([
     fetchL2Fees(
       normalizedRange,
       selectedSequencer ? getSequencerAddress(selectedSequencer) : undefined,
     ),
     fetchL2HeadBlock(normalizedRange),
     fetchL1HeadBlock(normalizedRange),
+    fetchSequencerDistribution(normalizedRange),
   ]);
 
   return {
@@ -135,6 +141,7 @@ export const fetchEconomicsData = async (
     l1DataCost: l2FeesRes.data?.l1_data_cost ?? null,
     l2Block: l2BlockRes.data,
     l1Block: l1BlockRes.data,
-    badRequestResults: [l2FeesRes, l2BlockRes, l1BlockRes],
+    sequencerDist: sequencerDistRes.data || [],
+    badRequestResults: [l2FeesRes, l2BlockRes, l1BlockRes, sequencerDistRes],
   };
 };


### PR DESCRIPTION
## Summary
- fetch sequencer distribution in `fetchEconomicsData`
- expose that data in `useDataFetcher`
- update tests for economics data fetch

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68503da542948328969bc59327b54e6e