### PR TITLE
Update status page link

### DIFF
--- a/dashboard/components/DashboardHeader.tsx
+++ b/dashboard/components/DashboardHeader.tsx
@@ -82,7 +82,7 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({
         {/* Economics view is still supported via URL parameters, but the
             navigation button is hidden. */}
         <a
-          href="https://taikoscope.instatus.com/"
+          href="https://status.taiko.xyz/"
           target="_blank"
           rel="noopener noreferrer"
           className="text-sm hover:underline"


### PR DESCRIPTION
## Summary
- replace old instatus link with new taiko status domain

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6851759615748328b09a25b66aeea463