### PR TITLE
Add null checks in dashboard toast logic

### DIFF
--- a/dashboard/components/ToastProvider.tsx
+++ b/dashboard/components/ToastProvider.tsx
@@ -14,6 +14,7 @@ export const ToastProvider: React.FC<React.PropsWithChildren> = ({
   useEffect(() => {
     const handler = (event: Event) => {
       const message = (event as CustomEvent<string>).detail;
+      if (!message) return;
       const id = Date.now() + Math.random();
       const toast: Toast = { id, message };
       setToasts((t) => [...t, toast]);

--- a/dashboard/utils/toast.ts
+++ b/dashboard/utils/toast.ts
@@ -1,5 +1,8 @@
 export const TOAST_EVENT = 'toast-event';
 
 export const showToast = (message: string) => {
+  if (typeof window === 'undefined' || !message) {
+    return;
+  }
   window.dispatchEvent(new CustomEvent(TOAST_EVENT, { detail: message }));
 };


### PR DESCRIPTION
## Summary
- guard toast helper from server usage
- ignore empty toast events in provider

## Testing
- `npm run lint:whitespace`
- `npm run check`
- `npm run test`
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685141f1dda88328b365d684437e36e3