### PR TITLE
Add hourly aggregated metrics

### DIFF
--- a/crates/clickhouse/migrations/005_create_metrics_views.sql
+++ b/crates/clickhouse/migrations/005_create_metrics_views.sql
@@ -1,0 +1,92 @@
+CREATE MATERIALIZED VIEW IF NOT EXISTS ${DB}.daily_l2_metrics_mv
+(
+    day Date,
+    min_ts_state AggregateFunction(min, UInt64),
+    max_ts_state AggregateFunction(max, UInt64),
+    cnt_state AggregateFunction(count, UInt64),
+    tx_sum_state AggregateFunction(sum, UInt64),
+    gas_sum_state AggregateFunction(sum, UInt128),
+    priority_fee_sum_state AggregateFunction(sum, UInt128),
+    base_fee_sum_state AggregateFunction(sum, UInt128)
+) ENGINE = AggregatingMergeTree()
+PARTITION BY day
+ORDER BY day
+AS
+SELECT
+    toDate(h.block_ts) AS day,
+    minState(h.block_ts) AS min_ts_state,
+    maxState(h.block_ts) AS max_ts_state,
+    countState() AS cnt_state,
+    sumState(sum_tx) AS tx_sum_state,
+    sumState(sum_gas_used) AS gas_sum_state,
+    sumState(sum_priority_fee) AS priority_fee_sum_state,
+    sumState(sum_base_fee) AS base_fee_sum_state
+FROM ${DB}.l2_head_events h
+GROUP BY day;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS ${DB}.daily_batch_metrics_mv
+(
+    day Date,
+    min_ts_state AggregateFunction(min, UInt64),
+    max_ts_state AggregateFunction(max, UInt64),
+    cnt_state AggregateFunction(count, UInt64),
+    blob_avg_state AggregateFunction(avg, Float64)
+) ENGINE = AggregatingMergeTree()
+PARTITION BY day
+ORDER BY day
+AS
+SELECT
+    toDate(l1.block_ts) AS day,
+    minState(toUInt64(l1.block_ts * 1000)) AS min_ts_state,
+    maxState(toUInt64(l1.block_ts * 1000)) AS max_ts_state,
+    countState() AS cnt_state,
+    avgState(toFloat64(b.blob_count)) AS blob_avg_state
+FROM ${DB}.batches b
+INNER JOIN ${DB}.l1_head_events l1 ON b.l1_block_number = l1.l1_block_number
+GROUP BY day;
+CREATE MATERIALIZED VIEW IF NOT EXISTS ${DB}.hourly_l2_metrics_mv
+(
+    hour DateTime64(3),
+    min_ts_state AggregateFunction(min, UInt64),
+    max_ts_state AggregateFunction(max, UInt64),
+    cnt_state AggregateFunction(count, UInt64),
+    tx_sum_state AggregateFunction(sum, UInt64),
+    gas_sum_state AggregateFunction(sum, UInt128),
+    priority_fee_sum_state AggregateFunction(sum, UInt128),
+    base_fee_sum_state AggregateFunction(sum, UInt128)
+) ENGINE = AggregatingMergeTree()
+PARTITION BY toDate(hour)
+ORDER BY hour
+AS
+SELECT
+    toStartOfHour(fromUnixTimestamp64Milli(h.block_ts * 1000)) AS hour,
+    minState(h.block_ts) AS min_ts_state,
+    maxState(h.block_ts) AS max_ts_state,
+    countState() AS cnt_state,
+    sumState(sum_tx) AS tx_sum_state,
+    sumState(sum_gas_used) AS gas_sum_state,
+    sumState(sum_priority_fee) AS priority_fee_sum_state,
+    sumState(sum_base_fee) AS base_fee_sum_state
+FROM ${DB}.l2_head_events h
+GROUP BY hour;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS ${DB}.hourly_batch_metrics_mv
+(
+    hour DateTime64(3),
+    min_ts_state AggregateFunction(min, UInt64),
+    max_ts_state AggregateFunction(max, UInt64),
+    cnt_state AggregateFunction(count, UInt64),
+    blob_avg_state AggregateFunction(avg, Float64)
+) ENGINE = AggregatingMergeTree()
+PARTITION BY toDate(hour)
+ORDER BY hour
+AS
+SELECT
+    toStartOfHour(fromUnixTimestamp64Milli(l1.block_ts * 1000)) AS hour,
+    minState(toUInt64(l1.block_ts * 1000)) AS min_ts_state,
+    maxState(toUInt64(l1.block_ts * 1000)) AS max_ts_state,
+    countState() AS cnt_state,
+    avgState(toFloat64(b.blob_count)) AS blob_avg_state
+FROM ${DB}.batches b
+INNER JOIN ${DB}.l1_head_events l1 ON b.l1_block_number = l1.l1_block_number
+GROUP BY hour;

--- a/crates/clickhouse/src/reader.rs
+++ b/crates/clickhouse/src/reader.rs
@@ -42,8 +42,8 @@ pub enum TimeRange {
 }
 
 impl TimeRange {
-    /// Maximum allowed range in seconds (7 days).
-    const MAX_SECONDS: u64 = 7 * 24 * 3600;
+    /// Maximum allowed range in seconds (30 days).
+    const MAX_SECONDS: u64 = 30 * 24 * 3600;
 
     /// Create a [`TimeRange`] from a [`chrono::Duration`], clamping to the
     /// allowed maximum of seven days.

--- a/crates/clickhouse/src/reader.rs
+++ b/crates/clickhouse/src/reader.rs
@@ -46,7 +46,7 @@ impl TimeRange {
     const MAX_SECONDS: u64 = 30 * 24 * 3600;
 
     /// Create a [`TimeRange`] from a [`chrono::Duration`], clamping to the
-    /// allowed maximum of seven days.
+    /// allowed maximum of thirty days.
     pub fn from_duration(duration: chrono::Duration) -> Self {
         let secs = duration.num_seconds().clamp(0, Self::MAX_SECONDS as i64) as u64;
         match secs {

--- a/crates/clickhouse/src/schema.rs
+++ b/crates/clickhouse/src/schema.rs
@@ -31,8 +31,12 @@ pub const VIEWS: &[&str] = &[
     "batch_verify_times_mv",
     "hourly_avg_prove_times_mv",
     "hourly_avg_verify_times_mv",
+    "hourly_l2_metrics_mv",
+    "hourly_batch_metrics_mv",
     "daily_avg_prove_times_mv",
     "daily_avg_verify_times_mv",
+    "daily_l2_metrics_mv",
+    "daily_batch_metrics_mv",
 ];
 
 /// Schema definitions for tables


### PR DESCRIPTION
## Summary
- add hourly l2_metrics and batch_metrics materialized views
- register new views in the ClickHouse schema
- merge daily and hourly migration scripts

## Testing
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_6851399999208328a52d9905da6094d1