### PR TITLE
Fix profit calc

### DIFF
--- a/dashboard/components/ProfitRankingTable.tsx
+++ b/dashboard/components/ProfitRankingTable.tsx
@@ -72,9 +72,10 @@ export const ProfitRankingTable: React.FC<ProfitRankingTableProps> = ({
       };
     }
     const revenueEth =
-      (fees.priority_fee ?? 0) +
-      (fees.base_fee ?? 0) -
-      (fees.l1_data_cost ?? 0);
+      ((fees.priority_fee ?? 0) +
+        (fees.base_fee ?? 0) -
+        (fees.l1_data_cost ?? 0)) /
+      1e18;
     const profit = revenueEth * ethPrice - costPerSeq;
     return { name: seq.name, blocks: seq.value, profit };
   });

--- a/dashboard/tests/profitRankingTable.test.ts
+++ b/dashboard/tests/profitRankingTable.test.ts
@@ -14,7 +14,11 @@ describe('ProfitRankingTable', () => {
         data: { data: [{ name: 'SeqA', value: 10, tps: null }] },
       } as any)
       .mockReturnValueOnce({
-        data: [{ priority_fee: 2, base_fee: 1, l1_data_cost: 0 }],
+        data: [{
+          priority_fee: 2e18,
+          base_fee: 1e18,
+          l1_data_cost: 0,
+        }],
       } as any);
     vi.spyOn(api, 'fetchSequencerDistribution').mockResolvedValue({
       data: [{ name: 'SeqA', value: 10, tps: null }],
@@ -22,7 +26,7 @@ describe('ProfitRankingTable', () => {
       error: null,
     } as any);
     vi.spyOn(api, 'fetchL2Fees').mockResolvedValue({
-      data: { priority_fee: 2, base_fee: 1, l1_data_cost: 0 },
+      data: { priority_fee: 2e18, base_fee: 1e18, l1_data_cost: 0 },
       badRequest: false,
       error: null,
     } as any);


### PR DESCRIPTION
## Summary
- fix USD profit display in profit ranking table
- adjust tests for wei-based profit values

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685162da45588328bf9df9b0000ced1a