### PR TITLE
Add Sankey fee flow chart

### DIFF
--- a/dashboard/components/FeeFlowChart.tsx
+++ b/dashboard/components/FeeFlowChart.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { ResponsiveContainer, Sankey, Tooltip } from 'recharts';
+import useSWR from 'swr';
+import { fetchDashboardData } from '../services/apiService';
+import { useEthPrice } from '../services/priceService';
+import { TimeRange } from '../types';
+
+interface FeeFlowChartProps {
+  timeRange: TimeRange;
+  address?: string;
+}
+
+export const FeeFlowChart: React.FC<FeeFlowChartProps> = ({
+  timeRange,
+  address,
+}) => {
+  const { data: dashRes } = useSWR(['dashboardData', timeRange, address], () =>
+    fetchDashboardData(timeRange, address),
+  );
+  const { data: ethPrice = 0 } = useEthPrice();
+
+  const priority = dashRes?.data?.priority_fee ?? null;
+  const base = dashRes?.data?.base_fee ?? null;
+  if (priority == null && base == null) {
+    return (
+      <div className="flex items-center justify-center h-full text-gray-500">
+        No data available
+      </div>
+    );
+  }
+
+  const priorityUsd = ((priority ?? 0) / 1e18) * ethPrice;
+  const baseUsd = ((base ?? 0) / 1e18) * ethPrice;
+
+  const data = {
+    nodes: [{ name: 'Users' }, { name: 'Sequencers' }, { name: 'Taiko DAO' }],
+    links: [
+      { source: 0, target: 1, value: priorityUsd },
+      { source: 0, target: 2, value: baseUsd },
+    ],
+  };
+
+  return (
+    <div className="mt-6" style={{ height: 240 }}>
+      <ResponsiveContainer width="100%" height="100%">
+        <Sankey
+          data={data}
+          nodePadding={10}
+          node={{ stroke: '#888' }}
+          link={{ stroke: '#ccc' }}
+        >
+          <Tooltip
+            formatter={(v: number) => `$${v.toFixed(2)}`}
+            labelFormatter={() => ''}
+          />
+        </Sankey>
+      </ResponsiveContainer>
+    </div>
+  );
+};

--- a/dashboard/components/views/DashboardView.tsx
+++ b/dashboard/components/views/DashboardView.tsx
@@ -6,6 +6,7 @@ import { IncomeChart } from '../IncomeChart';
 import { CostChart } from '../CostChart';
 import { ProfitabilityChart } from '../ProfitabilityChart';
 import { ProfitRankingTable } from '../ProfitRankingTable';
+import { FeeFlowChart } from '../FeeFlowChart';
 import { ChartCard } from '../ChartCard';
 import { TAIKO_PINK } from '../../theme';
 import { TimeRange, MetricData } from '../../types';
@@ -113,10 +114,10 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
   const skeletonGroupCounts: Record<string, number> = isEconomicsView
     ? { 'Network Economics': 3 }
     : {
-      'Network Performance': 3,
-      'Network Health': 5,
-      Sequencers: 3,
-    };
+        'Network Performance': 3,
+        'Network Health': 5,
+        Sequencers: 3,
+      };
 
   const displayGroupName = useCallback(
     (group: string): string => {
@@ -332,6 +333,10 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
               timeRange={timeRange}
               cloudCost={cloudCost}
               proverCost={proverCost}
+            />
+            <FeeFlowChart
+              timeRange={timeRange}
+              address={selectedSequencer || undefined}
             />
           </>
         )}


### PR DESCRIPTION
## Summary
- visualize fee flows on the economics view
- show how user fees split between sequencers and the Taiko DAO

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6851674fbf388328a9903d5e8d16c8df