### PR TITLE
Add income and cost charts to economics view

### DIFF
--- a/dashboard/components/CostChart.tsx
+++ b/dashboard/components/CostChart.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import useSWR from 'swr';
+import { fetchFeeComponents } from '../services/apiService';
+import { TimeRange, FeeComponent } from '../types';
+import { rangeToHours } from '../utils/timeRange';
+
+interface CostChartProps {
+  timeRange: TimeRange;
+  cloudCost: number;
+  proverCost: number;
+  address?: string;
+}
+
+export const CostChart: React.FC<CostChartProps> = ({
+  timeRange,
+  cloudCost,
+  proverCost,
+  address,
+}) => {
+  const { data: feeRes } = useSWR(['feeComponents', timeRange, address], () =>
+    fetchFeeComponents(timeRange, address),
+  );
+  const feeData: FeeComponent[] | null = feeRes?.data ?? null;
+
+  if (!feeData || feeData.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-full text-gray-500">
+        No data available
+      </div>
+    );
+  }
+
+  const hours = rangeToHours(timeRange);
+  const HOURS_IN_MONTH = 30 * 24;
+  const totalCost = ((cloudCost + proverCost) / HOURS_IN_MONTH) * hours;
+  const costPerBlock = totalCost / feeData.length;
+
+  const data = feeData.map((b) => ({ block: b.block, cost: costPerBlock }));
+
+  return (
+    <ResponsiveContainer width="100%" height={240}>
+      <LineChart
+        data={data}
+        margin={{ top: 5, right: 40, left: 20, bottom: 40 }}
+      >
+        <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
+        <XAxis
+          dataKey="block"
+          stroke="#666666"
+          fontSize={12}
+          label={{
+            value: 'L2 Block',
+            position: 'insideBottom',
+            offset: -10,
+            fontSize: 10,
+            fill: '#666666',
+          }}
+        />
+        <YAxis
+          stroke="#666666"
+          fontSize={12}
+          domain={['auto', 'auto']}
+          tickFormatter={(v: number) => `$${v.toLocaleString()}`}
+          label={{
+            value: 'Cost (USD)',
+            angle: -90,
+            position: 'insideLeft',
+            offset: -16,
+            fontSize: 10,
+            fill: '#666666',
+          }}
+        />
+        <Tooltip
+          labelFormatter={(v: number) => `Block ${v}`}
+          formatter={(value: number) => [`$${value.toFixed(2)}`, 'Cost']}
+          contentStyle={{
+            backgroundColor: 'rgba(255,255,255,0.8)',
+            borderColor: '#E573B5',
+          }}
+          labelStyle={{ color: '#333' }}
+        />
+        <Line
+          type="monotone"
+          dataKey="cost"
+          stroke="#E573B5"
+          strokeWidth={2}
+          dot={false}
+          name="Cost"
+        />
+      </LineChart>
+    </ResponsiveContainer>
+  );
+};

--- a/dashboard/components/IncomeChart.tsx
+++ b/dashboard/components/IncomeChart.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import useSWR from 'swr';
+import { useEthPrice } from '../services/priceService';
+import { fetchFeeComponents } from '../services/apiService';
+import { TimeRange, FeeComponent } from '../types';
+
+interface IncomeChartProps {
+  timeRange: TimeRange;
+  address?: string;
+}
+
+export const IncomeChart: React.FC<IncomeChartProps> = ({
+  timeRange,
+  address,
+}) => {
+  const { data: feeRes } = useSWR(['feeComponents', timeRange, address], () =>
+    fetchFeeComponents(timeRange, address),
+  );
+  const feeData: FeeComponent[] | null = feeRes?.data ?? null;
+  const { data: ethPrice = 0, error: ethPriceError } = useEthPrice();
+
+  if (!feeData || feeData.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-full text-gray-500">
+        No data available
+      </div>
+    );
+  }
+
+  const data = feeData.map((b) => {
+    const revenueEth = (b.priority + b.base - (b.l1Cost ?? 0)) / 1e18;
+    const income = revenueEth * ethPrice;
+    return { block: b.block, income };
+  });
+
+  return (
+    <>
+      {ethPriceError && (
+        <div className="text-red-500 text-xs mb-1">ETH price unavailable</div>
+      )}
+      <ResponsiveContainer width="100%" height={240}>
+        <LineChart
+          data={data}
+          margin={{ top: 5, right: 40, left: 20, bottom: 40 }}
+        >
+          <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
+          <XAxis
+            dataKey="block"
+            stroke="#666666"
+            fontSize={12}
+            label={{
+              value: 'L2 Block',
+              position: 'insideBottom',
+              offset: -10,
+              fontSize: 10,
+              fill: '#666666',
+            }}
+          />
+          <YAxis
+            stroke="#666666"
+            fontSize={12}
+            domain={['auto', 'auto']}
+            tickFormatter={(v: number) => `$${v.toLocaleString()}`}
+            label={{
+              value: 'Income (USD)',
+              angle: -90,
+              position: 'insideLeft',
+              offset: -16,
+              fontSize: 10,
+              fill: '#666666',
+            }}
+          />
+          <Tooltip
+            labelFormatter={(v: number) => `Block ${v}`}
+            formatter={(value: number) => [`$${value.toFixed(2)}`, 'Income']}
+            contentStyle={{
+              backgroundColor: 'rgba(255,255,255,0.8)',
+              borderColor: '#4E79A7',
+            }}
+            labelStyle={{ color: '#333' }}
+          />
+          <Line
+            type="monotone"
+            dataKey="income"
+            stroke="#4E79A7"
+            strokeWidth={2}
+            dot={false}
+            name="Income"
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </>
+  );
+};

--- a/dashboard/components/views/DashboardView.tsx
+++ b/dashboard/components/views/DashboardView.tsx
@@ -2,6 +2,8 @@ import React, { useCallback, lazy, useState } from 'react';
 import { ErrorDisplay } from '../layout/ErrorDisplay';
 import { MetricsGrid } from '../layout/MetricsGrid';
 import { ProfitCalculator } from '../ProfitCalculator';
+import { IncomeChart } from '../IncomeChart';
+import { CostChart } from '../CostChart';
 import { ProfitabilityChart } from '../ProfitabilityChart';
 import { ChartCard } from '../ChartCard';
 import { TAIKO_PINK } from '../../theme';
@@ -302,12 +304,26 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
               onProverCostChange={setProverCost}
             />
             <div className="mt-6">
-            <ProfitabilityChart
-              timeRange={timeRange}
-              cloudCost={cloudCost}
-              proverCost={proverCost}
-              address={selectedSequencer || undefined}
-            />
+              <IncomeChart
+                timeRange={timeRange}
+                address={selectedSequencer || undefined}
+              />
+            </div>
+            <div className="mt-6">
+              <CostChart
+                timeRange={timeRange}
+                cloudCost={cloudCost}
+                proverCost={proverCost}
+                address={selectedSequencer || undefined}
+              />
+            </div>
+            <div className="mt-6">
+              <ProfitabilityChart
+                timeRange={timeRange}
+                cloudCost={cloudCost}
+                proverCost={proverCost}
+                address={selectedSequencer || undefined}
+              />
             </div>
           </>
         )}

--- a/dashboard/tests/costChart.test.ts
+++ b/dashboard/tests/costChart.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import * as swr from 'swr';
+vi.mock('swr', () => ({ default: vi.fn() }));
+import { CostChart } from '../components/CostChart';
+
+const feeData = [
+  { block: 1, priority: 1, base: 1, l1Cost: 0 },
+];
+
+describe('CostChart', () => {
+  it('renders with cost data', () => {
+    vi.mocked(swr.default).mockReturnValue({ data: { data: feeData } } as any);
+
+    const html = renderToStaticMarkup(
+      React.createElement(CostChart, {
+        timeRange: '1h',
+        cloudCost: 100,
+        proverCost: 100,
+      }),
+    );
+
+    expect(html).toContain('recharts-responsive-container');
+  });
+});

--- a/dashboard/tests/incomeChart.test.ts
+++ b/dashboard/tests/incomeChart.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import * as swr from 'swr';
+vi.mock('swr', () => ({ default: vi.fn() }));
+import * as priceService from '../services/priceService';
+import { IncomeChart } from '../components/IncomeChart';
+
+const feeData = [
+  { block: 1, priority: 1, base: 1, l1Cost: 0 },
+];
+
+describe('IncomeChart', () => {
+  it('renders with income data', () => {
+    vi.mocked(swr.default).mockReturnValue({ data: { data: feeData } } as any);
+    vi.spyOn(priceService, 'useEthPrice').mockReturnValue({ data: 1 } as any);
+
+    const html = renderToStaticMarkup(
+      React.createElement(IncomeChart, {
+        timeRange: '1h',
+      }),
+    );
+
+    expect(html).toContain('recharts-responsive-container');
+  });
+});


### PR DESCRIPTION
## Summary
- add IncomeChart and CostChart components
- show Income, Cost and Profit charts in economics view
- test the new charts

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68514460efb083289277887ac644bce8