### PR TITLE
Fix profit calculator parsing

### DIFF
--- a/dashboard/components/ProfitCalculator.tsx
+++ b/dashboard/components/ProfitCalculator.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { MetricData, TimeRange } from '../types';
-import { findMetricValue } from '../utils';
+import { findMetricValue, parseEthValue } from '../utils';
 import { rangeToHours } from '../utils/timeRange';
 import { useEthPrice } from '../services/priceService';
 
@@ -34,9 +34,9 @@ export const ProfitCalculator: React.FC<ProfitCalculatorProps> = ({
   const baseStr = findMetricValue(metrics, 'base fee');
   const l1DataCostStr = findMetricValue(metrics, 'l1 data cost');
 
-  const priority = parseFloat(priorityStr.replace(/[^0-9.]/g, '')) || 0;
-  const base = parseFloat(baseStr.replace(/[^0-9.]/g, '')) || 0;
-  const l1DataCost = parseFloat(l1DataCostStr.replace(/[^0-9.]/g, '')) || 0;
+  const priority = parseEthValue(priorityStr);
+  const base = parseEthValue(baseStr);
+  const l1DataCost = parseEthValue(l1DataCostStr);
 
   const totalFee = priority + base - l1DataCost;
 

--- a/dashboard/tests/profitCalculator.test.ts
+++ b/dashboard/tests/profitCalculator.test.ts
@@ -46,4 +46,24 @@ describe('ProfitCalculator', () => {
     const matches = html.match(/min="0"/g) ?? [];
     expect(matches.length).toBe(2);
   });
+
+  it('handles base fee in gwei', () => {
+    vi.spyOn(priceService, 'useEthPrice').mockReturnValue({
+      data: 2000,
+    } as any);
+    const html = renderToStaticMarkup(
+      React.createElement(ProfitCalculator, {
+        metrics: [
+          { title: 'Priority Fee', value: '0.6 ETH' },
+          { title: 'Base Fee', value: '1334501 Gwei' },
+        ],
+        timeRange: '1h',
+        cloudCost: 0,
+        proverCost: 0,
+        onCloudCostChange: () => {},
+        onProverCostChange: () => {},
+      }),
+    );
+    expect(html.includes('1,202')).toBe(true);
+  });
 });

--- a/dashboard/tests/utils.test.ts
+++ b/dashboard/tests/utils.test.ts
@@ -12,6 +12,7 @@ import {
   formatLargeNumber,
   formatWithCommas,
   formatEth,
+  parseEthValue,
   bytesToHex,
   loadRefreshRate,
   saveRefreshRate,
@@ -130,6 +131,13 @@ describe('utils', () => {
     expect(formatEth(42e18)).toBe('42.0 ETH');
     expect(formatEth(0)).toBe('0.00 ETH');
     expect(formatEth(1e8)).toBe('0.10 Gwei');
+    expect(formatEth(1334501e9)).toBe('1,334,501 Gwei');
+  });
+
+  it('parses ETH and Gwei values', () => {
+    expect(parseEthValue('0.6 ETH')).toBe(0.6);
+    expect(parseEthValue('1334501 Gwei')).toBeCloseTo(0.001334501);
+    expect(parseEthValue('N/A')).toBe(0);
   });
 
   it('converts bytes to hex', () => {

--- a/dashboard/utils.ts
+++ b/dashboard/utils.ts
@@ -74,9 +74,18 @@ export const formatEth = (wei: number): string => {
   const ethFormatted = formatDecimal(eth);
   if (wei !== 0 && ethFormatted === '0.00') {
     const gwei = wei / 1e9;
-    return `${formatDecimal(gwei)} Gwei`;
+    const gweiFormatted = Number.isInteger(gwei)
+      ? gwei.toLocaleString()
+      : formatDecimal(gwei);
+    return `${gweiFormatted} Gwei`;
   }
   return `${ethFormatted} ETH`;
+};
+
+export const parseEthValue = (value: string): number => {
+  const amount = parseFloat(value.replace(/[^0-9.]/g, ''));
+  if (!Number.isFinite(amount)) return 0;
+  return /gwei/i.test(value) ? amount / 1e9 : amount;
 };
 
 export const formatTime = (ms: number): string =>


### PR DESCRIPTION
## Summary
- ensure gwei amounts are parsed as ETH values
- drop trailing `.0` for gwei amounts
- test gwei parsing and formatting

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685174b605208328ab205a6ac55e16f9