### PR TITLE
Fix migration cast for tx_sum

### DIFF
--- a/crates/clickhouse/migrations/005_create_metrics_views.sql
+++ b/crates/clickhouse/migrations/005_create_metrics_views.sql
@@ -17,7 +17,7 @@ SELECT
     minState(h.block_ts) AS min_ts_state,
     maxState(h.block_ts) AS max_ts_state,
     countState() AS cnt_state,
-    sumState(sum_tx) AS tx_sum_state,
+    sumState(toUInt64(sum_tx)) AS tx_sum_state,
     sumState(sum_gas_used) AS gas_sum_state,
     sumState(sum_priority_fee) AS priority_fee_sum_state,
     sumState(sum_base_fee) AS base_fee_sum_state
@@ -63,7 +63,7 @@ SELECT
     minState(h.block_ts) AS min_ts_state,
     maxState(h.block_ts) AS max_ts_state,
     countState() AS cnt_state,
-    sumState(sum_tx) AS tx_sum_state,
+    sumState(toUInt64(sum_tx)) AS tx_sum_state,
     sumState(sum_gas_used) AS gas_sum_state,
     sumState(sum_priority_fee) AS priority_fee_sum_state,
     sumState(sum_base_fee) AS base_fee_sum_state


### PR DESCRIPTION
## Summary
- fix type mismatch in `005_create_metrics_views.sql`

## Testing
- `cargo fmt --all` *(fails: `cargo-fmt` not installed)*
- `cargo nextest run --workspace --all-targets` *(fails: package requires unstable feature `edition2024`)*

------
https://chatgpt.com/codex/tasks/task_b_685158263e6083289552a95bce9114dc