### PR TITLE
Remove sequencer filter from economics view

### DIFF
--- a/dashboard/components/DashboardHeader.tsx
+++ b/dashboard/components/DashboardHeader.tsx
@@ -6,6 +6,7 @@ import { isValidRefreshRate } from '../utils';
 import { isValidTimeRange, formatTimeRangeDisplay } from '../utils/timeRange';
 import { useRouterNavigation } from '../hooks/useRouterNavigation';
 import { useErrorHandler } from '../hooks/useErrorHandler';
+import { useSearchParams } from 'react-router-dom';
 import { showToast } from '../utils/toast';
 import { DayPicker } from 'react-day-picker';
 import * as Popover from '@radix-ui/react-popover';
@@ -55,6 +56,8 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({
 }) => {
   const { navigateToDashboard } = useRouterNavigation();
   const { errorMessage } = useErrorHandler();
+  const [searchParams] = useSearchParams();
+  const isEconomicsView = searchParams.get('view') === 'economics';
   React.useEffect(() => {
     if (errorMessage) {
       showToast(errorMessage);
@@ -101,11 +104,13 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({
           lastRefresh={lastRefresh}
           onRefresh={onManualRefresh}
         />
-        <SequencerSelector
-          sequencers={sequencers}
-          value={selectedSequencer}
-          onChange={onSequencerChange}
-        />
+        {!isEconomicsView && (
+          <SequencerSelector
+            sequencers={sequencers}
+            value={selectedSequencer}
+            onChange={onSequencerChange}
+          />
+        )}
         {/* Export button removed as per request */}
       </div>
     </header>

--- a/dashboard/hooks/useDashboardController.ts
+++ b/dashboard/hooks/useDashboardController.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useMetricsData } from './useMetricsData';
 import { useChartsData } from './useChartsData';
 import { useBlockData } from './useBlockData';
@@ -30,6 +30,12 @@ export const useDashboardController = () => {
       blockData,
       metricsData,
     });
+
+  useEffect(() => {
+    if (metricsData.isEconomicsView && selectedSequencer) {
+      setSelectedSequencer(null);
+    }
+  }, [metricsData.isEconomicsView, selectedSequencer, setSelectedSequencer]);
 
   // Table actions
   const {

--- a/dashboard/hooks/useDataFetcher.ts
+++ b/dashboard/hooks/useDataFetcher.ts
@@ -46,13 +46,15 @@ export const useDataFetcher = ({
     [tableView, viewParam, isTableRoute],
   );
 
+  const selectedSequencerForFetch = isEconomicsView ? null : selectedSequencer;
+
   const fetchKey = isTableView
     ? null
-    : ['metrics', timeRange, selectedSequencer, isEconomicsView];
+    : ['metrics', timeRange, selectedSequencerForFetch, isEconomicsView];
 
   const fetcher = async () => {
     if (isEconomicsView) {
-      const data = await fetchEconomicsData(timeRange, selectedSequencer);
+      const data = await fetchEconomicsData(timeRange, selectedSequencerForFetch);
       const anyBadRequest = hasBadRequest(data.badRequestResults);
 
       const metricsInput: MetricInputData = {
@@ -83,7 +85,7 @@ export const useDataFetcher = ({
       };
     }
 
-    const data = await fetchMainDashboardData(timeRange, selectedSequencer);
+    const data = await fetchMainDashboardData(timeRange, selectedSequencerForFetch);
 
     const anyBadRequest = hasBadRequest(data.badRequestResults);
     const activeGateways = data.preconfData

--- a/dashboard/tests/dashboardHeader.test.ts
+++ b/dashboard/tests/dashboardHeader.test.ts
@@ -40,4 +40,33 @@ describe('DashboardHeader', () => {
     expect(html.includes('All Sequencers')).toBe(true);
     expect(html.includes('Economics')).toBe(false);
   });
+
+  it('hides sequencer selector in economics view', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(
+        ThemeProvider,
+        null,
+        React.createElement(
+          ErrorProvider,
+          null,
+          React.createElement(
+            MemoryRouter,
+            { initialEntries: ['/?view=economics'] },
+            React.createElement(DashboardHeader, {
+              timeRange: '1h',
+              onTimeRangeChange: () => {},
+              refreshRate: 60000,
+              onRefreshRateChange: () => {},
+              lastRefresh: Date.now(),
+              onManualRefresh: () => {},
+              sequencers: ['seq1', 'seq2'],
+              selectedSequencer: null,
+              onSequencerChange: () => {},
+            }),
+          ),
+        ),
+      ),
+    );
+    expect(html.includes('All Sequencers')).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- show all sequencer data on the economics page
- hide sequencer dropdown in economics view
- adjust dashboard controller and fetcher logic
- test header behaviour in economics mode

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685149c50b508328b0e145ba5c2e00ef