### PR TITLE
Fix ETH formatting in economics view

### DIFF
--- a/dashboard/tests/utils.test.ts
+++ b/dashboard/tests/utils.test.ts
@@ -128,6 +128,8 @@ describe('utils', () => {
 
   it('formats ETH amounts', () => {
     expect(formatEth(42e18)).toBe('42.0 ETH');
+    expect(formatEth(0)).toBe('0.00 ETH');
+    expect(formatEth(1e8)).toBe('0.10 Gwei');
   });
 
   it('converts bytes to hex', () => {

--- a/dashboard/utils.ts
+++ b/dashboard/utils.ts
@@ -69,8 +69,15 @@ export const formatLargeNumber = (value: number): string => {
 export const formatWithCommas = (value: number): string =>
   value.toLocaleString();
 
-export const formatEth = (wei: number): string =>
-  `${formatDecimal(wei / 1e18)} ETH`;
+export const formatEth = (wei: number): string => {
+  const eth = wei / 1e18;
+  const ethFormatted = formatDecimal(eth);
+  if (wei !== 0 && ethFormatted === '0.00') {
+    const gwei = wei / 1e9;
+    return `${formatDecimal(gwei)} Gwei`;
+  }
+  return `${ethFormatted} ETH`;
+};
 
 export const formatTime = (ms: number): string =>
   new Date(ms).toLocaleTimeString([], {


### PR DESCRIPTION
## Summary
- show small ETH values in Gwei
- test ETH formatter

## Testing
- `just ci`
- `npm run check`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_b_68516cccf9dc8328bb934d3106809a3a