### PR TITLE
Ensure block metrics link to explorer

### DIFF
--- a/dashboard/components/MetricCard.tsx
+++ b/dashboard/components/MetricCard.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
+import { TAIKO_PINK } from '../theme';
 
 interface MetricCardProps {
   title: React.ReactNode;
   value: string;
+  link?: string;
   unit?: string; // Unit is passed but not displayed in the title directly as (unit)
   description?: React.ReactNode;
   className?: string;
@@ -12,6 +14,7 @@ interface MetricCardProps {
 export const MetricCard: React.FC<MetricCardProps> = ({
   title,
   value,
+  link,
   description,
   className,
   onMore,
@@ -41,7 +44,19 @@ export const MetricCard: React.FC<MetricCardProps> = ({
       <p
         className={`mt-1 font-semibold text-gray-900 dark:text-gray-100 ${isAddress ? 'text-base break-all' : `text-2xl${isShortValue ? '' : ' whitespace-nowrap overflow-hidden text-ellipsis'}`}`}
       >
-        {value}
+        {link ? (
+          <a
+            href={link}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:underline"
+            style={{ color: TAIKO_PINK }}
+          >
+            {value}
+          </a>
+        ) : (
+          value
+        )}
       </p>
       {description && (
         <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">

--- a/dashboard/components/layout/MetricsGrid.tsx
+++ b/dashboard/components/layout/MetricsGrid.tsx
@@ -83,6 +83,7 @@ export const MetricsGrid: React.FC<MetricsGridProps> = ({
                     key={`${group}-${idx}`}
                     title={m.title}
                     value={m.value}
+                    link={m.link}
                     onMore={
                       typeof m.title === 'string'
                         ? onMetricAction(m.title)

--- a/dashboard/hooks/useBlockData.ts
+++ b/dashboard/hooks/useBlockData.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { fetchL1HeadNumber, fetchL2HeadNumber } from '../services/apiService';
 import { MetricData } from '../types';
+import { TAIKOSCAN_BASE } from '../utils';
 
 export const useBlockData = () => {
   const [l2HeadBlock, setL2HeadBlock] = useState<string>('0');
@@ -32,10 +33,24 @@ export const useBlockData = () => {
     (metrics: MetricData[]): MetricData[] => {
       return metrics.map((metric) => {
         if (metric.title === 'L1 Block') {
-          return { ...metric, value: l1HeadBlock };
+          const num = Number(l1HeadBlock.replace(/,/g, ''));
+          return {
+            ...metric,
+            value: l1HeadBlock,
+            link: Number.isFinite(num)
+              ? `${TAIKOSCAN_BASE}/block/${num}`
+              : metric.link,
+          };
         }
         if (metric.title === 'L2 Block') {
-          return { ...metric, value: l2HeadBlock };
+          const num = Number(l2HeadBlock.replace(/,/g, ''));
+          return {
+            ...metric,
+            value: l2HeadBlock,
+            link: Number.isFinite(num)
+              ? `${TAIKOSCAN_BASE}/block/${num}`
+              : metric.link,
+          };
         }
         return metric;
       });

--- a/dashboard/tests/helpers.test.ts
+++ b/dashboard/tests/helpers.test.ts
@@ -75,8 +75,10 @@ describe('helpers', () => {
     expect(metrics[13].value).toBe('2.00 ETH');
     expect(metrics[13].group).toBe('Network Economics');
     expect(metrics[14].value).toBe('100');
+    expect(metrics[14].link).toContain('/block/100');
     expect(metrics[14].group).toBe('Block Information');
     expect(metrics[15].value).toBe('50');
+    expect(metrics[15].link).toContain('/block/50');
     expect(metrics[15].group).toBe('Block Information');
   });
 

--- a/dashboard/tests/metricsCreator.test.ts
+++ b/dashboard/tests/metricsCreator.test.ts
@@ -41,6 +41,11 @@ describe('metricsCreator', () => {
     const next = metrics.find((m) => m.title === 'Next Sequencer');
     expect(current?.value).toBe('Chainbound A');
     expect(next?.value).toBe('Chainbound B');
+
+    const l2BlockMetric = metrics.find((m) => m.title === 'L2 Block');
+    expect(l2BlockMetric?.link).toContain('/block/100');
+    const l1BlockMetric = metrics.find((m) => m.title === 'L1 Block');
+    expect(l1BlockMetric?.link).toContain('/block/50');
   });
 
   it('falls back to N/A for missing values', () => {

--- a/dashboard/types.ts
+++ b/dashboard/types.ts
@@ -18,6 +18,7 @@ import type { ReactNode } from 'react';
 export interface MetricData {
   title: ReactNode;
   value: string;
+  link?: string;
   unit?: string; // e.g., '1h', '24h', or specific units like 'ms'
   description?: ReactNode;
   group?: string;

--- a/dashboard/utils/metricsCreator.ts
+++ b/dashboard/utils/metricsCreator.ts
@@ -5,6 +5,7 @@ import {
   formatDecimal,
   formatEth,
   formatWithCommas,
+  TAIKOSCAN_BASE,
 } from '../utils';
 import { getSequencerName } from '../sequencerConfig';
 
@@ -130,11 +131,15 @@ export const createMetrics = (data: MetricInputData): MetricData[] => [
   {
     title: 'L2 Block',
     value: data.l2Block != null ? data.l2Block.toLocaleString() : 'N/A',
+    link:
+      data.l2Block != null ? `${TAIKOSCAN_BASE}/block/${data.l2Block}` : undefined,
     group: 'Block Information',
   },
   {
     title: 'L1 Block',
     value: data.l1Block != null ? data.l1Block.toLocaleString() : 'N/A',
+    link:
+      data.l1Block != null ? `${TAIKOSCAN_BASE}/block/${data.l1Block}` : undefined,
     group: 'Block Information',
   },
 ];


### PR DESCRIPTION
## Summary
- add `link` field to `MetricData`
- display metrics as links when a link is provided
- generate explorer links for L1/L2 block metrics
- update block head updates to preserve links
- adjust tests for new block links

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68512ac0a7808328945bc73b7bf98c7f