### PR TITLE
Limit network calls on L2 gas used table

### DIFF
--- a/dashboard/hooks/useBlockData.ts
+++ b/dashboard/hooks/useBlockData.ts
@@ -1,28 +1,25 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { fetchL1HeadNumber, fetchL2HeadNumber } from '../services/apiService';
+import { fetchDashboardData } from '../services/apiService';
 import { MetricData } from '../types';
 import { TAIKOSCAN_BASE } from '../utils';
 
 export const useBlockData = () => {
   const [l2HeadBlock, setL2HeadBlock] = useState<string>('0');
   const [l1HeadBlock, setL1HeadBlock] = useState<string>('0');
+  const [candidates, setCandidates] = useState<string[]>([]);
   const pollId = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const updateBlockHeads = useCallback(async () => {
     try {
-      const [l1, l2] = await Promise.all([
-        fetchL1HeadNumber(),
-        fetchL2HeadNumber(),
-      ]);
-
-      if (l1.data !== null) {
-        const value = l1.data.toLocaleString();
-        setL1HeadBlock(value);
+      const res = await fetchDashboardData('1h');
+      if (res.data?.l1_block != null) {
+        setL1HeadBlock(res.data.l1_block.toLocaleString());
       }
-
-      if (l2.data !== null) {
-        const value = l2.data.toLocaleString();
-        setL2HeadBlock(value);
+      if (res.data?.l2_block != null) {
+        setL2HeadBlock(res.data.l2_block.toLocaleString());
+      }
+      if (res.data?.preconf_data?.candidates) {
+        setCandidates(res.data.preconf_data.candidates);
       }
     } catch (error) {
       console.error('Failed to update block heads:', error);
@@ -93,6 +90,7 @@ export const useBlockData = () => {
   return {
     l2HeadBlock,
     l1HeadBlock,
+    candidates,
     updateBlockHeads,
     updateMetricsWithBlockHeads,
   };

--- a/dashboard/hooks/useDashboardController.ts
+++ b/dashboard/hooks/useDashboardController.ts
@@ -25,11 +25,7 @@ export const useDashboardController = () => {
 
   // Sequencer handling
   const { selectedSequencer, setSelectedSequencer, sequencerList } =
-    useSequencerHandler({
-      chartsData,
-      blockData,
-      metricsData,
-    });
+    useSequencerHandler({ blockData, metricsData });
 
   useEffect(() => {
     if (metricsData.isEconomicsView && selectedSequencer) {

--- a/dashboard/hooks/useSequencerHandler.ts
+++ b/dashboard/hooks/useSequencerHandler.ts
@@ -1,13 +1,12 @@
 import { useState, useEffect, useMemo, useRef } from 'react';
+import { getSequencerName } from '../sequencerConfig';
 import { useSearchParams } from 'react-router-dom';
 
 interface UseSequencerHandlerProps {
-  chartsData: {
-    sequencerDistribution: Array<{ name: string }>;
-  };
   blockData: {
     l1HeadBlock: string;
     l2HeadBlock: string;
+    candidates: string[];
     updateMetricsWithBlockHeads: (metrics: any[]) => any[];
   };
   metricsData: {
@@ -16,19 +15,15 @@ interface UseSequencerHandlerProps {
   };
 }
 
-export const useSequencerHandler = ({
-  chartsData,
-  blockData,
-  metricsData,
-}: UseSequencerHandlerProps) => {
+export const useSequencerHandler = ({ blockData, metricsData }: UseSequencerHandlerProps) => {
   const [searchParams] = useSearchParams();
   const [selectedSequencer, setSelectedSequencer] = useState<string | null>(
     searchParams.get('sequencer'),
   );
 
   const sequencerList = useMemo(
-    () => chartsData.sequencerDistribution.map((s) => s.name),
-    [chartsData.sequencerDistribution],
+    () => blockData.candidates.map((a) => getSequencerName(a)),
+    [blockData.candidates],
   );
 
   // Sync with URL params - extract specific value to avoid object dependency


### PR DESCRIPTION
## Summary
- retrieve head block numbers and sequencer addresses from `/dashboard-data`
- derive sequencer list from fetched candidates
- update dashboard controller to use new handler signature

## Testing
- `just lint`
- `just lint-dashboard`
- `just check-dashboard`
- `just test-dashboard`
- `just test`
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68515577487c8328b9538d9751293d80