### PR TITLE
Fix sequencer link in block tx table

### DIFF
--- a/dashboard/config/tableConfig.ts
+++ b/dashboard/config/tableConfig.ts
@@ -233,7 +233,7 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
         (d) => ({
           block: blockLink(d.block),
           txs: d.txs.toLocaleString(),
-          sequencer: d.sequencer,
+          sequencer: addressLink(d.sequencer),
         }),
       ),
     urlKey: 'block-tx',


### PR DESCRIPTION
## Summary
- link sequencer address in Block Tx table

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68504373f4508328bb28344f089b265a