### PR TITLE
Change date formatting to day/month/year

### DIFF
--- a/dashboard/components/BlockTimeChart.tsx
+++ b/dashboard/components/BlockTimeChart.tsx
@@ -11,7 +11,12 @@ import {
   ResponsiveContainer,
 } from 'recharts';
 import { TimeSeriesData } from '../types';
-import { formatDecimal, formatInterval, computeIntervalFlags } from '../utils';
+import {
+  formatDecimal,
+  formatInterval,
+  computeIntervalFlags,
+  formatDateTime,
+} from '../utils';
 
 interface BlockTimeChartProps {
   data: TimeSeriesData[];
@@ -83,7 +88,7 @@ const BlockTimeChartComponent: React.FC<BlockTimeChartProps> = ({
         <Tooltip
           labelFormatter={(label: number, payload) => {
             const ts = payload?.[0]?.payload?.blockTime;
-            const timeStr = ts ? new Date(ts).toLocaleString() : '';
+            const timeStr = ts ? formatDateTime(ts) : '';
             return `Block ${label.toLocaleString()} (${timeStr})`;
           }}
           formatter={(value: number) => [

--- a/dashboard/components/BlockTxChart.tsx
+++ b/dashboard/components/BlockTxChart.tsx
@@ -8,6 +8,7 @@ import {
   Tooltip,
   ResponsiveContainer,
 } from 'recharts';
+import { formatDateTime } from '../utils';
 import type { BlockTransaction } from '../services/apiService';
 
 interface BlockTxChartProps {
@@ -69,7 +70,7 @@ const BlockTxChartComponent: React.FC<BlockTxChartProps> = ({
         <Tooltip
           labelFormatter={(label: number, payload) => {
             const ts = payload?.[0]?.payload?.blockTime;
-            const timeStr = ts ? new Date(ts).toLocaleString() : '';
+            const timeStr = ts ? formatDateTime(ts) : '';
             return `Block ${label.toLocaleString()} (${timeStr})`;
           }}
           formatter={(value: number) => [value.toLocaleString(), 'avg txs']}

--- a/dashboard/components/GasUsedChart.tsx
+++ b/dashboard/components/GasUsedChart.tsx
@@ -9,7 +9,7 @@ import {
   ResponsiveContainer,
 } from 'recharts';
 import { TimeSeriesData } from '../types';
-import { formatLargeNumber } from '../utils';
+import { formatLargeNumber, formatDateTime } from '../utils';
 
 interface GasUsedChartProps {
   data: TimeSeriesData[];
@@ -65,7 +65,7 @@ const GasUsedChartComponent: React.FC<GasUsedChartProps> = ({
         <Tooltip
           labelFormatter={(label: number, payload) => {
             const ts = payload?.[0]?.payload?.blockTime;
-            const timeStr = ts ? new Date(ts).toLocaleString() : '';
+            const timeStr = ts ? formatDateTime(ts) : '';
             return `Block ${label.toLocaleString()} (${timeStr})`;
           }}
           formatter={(value: number) => [formatLargeNumber(value), 'gas']}

--- a/dashboard/components/ReorgDepthChart.tsx
+++ b/dashboard/components/ReorgDepthChart.tsx
@@ -10,6 +10,7 @@ import {
 } from 'recharts';
 import { L2ReorgEvent } from '../types';
 import { TAIKO_PINK } from '../theme';
+import { formatDateTime } from '../utils';
 
 interface ReorgDepthChartProps {
   data: L2ReorgEvent[];
@@ -33,7 +34,7 @@ const ReorgDepthChartComponent: React.FC<ReorgDepthChartProps> = ({ data }) => {
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis
           dataKey="timestamp"
-          tickFormatter={(v: number) => new Date(v).toLocaleString()}
+          tickFormatter={(v: number) => formatDateTime(v)}
           stroke="#666666"
           fontSize={12}
           label={{
@@ -59,7 +60,7 @@ const ReorgDepthChartComponent: React.FC<ReorgDepthChartProps> = ({ data }) => {
           }}
         />
         <Tooltip
-          labelFormatter={(label: number) => new Date(label).toLocaleString()}
+          labelFormatter={(label: number) => formatDateTime(label)}
           formatter={(value: number) => [value.toString(), 'depth']}
           contentStyle={{
             backgroundColor: 'rgba(255, 255, 255, 0.8)',

--- a/dashboard/config/tableConfig.ts
+++ b/dashboard/config/tableConfig.ts
@@ -22,7 +22,7 @@ import {
   fetchL2Tps,
 } from '../services/apiService';
 import { getSequencerName, getSequencerAddress } from '../sequencerConfig';
-import { bytesToHex, blockLink, addressLink } from '../utils';
+import { bytesToHex, blockLink, addressLink, formatDateTime } from '../utils';
 import { TAIKO_PINK } from '../theme';
 import React from 'react';
 
@@ -71,7 +71,7 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
     ],
     mapData: (data) =>
       (data as L2ReorgEvent[]).map((e) => ({
-        timestamp: new Date(e.timestamp).toLocaleString(),
+        timestamp: formatDateTime(e.timestamp),
         l2_block_number: blockLink(e.l2_block_number),
         depth: e.depth.toLocaleString(),
       })),

--- a/dashboard/utils.ts
+++ b/dashboard/utils.ts
@@ -81,6 +81,9 @@ export const formatTime = (ms: number): string =>
     timeZone: 'UTC',
   });
 
+export const formatDateTime = (ms: number): string =>
+  new Date(ms).toLocaleString('en-GB');
+
 export const formatInterval = (
   seconds: number,
   showHours: boolean,


### PR DESCRIPTION
## Summary
- show date/time using day-first format in dashboard
- add `formatDateTime` util and update charts and tables

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68515741ee588328a3af8ff5085c42c2