### PR TITLE
Fix address column links

### DIFF
--- a/dashboard/config/tableConfig.ts
+++ b/dashboard/config/tableConfig.ts
@@ -120,7 +120,7 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
         const name = getSequencerName(g);
         return {
           sequencer: name === g ? 'Unknown' : name,
-          address: g,
+          address: addressLink(g),
         };
       }),
     urlKey: 'gateways',


### PR DESCRIPTION
## Summary
- make sequencer addresses clickable links on the dashboard

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685043e5e2908328b3ef88468f381eec