### PR TITLE
Add chart and table endpoints

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -746,13 +746,22 @@ async fn l2_block_times_aggregated(
     validate_range_exclusivity(has_time_range, false)?;
 
     let time_range = resolve_time_range_enum(&params.range, &params.time_range);
-    let address = params.address.as_ref().and_then(|addr| match addr.parse::<Address>() {
-        Ok(a) => Some(AddressBytes::from(a)),
-        Err(e) => {
-            tracing::warn!(error = %e, "Failed to parse address");
-            None
+    let address = if let Some(addr) = params.address.as_ref() {
+        match addr.parse::<Address>() {
+            Ok(a) => Some(AddressBytes::from(a)),
+            Err(e) => {
+                tracing::warn!(error = %e, "Failed to parse address");
+                return Err(ErrorResponse::new(
+                    "invalid-params",
+                    "Bad Request",
+                    StatusCode::BAD_REQUEST,
+                    e.to_string(),
+                ));
+            }
         }
-    });
+    } else {
+        None
+    };
     let blocks = match state.client.get_l2_block_times(address, time_range).await {
         Ok(rows) => rows,
         Err(e) => {
@@ -791,13 +800,22 @@ async fn l2_gas_used_aggregated(
     validate_range_exclusivity(has_time_range, false)?;
 
     let time_range = resolve_time_range_enum(&params.range, &params.time_range);
-    let address = params.address.as_ref().and_then(|addr| match addr.parse::<Address>() {
-        Ok(a) => Some(AddressBytes::from(a)),
-        Err(e) => {
-            tracing::warn!(error = %e, "Failed to parse address");
-            None
+    let address = if let Some(addr) = params.address.as_ref() {
+        match addr.parse::<Address>() {
+            Ok(a) => Some(AddressBytes::from(a)),
+            Err(e) => {
+                tracing::warn!(error = %e, "Failed to parse address");
+                return Err(ErrorResponse::new(
+                    "invalid-params",
+                    "Bad Request",
+                    StatusCode::BAD_REQUEST,
+                    e.to_string(),
+                ));
+            }
         }
-    });
+    } else {
+        None
+    };
     let blocks = match state.client.get_l2_gas_used(address, time_range).await {
         Ok(rows) => rows,
         Err(e) => {
@@ -839,13 +857,22 @@ async fn l2_tps(
     validate_range_exclusivity(has_time_range, false)?;
 
     let time_range = resolve_time_range_enum(&params.range, &params.time_range);
-    let address = params.address.as_ref().and_then(|addr| match addr.parse::<Address>() {
-        Ok(a) => Some(AddressBytes::from(a)),
-        Err(e) => {
-            tracing::warn!(error = %e, "Failed to parse address");
-            None
+    let address = if let Some(addr) = params.address.as_ref() {
+        match addr.parse::<Address>() {
+            Ok(a) => Some(AddressBytes::from(a)),
+            Err(e) => {
+                tracing::warn!(error = %e, "Failed to parse address");
+                return Err(ErrorResponse::new(
+                    "invalid-params",
+                    "Bad Request",
+                    StatusCode::BAD_REQUEST,
+                    e.to_string(),
+                ));
+            }
         }
-    });
+    } else {
+        None
+    };
     let blocks = match state.client.get_l2_tps(address, time_range).await {
         Ok(rows) => rows,
         Err(e) => {
@@ -993,13 +1020,22 @@ async fn block_transactions_aggregated(
     validate_range_exclusivity(has_time_range, false)?;
 
     let since = resolve_time_range_since(&params.range, &params.time_range);
-    let address = params.address.as_ref().and_then(|addr| match addr.parse::<Address>() {
-        Ok(a) => Some(AddressBytes::from(a)),
-        Err(e) => {
-            tracing::warn!(error = %e, "Failed to parse address");
-            None
+    let address = if let Some(addr) = params.address.as_ref() {
+        match addr.parse::<Address>() {
+            Ok(a) => Some(AddressBytes::from(a)),
+            Err(e) => {
+                tracing::warn!(error = %e, "Failed to parse address");
+                return Err(ErrorResponse::new(
+                    "invalid-params",
+                    "Bad Request",
+                    StatusCode::BAD_REQUEST,
+                    e.to_string(),
+                ));
+            }
         }
-    });
+    } else {
+        None
+    };
 
     let rows = match state
         .client
@@ -1281,13 +1317,22 @@ async fn l2_fees(
     validate_range_exclusivity(has_time_range, false)?;
 
     let time_range = resolve_time_range_enum(&params.range, &params.time_range);
-    let address = params.address.as_ref().and_then(|addr| match addr.parse::<Address>() {
-        Ok(a) => Some(AddressBytes::from(a)),
-        Err(e) => {
-            tracing::warn!(error = %e, "Failed to parse address");
-            None
+    let address = if let Some(addr) = params.address.as_ref() {
+        match addr.parse::<Address>() {
+            Ok(a) => Some(AddressBytes::from(a)),
+            Err(e) => {
+                tracing::warn!(error = %e, "Failed to parse address");
+                return Err(ErrorResponse::new(
+                    "invalid-params",
+                    "Bad Request",
+                    StatusCode::BAD_REQUEST,
+                    e.to_string(),
+                ));
+            }
         }
-    });
+    } else {
+        None
+    };
 
     let (priority_fee, base_fee, l1_data_cost) = tokio::try_join!(
         state.client.get_l2_priority_fee(address, time_range),
@@ -1330,13 +1375,22 @@ async fn l2_fee_components(
     validate_range_exclusivity(has_time_range, false)?;
 
     let time_range = resolve_time_range_enum(&params.range, &params.time_range);
-    let address = params.address.as_ref().and_then(|addr| match addr.parse::<Address>() {
-        Ok(a) => Some(AddressBytes::from(a)),
-        Err(e) => {
-            tracing::warn!(error = %e, "Failed to parse address");
-            None
+    let address = if let Some(addr) = params.address.as_ref() {
+        match addr.parse::<Address>() {
+            Ok(a) => Some(AddressBytes::from(a)),
+            Err(e) => {
+                tracing::warn!(error = %e, "Failed to parse address");
+                return Err(ErrorResponse::new(
+                    "invalid-params",
+                    "Bad Request",
+                    StatusCode::BAD_REQUEST,
+                    e.to_string(),
+                ));
+            }
         }
-    });
+    } else {
+        None
+    };
 
     let blocks = state.client.get_l2_fee_components(address, time_range).await.map_err(|e| {
         tracing::error!(error = %e, "Failed to get fee components");
@@ -1883,6 +1937,16 @@ mod tests {
         assert_eq!(body["type"], "invalid-params");
     }
 
+    #[tokio::test]
+    async fn l2_block_times_aggregated_invalid_address() {
+        let mock = Mock::new();
+        let app = build_app(mock.url());
+        let (status, body) =
+            send_error_request(app, "/l2-block-times/aggregated?range=1h&address=zzz").await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(body["type"], "invalid-params");
+    }
+
     #[derive(Serialize, Row)]
     struct L2GasUsedRowTest {
         l2_block_number: u64,
@@ -1936,6 +2000,16 @@ mod tests {
             body,
             json!({ "blocks": [ { "l2_block_number": 0, "block_time": "1970-01-01T00:00:01Z", "gas_used": 21 } ] })
         );
+    }
+
+    #[tokio::test]
+    async fn l2_gas_used_aggregated_invalid_address() {
+        let mock = Mock::new();
+        let app = build_app(mock.url());
+        let (status, body) =
+            send_error_request(app, "/l2-gas-used/aggregated?range=1h&address=zzz").await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(body["type"], "invalid-params");
     }
 
     #[derive(Serialize, Row)]
@@ -2360,6 +2434,16 @@ mod tests {
         let app = build_app(mock.url());
         let (status, body) =
             send_error_request(app, "/block-transactions?range=1h&address=zzz").await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(body["type"], "invalid-params");
+    }
+
+    #[tokio::test]
+    async fn block_transactions_aggregated_invalid_address() {
+        let mock = Mock::new();
+        let app = build_app(mock.url());
+        let (status, body) =
+            send_error_request(app, "/block-transactions/aggregated?range=1h&address=zzz").await;
         assert_eq!(status, StatusCode::BAD_REQUEST);
         assert_eq!(body["type"], "invalid-params");
     }

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -33,6 +33,8 @@ pub const DEFAULT_MAX_REQUESTS: u64 = u64::MAX;
 pub const DEFAULT_RATE_PERIOD: StdDuration = StdDuration::from_secs(1);
 /// Maximum number of records returned by the `/block-transactions` endpoint.
 pub const MAX_BLOCK_TRANSACTIONS_LIMIT: u64 = 50000;
+/// Maximum number of records returned by table endpoints.
+pub const MAX_TABLE_LIMIT: u64 = 50000;
 
 /// `OpenAPI` documentation structure
 #[derive(Debug, OpenApi)]
@@ -51,11 +53,14 @@ pub const MAX_BLOCK_TRANSACTIONS_LIMIT: u64 = 50000;
         verify_times,
         l1_block_times,
         l2_block_times,
+        l2_block_times_aggregated,
         l2_gas_used,
+        l2_gas_used_aggregated,
         l2_tps,
+        block_transactions,
+        block_transactions_aggregated,
         sequencer_distribution,
         sequencer_blocks,
-        block_transactions,
         l2_fees,
         l2_fee_components,
         dashboard_data,
@@ -722,83 +727,21 @@ async fn l1_block_times(
 
 #[utoipa::path(
     get,
-    path = "/l2-block-times",
+    path = "/l2-block-times/aggregated",
     params(
         RangeQuery
     ),
     responses(
-        (status = 200, description = "L2 block times", body = L2BlockTimesResponse),
+        (status = 200, description = "Aggregated L2 block times", body = L2BlockTimesResponse),
         (status = 500, description = "Database error", body = ErrorResponse)
     ),
     tag = "taikoscope"
 )]
-async fn l2_block_times(
+async fn l2_block_times_aggregated(
     Query(params): Query<RangeQuery>,
     State(state): State<ApiState>,
 ) -> Result<Json<L2BlockTimesResponse>, ErrorResponse> {
-    // Validate time range parameters
     validate_time_range(&params.time_range)?;
-
-    // Check for range exclusivity
-    let has_time_range = has_time_range_params(&params.time_range);
-    validate_range_exclusivity(has_time_range, false)?;
-
-    let time_range = resolve_time_range_enum(&params.range, &params.time_range);
-    let address = if let Some(addr) = params.address.as_ref() {
-        match addr.parse::<Address>() {
-            Ok(a) => Some(AddressBytes::from(a)),
-            Err(e) => {
-                tracing::warn!(error = %e, "Failed to parse address");
-                return Err(ErrorResponse::new(
-                    "invalid-params",
-                    "Bad Request",
-                    StatusCode::BAD_REQUEST,
-                    e.to_string(),
-                ));
-            }
-        }
-    } else {
-        None
-    };
-    let mut blocks = match state.client.get_l2_block_times(address, time_range).await {
-        Ok(rows) => rows,
-        Err(e) => {
-            tracing::error!(error = %e, "Failed to get L2 block times");
-            return Err(ErrorResponse::new(
-                "database-error",
-                "Database error",
-                StatusCode::INTERNAL_SERVER_ERROR,
-                e.to_string(),
-            ));
-        }
-    };
-    if time_range.seconds() > 3600 {
-        blocks = aggregate_l2_block_times(blocks);
-    }
-    tracing::info!(count = blocks.len(), "Returning L2 block times");
-    Ok(Json(L2BlockTimesResponse { blocks }))
-}
-
-#[utoipa::path(
-    get,
-    path = "/l2-gas-used",
-    params(
-        RangeQuery
-    ),
-    responses(
-        (status = 200, description = "L2 gas used", body = L2GasUsedResponse),
-        (status = 500, description = "Database error", body = ErrorResponse)
-    ),
-    tag = "taikoscope"
-)]
-async fn l2_gas_used(
-    Query(params): Query<RangeQuery>,
-    State(state): State<ApiState>,
-) -> Result<Json<L2GasUsedResponse>, ErrorResponse> {
-    // Validate time range parameters
-    validate_time_range(&params.time_range)?;
-
-    // Check for range exclusivity
     let has_time_range = has_time_range_params(&params.time_range);
     validate_range_exclusivity(has_time_range, false)?;
 
@@ -810,7 +753,52 @@ async fn l2_gas_used(
             None
         }
     });
-    let mut blocks = match state.client.get_l2_gas_used(address, time_range).await {
+    let blocks = match state.client.get_l2_block_times(address, time_range).await {
+        Ok(rows) => rows,
+        Err(e) => {
+            tracing::error!(error = %e, "Failed to get L2 block times");
+            return Err(ErrorResponse::new(
+                "database-error",
+                "Database error",
+                StatusCode::INTERNAL_SERVER_ERROR,
+                e.to_string(),
+            ));
+        }
+    };
+    let blocks = aggregate_l2_block_times(blocks);
+    tracing::info!(count = blocks.len(), "Returning aggregated L2 block times");
+    Ok(Json(L2BlockTimesResponse { blocks }))
+}
+
+#[utoipa::path(
+    get,
+    path = "/l2-gas-used/aggregated",
+    params(
+        RangeQuery
+    ),
+    responses(
+        (status = 200, description = "Aggregated L2 gas used", body = L2GasUsedResponse),
+        (status = 500, description = "Database error", body = ErrorResponse)
+    ),
+    tag = "taikoscope"
+)]
+async fn l2_gas_used_aggregated(
+    Query(params): Query<RangeQuery>,
+    State(state): State<ApiState>,
+) -> Result<Json<L2GasUsedResponse>, ErrorResponse> {
+    validate_time_range(&params.time_range)?;
+    let has_time_range = has_time_range_params(&params.time_range);
+    validate_range_exclusivity(has_time_range, false)?;
+
+    let time_range = resolve_time_range_enum(&params.range, &params.time_range);
+    let address = params.address.as_ref().and_then(|addr| match addr.parse::<Address>() {
+        Ok(a) => Some(AddressBytes::from(a)),
+        Err(e) => {
+            tracing::warn!(error = %e, "Failed to parse address");
+            None
+        }
+    });
+    let blocks = match state.client.get_l2_gas_used(address, time_range).await {
         Ok(rows) => rows,
         Err(e) => {
             tracing::error!("Failed to get L2 gas used: {}", e);
@@ -822,10 +810,8 @@ async fn l2_gas_used(
             ));
         }
     };
-    if time_range.seconds() > 3600 {
-        blocks = aggregate_l2_gas_used(blocks);
-    }
-    tracing::info!(count = blocks.len(), "Returning L2 gas used");
+    let blocks = aggregate_l2_gas_used(blocks);
+    tracing::info!(count = blocks.len(), "Returning aggregated L2 gas used");
     Ok(Json(L2GasUsedResponse { blocks }))
 }
 
@@ -988,12 +974,217 @@ async fn sequencer_blocks(
 
 #[utoipa::path(
     get,
+    path = "/block-transactions/aggregated",
+    params(
+        RangeQuery
+    ),
+    responses(
+        (status = 200, description = "Aggregated block transactions", body = BlockTransactionsResponse),
+        (status = 500, description = "Database error", body = ErrorResponse)
+    ),
+    tag = "taikoscope"
+)]
+async fn block_transactions_aggregated(
+    Query(params): Query<RangeQuery>,
+    State(state): State<ApiState>,
+) -> Result<Json<BlockTransactionsResponse>, ErrorResponse> {
+    validate_time_range(&params.time_range)?;
+    let has_time_range = has_time_range_params(&params.time_range);
+    validate_range_exclusivity(has_time_range, false)?;
+
+    let since = resolve_time_range_since(&params.range, &params.time_range);
+    let address = params.address.as_ref().and_then(|addr| match addr.parse::<Address>() {
+        Ok(a) => Some(AddressBytes::from(a)),
+        Err(e) => {
+            tracing::warn!(error = %e, "Failed to parse address");
+            None
+        }
+    });
+
+    let rows = match state
+        .client
+        .get_block_transactions_paginated(since, MAX_BLOCK_TRANSACTIONS_LIMIT, None, None, address)
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::error!(error = %e, "Failed to get block transactions");
+            return Err(ErrorResponse::new(
+                "database-error",
+                "Database error",
+                StatusCode::INTERNAL_SERVER_ERROR,
+                e.to_string(),
+            ));
+        }
+    };
+
+    let blocks: Vec<BlockTransactionsItem> = rows
+        .into_iter()
+        .map(|r| BlockTransactionsItem {
+            block: r.l2_block_number,
+            txs: r.sum_tx,
+            sequencer: format!("0x{}", encode(r.sequencer)),
+            block_time: r.block_time,
+        })
+        .collect();
+
+    let blocks = aggregate_block_transactions(blocks);
+    tracing::info!(count = blocks.len(), "Returning aggregated block transactions");
+    Ok(Json(BlockTransactionsResponse { blocks }))
+}
+
+#[utoipa::path(
+    get,
+    path = "/l2-block-times",
+    params(
+        PaginatedQuery
+    ),
+    responses(
+        (status = 200, description = "Paginated L2 block times", body = L2BlockTimesResponse),
+        (status = 500, description = "Database error", body = ErrorResponse)
+    ),
+    tag = "taikoscope"
+)]
+async fn l2_block_times(
+    Query(params): Query<PaginatedQuery>,
+    State(state): State<ApiState>,
+) -> Result<Json<L2BlockTimesResponse>, ErrorResponse> {
+    validate_time_range(&params.common.time_range)?;
+    let limit = validate_pagination(
+        params.starting_after.as_ref(),
+        params.ending_before.as_ref(),
+        params.limit.as_ref(),
+        MAX_TABLE_LIMIT,
+    )?;
+    let has_time_range = has_time_range_params(&params.common.time_range);
+    let has_slot_range = params.starting_after.is_some() || params.ending_before.is_some();
+    validate_range_exclusivity(has_time_range, has_slot_range)?;
+
+    let since = resolve_time_range_since(&params.common.range, &params.common.time_range);
+    let address = if let Some(addr) = params.common.address.as_ref() {
+        match addr.parse::<Address>() {
+            Ok(a) => Some(AddressBytes::from(a)),
+            Err(e) => {
+                tracing::warn!(error = %e, "Failed to parse address");
+                return Err(ErrorResponse::new(
+                    "invalid-params",
+                    "Bad Request",
+                    StatusCode::BAD_REQUEST,
+                    e.to_string(),
+                ));
+            }
+        }
+    } else {
+        None
+    };
+
+    let rows = match state
+        .client
+        .get_l2_block_times_paginated(
+            since,
+            limit,
+            params.starting_after,
+            params.ending_before,
+            address,
+        )
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::error!(error = %e, "Failed to get L2 block times");
+            return Err(ErrorResponse::new(
+                "database-error",
+                "Database error",
+                StatusCode::INTERNAL_SERVER_ERROR,
+                e.to_string(),
+            ));
+        }
+    };
+
+    tracing::info!(count = rows.len(), "Returning table L2 block times");
+    Ok(Json(L2BlockTimesResponse { blocks: rows }))
+}
+
+#[utoipa::path(
+    get,
+    path = "/l2-gas-used",
+    params(
+        PaginatedQuery
+    ),
+    responses(
+        (status = 200, description = "Paginated L2 gas used", body = L2GasUsedResponse),
+        (status = 500, description = "Database error", body = ErrorResponse)
+    ),
+    tag = "taikoscope"
+)]
+async fn l2_gas_used(
+    Query(params): Query<PaginatedQuery>,
+    State(state): State<ApiState>,
+) -> Result<Json<L2GasUsedResponse>, ErrorResponse> {
+    validate_time_range(&params.common.time_range)?;
+    let limit = validate_pagination(
+        params.starting_after.as_ref(),
+        params.ending_before.as_ref(),
+        params.limit.as_ref(),
+        MAX_TABLE_LIMIT,
+    )?;
+    let has_time_range = has_time_range_params(&params.common.time_range);
+    let has_slot_range = params.starting_after.is_some() || params.ending_before.is_some();
+    validate_range_exclusivity(has_time_range, has_slot_range)?;
+
+    let since = resolve_time_range_since(&params.common.range, &params.common.time_range);
+    let address = if let Some(addr) = params.common.address.as_ref() {
+        match addr.parse::<Address>() {
+            Ok(a) => Some(AddressBytes::from(a)),
+            Err(e) => {
+                tracing::warn!(error = %e, "Failed to parse address");
+                return Err(ErrorResponse::new(
+                    "invalid-params",
+                    "Bad Request",
+                    StatusCode::BAD_REQUEST,
+                    e.to_string(),
+                ));
+            }
+        }
+    } else {
+        None
+    };
+
+    let rows = match state
+        .client
+        .get_l2_gas_used_paginated(
+            since,
+            limit,
+            params.starting_after,
+            params.ending_before,
+            address,
+        )
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::error!("Failed to get L2 gas used: {}", e);
+            return Err(ErrorResponse::new(
+                "database-error",
+                "Database error",
+                StatusCode::INTERNAL_SERVER_ERROR,
+                e.to_string(),
+            ));
+        }
+    };
+
+    tracing::info!(count = rows.len(), "Returning table L2 gas used");
+    Ok(Json(L2GasUsedResponse { blocks: rows }))
+}
+
+#[utoipa::path(
+    get,
     path = "/block-transactions",
     params(
         BlockTransactionsQuery
     ),
     responses(
-        (status = 200, description = "Block transactions", body = BlockTransactionsResponse),
+        (status = 200, description = "Paginated block transactions", body = BlockTransactionsResponse),
         (status = 500, description = "Database error", body = ErrorResponse)
     ),
     tag = "taikoscope"
@@ -1002,24 +1193,18 @@ async fn block_transactions(
     Query(params): Query<BlockTransactionsQuery>,
     State(state): State<ApiState>,
 ) -> Result<Json<BlockTransactionsResponse>, ErrorResponse> {
-    // Validate time range parameters
     validate_time_range(&params.common.time_range)?;
-
-    // Validate pagination parameters
     let limit = validate_pagination(
         params.starting_after.as_ref(),
         params.ending_before.as_ref(),
         params.limit.as_ref(),
-        MAX_BLOCK_TRANSACTIONS_LIMIT,
+        MAX_TABLE_LIMIT,
     )?;
-
-    // Check for range exclusivity between time range and slot range
     let has_time_range = has_time_range_params(&params.common.time_range);
     let has_slot_range = params.starting_after.is_some() || params.ending_before.is_some();
     validate_range_exclusivity(has_time_range, has_slot_range)?;
 
     let since = resolve_time_range_since(&params.common.range, &params.common.time_range);
-
     let address = if let Some(addr) = params.common.address.as_ref() {
         match addr.parse::<Address>() {
             Ok(a) => Some(AddressBytes::from(a)),
@@ -1060,7 +1245,7 @@ async fn block_transactions(
         }
     };
 
-    let mut blocks: Vec<BlockTransactionsItem> = rows
+    let blocks: Vec<BlockTransactionsItem> = rows
         .into_iter()
         .map(|r| BlockTransactionsItem {
             block: r.l2_block_number,
@@ -1070,12 +1255,7 @@ async fn block_transactions(
         })
         .collect();
 
-    let time_range = resolve_time_range_enum(&params.common.range, &params.common.time_range);
-    if time_range.seconds() > 3600 {
-        blocks = aggregate_block_transactions(blocks);
-    }
-
-    tracing::info!(count = blocks.len(), "Returning block transactions");
+    tracing::info!(count = blocks.len(), "Returning table block transactions");
     Ok(Json(BlockTransactionsResponse { blocks }))
 }
 
@@ -1333,12 +1513,15 @@ pub fn router(state: ApiState) -> Router {
         .route("/verify-times", get(verify_times))
         .route("/l1-block-times", get(l1_block_times))
         .route("/l2-block-times", get(l2_block_times))
+        .route("/l2-block-times/aggregated", get(l2_block_times_aggregated))
         .route("/l2-gas-used", get(l2_gas_used))
+        .route("/l2-gas-used/aggregated", get(l2_gas_used_aggregated))
         .route("/l2-tps", get(l2_tps))
         .route("/tps", get(l2_tps))
         .route("/sequencer-distribution", get(sequencer_distribution))
         .route("/sequencer-blocks", get(sequencer_blocks))
         .route("/block-transactions", get(block_transactions))
+        .route("/block-transactions/aggregated", get(block_transactions_aggregated))
         .route("/l2-fees", get(l2_fees))
         .route("/l2-fee-components", get(l2_fee_components))
         .route("/dashboard-data", get(dashboard_data))
@@ -1665,7 +1848,7 @@ mod tests {
             },
         ]));
         let app = build_app(mock.url());
-        let body = send_request(app, "/l2-block-times?range=24h").await;
+        let body = send_request(app, "/l2-block-times/aggregated?range=24h").await;
         assert_eq!(
             body,
             json!({ "blocks": [ { "l2_block_number": 0, "block_time": "1970-01-01T00:00:02Z", "ms_since_prev_block": 2000 } ] })
@@ -1684,7 +1867,7 @@ mod tests {
             },
         ]));
         let app = build_app(mock.url());
-        let body = send_request(app, "/l2-block-times?range=7d").await;
+        let body = send_request(app, "/l2-block-times/aggregated?range=7d").await;
         assert_eq!(
             body,
             json!({ "blocks": [ { "l2_block_number": 0, "block_time": "1970-01-01T00:00:02Z", "ms_since_prev_block": 2000 } ] })
@@ -1733,7 +1916,7 @@ mod tests {
             L2GasUsedRowTest { l2_block_number: 1, block_time: 1, gas_used: 42 },
         ]));
         let app = build_app(mock.url());
-        let body = send_request(app, "/l2-gas-used?range=24h").await;
+        let body = send_request(app, "/l2-gas-used/aggregated?range=24h").await;
         assert_eq!(
             body,
             json!({ "blocks": [ { "l2_block_number": 0, "block_time": "1970-01-01T00:00:01Z", "gas_used": 21 } ] })
@@ -1748,7 +1931,7 @@ mod tests {
             L2GasUsedRowTest { l2_block_number: 1, block_time: 1, gas_used: 42 },
         ]));
         let app = build_app(mock.url());
-        let body = send_request(app, "/l2-gas-used?range=7d").await;
+        let body = send_request(app, "/l2-gas-used/aggregated?range=7d").await;
         assert_eq!(
             body,
             json!({ "blocks": [ { "l2_block_number": 0, "block_time": "1970-01-01T00:00:01Z", "gas_used": 21 } ] })
@@ -1927,11 +2110,14 @@ mod tests {
             "/verify-times",
             "/l1-block-times",
             "/l2-block-times",
+            "/l2-block-times/aggregated",
             "/l2-gas-used",
+            "/l2-gas-used/aggregated",
             "/l2-tps",
             "/sequencer-distribution",
             "/sequencer-blocks",
             "/block-transactions",
+            "/block-transactions/aggregated",
             "/l2-fees",
             "/l2-fee-components",
             "/dashboard-data",

--- a/crates/clickhouse/src/reader.rs
+++ b/crates/clickhouse/src/reader.rs
@@ -548,6 +548,113 @@ impl ClickhouseReader {
             .collect())
     }
 
+    /// Get L2 block times since the given cutoff with cursor-based pagination.
+    /// Results are returned in descending order by block number.
+    pub async fn get_l2_block_times_paginated(
+        &self,
+        since: DateTime<Utc>,
+        limit: u64,
+        starting_after: Option<u64>,
+        ending_before: Option<u64>,
+        sequencer: Option<AddressBytes>,
+    ) -> Result<Vec<L2BlockTimeRow>> {
+        #[derive(Row, Deserialize)]
+        struct RawRow {
+            l2_block_number: u64,
+            block_time: u64,
+            ms_since_prev_block: Option<u64>,
+        }
+
+        let mut query = format!(
+            "SELECT h.l2_block_number, h.block_ts AS block_time, \
+                    toUInt64OrNull(toString((toUnixTimestamp64Milli(h.inserted_at) - \
+                        lagInFrame(toUnixTimestamp64Milli(h.inserted_at)) OVER (ORDER BY h.l2_block_number)))) \
+                        AS ms_since_prev_block \
+             FROM {db}.l2_head_events h \
+             WHERE h.block_ts >= {since} \
+               AND {filter}",
+            since = since.timestamp(),
+            filter = self.reorg_filter("h"),
+            db = self.db_name,
+        );
+        if let Some(addr) = sequencer {
+            query.push_str(&format!(" AND sequencer = unhex('{}')", encode(addr)));
+        }
+        if let Some(start) = starting_after {
+            query.push_str(&format!(" AND l2_block_number < {}", start));
+        }
+        if let Some(end) = ending_before {
+            query.push_str(&format!(" AND l2_block_number > {}", end));
+        }
+        query.push_str(" ORDER BY l2_block_number DESC");
+        query.push_str(&format!(" LIMIT {}", limit));
+
+        let rows = self.execute::<RawRow>(&query).await?;
+        Ok(rows
+            .into_iter()
+            .filter_map(|r| {
+                let dt = Utc.timestamp_opt(r.block_time as i64, 0).single()?;
+                r.ms_since_prev_block.map(|ms| L2BlockTimeRow {
+                    l2_block_number: r.l2_block_number,
+                    block_time: dt,
+                    ms_since_prev_block: Some(ms),
+                })
+            })
+            .collect())
+    }
+
+    /// Get L2 gas usage since the given cutoff with cursor-based pagination.
+    /// Results are returned in descending order by block number.
+    pub async fn get_l2_gas_used_paginated(
+        &self,
+        since: DateTime<Utc>,
+        limit: u64,
+        starting_after: Option<u64>,
+        ending_before: Option<u64>,
+        sequencer: Option<AddressBytes>,
+    ) -> Result<Vec<L2GasUsedRow>> {
+        #[derive(Row, Deserialize)]
+        struct RawRow {
+            l2_block_number: u64,
+            block_time: u64,
+            gas_used: u64,
+        }
+
+        let mut query = format!(
+            "SELECT h.l2_block_number, h.block_ts AS block_time, toUInt64(sum_gas_used) AS gas_used \
+             FROM {db}.l2_head_events h \
+             WHERE h.block_ts >= {since} \
+               AND {filter}",
+            since = since.timestamp(),
+            filter = self.reorg_filter("h"),
+            db = self.db_name,
+        );
+        if let Some(addr) = sequencer {
+            query.push_str(&format!(" AND sequencer = unhex('{}')", encode(addr)));
+        }
+        if let Some(start) = starting_after {
+            query.push_str(&format!(" AND l2_block_number < {}", start));
+        }
+        if let Some(end) = ending_before {
+            query.push_str(&format!(" AND l2_block_number > {}", end));
+        }
+        query.push_str(" ORDER BY l2_block_number DESC");
+        query.push_str(&format!(" LIMIT {}", limit));
+
+        let rows = self.execute::<RawRow>(&query).await?;
+        Ok(rows
+            .into_iter()
+            .map(|r| {
+                let dt = Utc.timestamp_opt(r.block_time as i64, 0).unwrap();
+                L2GasUsedRow {
+                    l2_block_number: r.l2_block_number,
+                    block_time: dt,
+                    gas_used: r.gas_used,
+                }
+            })
+            .collect())
+    }
+
     /// Get the average time in milliseconds it takes for a batch to be proven
     /// for proofs submitted within the given time range
     pub async fn get_avg_prove_time(&self, range: TimeRange) -> Result<Option<u64>> {


### PR DESCRIPTION
## Summary
- split aggregated and table endpoints
- adjust router paths
- update OpenAPI spec validation

## Testing
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_68503be12f708328b450f225985ed1fb