### PR TITLE
Add sequencer profit ranking to economics view

### DIFF
--- a/dashboard/components/ProfitRankingTable.tsx
+++ b/dashboard/components/ProfitRankingTable.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import useSWR from 'swr';
+import { TimeRange } from '../types';
+import {
+  fetchSequencerDistribution,
+  fetchL2Fees,
+} from '../services/apiService';
+import { getSequencerAddress } from '../sequencerConfig';
+import { useEthPrice } from '../services/priceService';
+import { rangeToHours } from '../utils/timeRange';
+
+interface ProfitRankingTableProps {
+  timeRange: TimeRange;
+  cloudCost: number;
+  proverCost: number;
+}
+
+const formatProfit = (value: number): string => {
+  const abs = Math.abs(value);
+  if (abs >= 1000) {
+    return Math.trunc(value).toLocaleString();
+  }
+  return value.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+};
+
+export const ProfitRankingTable: React.FC<ProfitRankingTableProps> = ({
+  timeRange,
+  cloudCost,
+  proverCost,
+}) => {
+  const { data: distRes } = useSWR(['profitRankingSeq', timeRange], () =>
+    fetchSequencerDistribution(timeRange),
+  );
+  const sequencers = distRes?.data ?? [];
+
+  const { data: ethPrice = 0 } = useEthPrice();
+
+  const { data: feeData } = useSWR(
+    sequencers.length ? ['profitRankingFees', timeRange, sequencers] : null,
+    async () => {
+      const fees = await Promise.all(
+        sequencers.map((s) =>
+          fetchL2Fees(timeRange, getSequencerAddress(s.name) || ''),
+        ),
+      );
+      return fees.map((f) => f.data);
+    },
+  );
+
+  if (!feeData) {
+    return (
+      <div className="flex items-center justify-center h-20 text-gray-500 dark:text-gray-400">
+        Loading...
+      </div>
+    );
+  }
+
+  const hours = rangeToHours(timeRange);
+  const MONTH_HOURS = 30 * 24;
+  const costPerSeq = ((cloudCost + proverCost) / MONTH_HOURS) * hours;
+
+  const rows = sequencers.map((seq, idx) => {
+    const fees = feeData[idx];
+    if (!fees) {
+      return {
+        name: seq.name,
+        blocks: seq.value,
+        profit: null as number | null,
+      };
+    }
+    const revenueEth =
+      (fees.priority_fee ?? 0) +
+      (fees.base_fee ?? 0) -
+      (fees.l1_data_cost ?? 0);
+    const profit = revenueEth * ethPrice - costPerSeq;
+    return { name: seq.name, blocks: seq.value, profit };
+  });
+
+  const sorted = rows.sort(
+    (a, b) => (b.profit ?? -Infinity) - (a.profit ?? -Infinity),
+  );
+
+  return (
+    <div className="mt-6">
+      <h3 className="text-lg font-semibold mb-2">Sequencer Profit Ranking</h3>
+      <div className="overflow-x-auto">
+        <table className="min-w-full border border-gray-200 dark:border-gray-700 divide-y divide-gray-200 dark:divide-gray-700 bg-white dark:bg-gray-800">
+          <thead>
+            <tr>
+              <th className="px-2 py-1 text-left">Sequencer</th>
+              <th className="px-2 py-1 text-left">Blocks</th>
+              <th className="px-2 py-1 text-left">Profit (USD)</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map((row) => (
+              <tr
+                key={row.name}
+                className="border-t border-gray-200 dark:border-gray-700"
+              >
+                <td className="px-2 py-1">{row.name}</td>
+                <td className="px-2 py-1">{row.blocks.toLocaleString()}</td>
+                <td className="px-2 py-1">
+                  {row.profit != null ? `$${formatProfit(row.profit)}` : 'N/A'}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};

--- a/dashboard/components/views/DashboardView.tsx
+++ b/dashboard/components/views/DashboardView.tsx
@@ -5,6 +5,7 @@ import { ProfitCalculator } from '../ProfitCalculator';
 import { IncomeChart } from '../IncomeChart';
 import { CostChart } from '../CostChart';
 import { ProfitabilityChart } from '../ProfitabilityChart';
+import { ProfitRankingTable } from '../ProfitRankingTable';
 import { ChartCard } from '../ChartCard';
 import { TAIKO_PINK } from '../../theme';
 import { TimeRange, MetricData } from '../../types';
@@ -325,6 +326,11 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
                 address={selectedSequencer || undefined}
               />
             </div>
+            <ProfitRankingTable
+              timeRange={timeRange}
+              cloudCost={cloudCost}
+              proverCost={proverCost}
+            />
           </>
         )}
 

--- a/dashboard/tests/profitRankingTable.test.ts
+++ b/dashboard/tests/profitRankingTable.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import * as swr from 'swr';
+vi.mock('swr', () => ({ default: vi.fn() }));
+import * as api from '../services/apiService';
+import * as priceService from '../services/priceService';
+import { ProfitRankingTable } from '../components/ProfitRankingTable';
+
+describe('ProfitRankingTable', () => {
+  it('renders sequencer profits', async () => {
+    vi.mocked(swr.default)
+      .mockReturnValueOnce({
+        data: { data: [{ name: 'SeqA', value: 10, tps: null }] },
+      } as any)
+      .mockReturnValueOnce({
+        data: [{ priority_fee: 2, base_fee: 1, l1_data_cost: 0 }],
+      } as any);
+    vi.spyOn(api, 'fetchSequencerDistribution').mockResolvedValue({
+      data: [{ name: 'SeqA', value: 10, tps: null }],
+      badRequest: false,
+      error: null,
+    } as any);
+    vi.spyOn(api, 'fetchL2Fees').mockResolvedValue({
+      data: { priority_fee: 2, base_fee: 1, l1_data_cost: 0 },
+      badRequest: false,
+      error: null,
+    } as any);
+    vi.spyOn(priceService, 'useEthPrice').mockReturnValue({
+      data: 1000,
+    } as any);
+
+    const html = renderToStaticMarkup(
+      React.createElement(ProfitRankingTable, {
+        timeRange: '1h',
+        cloudCost: 0,
+        proverCost: 0,
+      }),
+    );
+    expect(html.includes('Sequencer Profit Ranking')).toBe(true);
+    expect(html.includes('3,000')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add `ProfitRankingTable` component to show profit rankings per sequencer
- show the ranking table in the economics dashboard view
- test profit ranking table

## Testing
- `npm --prefix dashboard run format`
- `npm --prefix dashboard run lint`
- `npm --prefix dashboard run lint:whitespace`
- `npm --prefix dashboard run check`
- `npm --prefix dashboard run test`
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_685144255d308328acc66f77479c6001