### PR TITLE
Handle ETH price fetch errors

### DIFF
--- a/dashboard/components/ProfitabilityChart.tsx
+++ b/dashboard/components/ProfitabilityChart.tsx
@@ -31,7 +31,7 @@ export const ProfitabilityChart: React.FC<ProfitabilityChartProps> = ({
     fetchFeeComponents(timeRange, address),
   );
   const feeData: FeeComponent[] | null = feeRes?.data ?? null;
-  const { data: ethPrice = 0 } = useEthPrice();
+  const { data: ethPrice = 0, error: ethPriceError } = useEthPrice();
 
   if (!feeData || feeData.length === 0) {
     return (
@@ -53,11 +53,15 @@ export const ProfitabilityChart: React.FC<ProfitabilityChartProps> = ({
   });
 
   return (
-    <ResponsiveContainer width="100%" height={240}>
-      <LineChart
-        data={data}
-        margin={{ top: 5, right: 40, left: 20, bottom: 40 }}
-      >
+    <>
+      {ethPriceError && (
+        <div className="text-red-500 text-xs mb-1">ETH price unavailable</div>
+      )}
+      <ResponsiveContainer width="100%" height={240}>
+        <LineChart
+          data={data}
+          margin={{ top: 5, right: 40, left: 20, bottom: 40 }}
+        >
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis
           dataKey="block"
@@ -104,5 +108,6 @@ export const ProfitabilityChart: React.FC<ProfitabilityChartProps> = ({
         />
       </LineChart>
     </ResponsiveContainer>
+    </>
   );
 };

--- a/dashboard/services/priceService.ts
+++ b/dashboard/services/priceService.ts
@@ -6,7 +6,12 @@ const API_URL =
   'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd'
 
 export const getEthPrice = async (): Promise<number> => {
-  const res = await fetch(API_URL)
+  let res: Response
+  try {
+    res = await fetch(API_URL)
+  } catch {
+    return 0
+  }
   if (!res.ok) {
     throw new Error(`Failed to fetch ETH price: ${res.status}`)
   }
@@ -62,5 +67,7 @@ export const useEthPrice = () => {
     }
   }, [swr.data])
 
-  return swr
+  const error = swr.error ?? (swr.data === 0 ? new Error('ETH price unavailable') : undefined)
+
+  return { ...swr, error }
 }

--- a/dashboard/tests/priceService.test.ts
+++ b/dashboard/tests/priceService.test.ts
@@ -18,6 +18,12 @@ function mockFetchWithInvalidResponse() {
   })) as unknown as typeof fetch
 }
 
+function mockFetchWithNetworkError() {
+  return vi.fn(async () => {
+    throw new Error('network error')
+  }) as unknown as typeof fetch
+}
+
 afterEach(() => {
   globalThis.fetch = originalFetch
 })
@@ -32,6 +38,12 @@ describe('getEthPrice', () => {
   it('handles fetch failure', async () => {
     globalThis.fetch = mockFetch(0, false)
     await expect(getEthPrice()).rejects.toThrow('Failed to fetch ETH price: 500')
+  })
+
+  it('returns 0 on network error', async () => {
+    globalThis.fetch = mockFetchWithNetworkError()
+    const price = await getEthPrice()
+    expect(price).toBe(0)
   })
 
   it('handles invalid response format', async () => {


### PR DESCRIPTION
## Summary
- handle fetch errors in getEthPrice and return 0
- surface an error from useEthPrice when price is unavailable
- show message in ProfitabilityChart when ETH price can't be fetched
- test network failure path for getEthPrice

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68512b1327808328b825d286d1a7f506