### PR TITLE
Add explorer links for head block numbers

### DIFF
--- a/dashboard/components/DashboardFooter.tsx
+++ b/dashboard/components/DashboardFooter.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { TAIKO_PINK } from '../theme';
+import { TAIKOSCAN_BASE, ETHERSCAN_BASE } from '../utils';
 
 interface DashboardFooterProps {
   l2HeadBlock: string;
@@ -17,7 +18,21 @@ export const DashboardFooter: React.FC<DashboardFooterProps> = ({
           L2 Head Block
         </span>
         <p className="text-2xl font-semibold" style={{ color: TAIKO_PINK }}>
-          {l2HeadBlock}
+          {Number.isFinite(Number(l2HeadBlock.replace(/,/g, ''))) ? (
+            <a
+              href={`${TAIKOSCAN_BASE}/block/${Number(
+                l2HeadBlock.replace(/,/g, ''),
+              )}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:underline"
+              style={{ color: TAIKO_PINK }}
+            >
+              {l2HeadBlock}
+            </a>
+          ) : (
+            l2HeadBlock
+          )}
         </p>
       </div>
       <div>
@@ -25,7 +40,21 @@ export const DashboardFooter: React.FC<DashboardFooterProps> = ({
           L1 Head Block
         </span>
         <p className="text-2xl font-semibold" style={{ color: TAIKO_PINK }}>
-          {l1HeadBlock}
+          {Number.isFinite(Number(l1HeadBlock.replace(/,/g, ''))) ? (
+            <a
+              href={`${ETHERSCAN_BASE}/block/${Number(
+                l1HeadBlock.replace(/,/g, ''),
+              )}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:underline"
+              style={{ color: TAIKO_PINK }}
+            >
+              {l1HeadBlock}
+            </a>
+          ) : (
+            l1HeadBlock
+          )}
         </p>
       </div>
     </div>

--- a/dashboard/custom.d.ts
+++ b/dashboard/custom.d.ts
@@ -9,6 +9,8 @@ interface ImportMetaEnv {
   readonly NETWORK_NAME?: string;
   readonly VITE_TAIKOSCAN_BASE?: string;
   readonly TAIKOSCAN_BASE?: string;
+  readonly VITE_ETHERSCAN_BASE?: string;
+  readonly ETHERSCAN_BASE?: string;
 }
 
 interface ImportMeta {

--- a/dashboard/tests/dashboardFooter.test.ts
+++ b/dashboard/tests/dashboardFooter.test.ts
@@ -4,7 +4,7 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { DashboardFooter } from '../components/DashboardFooter';
 
 describe('DashboardFooter', () => {
-  it('renders block numbers', () => {
+  it('renders block numbers with links', () => {
     const html = renderToStaticMarkup(
       React.createElement(DashboardFooter, {
         l2HeadBlock: '409,253',
@@ -12,8 +12,10 @@ describe('DashboardFooter', () => {
       }),
     );
     expect(html.includes('L2 Head Block')).toBe(true);
-    expect(html.includes('409,253')).toBe(true);
     expect(html.includes('L1 Head Block')).toBe(true);
+    expect(html.includes('409,253')).toBe(true);
     expect(html.includes('3,951,872')).toBe(true);
+    expect(html.includes('/block/409253')).toBe(true);
+    expect(html.includes('/block/3951872')).toBe(true);
   });
 });

--- a/dashboard/utils.ts
+++ b/dashboard/utils.ts
@@ -12,11 +12,29 @@ export const TAIKOSCAN_BASE =
     ? 'https://hekla.taikoscan.io'
     : 'https://cb-blockscout-masaya.vercel.app/blocks');
 
+export const ETHERSCAN_BASE =
+  ((import.meta as any).env.VITE_ETHERSCAN_BASE as string | undefined) ??
+  ((import.meta as any).env.ETHERSCAN_BASE as string | undefined) ??
+  'https://etherscan.io';
+
 export const blockLink = (block: number): React.ReactElement =>
   React.createElement(
     'a',
     {
       href: `${TAIKOSCAN_BASE}/block/${block}`,
+      target: '_blank',
+      rel: 'noopener noreferrer',
+      className: 'font-semibold hover:underline',
+      style: { color: TAIKO_PINK },
+    },
+    block.toLocaleString(),
+  );
+
+export const l1BlockLink = (block: number): React.ReactElement =>
+  React.createElement(
+    'a',
+    {
+      href: `${ETHERSCAN_BASE}/block/${block}`,
       target: '_blank',
       rel: 'noopener noreferrer',
       className: 'font-semibold hover:underline',


### PR DESCRIPTION
## Summary
- link L2 head block to Taikoscan and L1 head block to Etherscan
- expose ETHERSCAN_BASE env var
- update footer unit test

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685175b88ed88328b57555a528db5259