### PR TITLE
Add economics outflows to Sankey chart

### DIFF
--- a/dashboard/components/FeeFlowChart.tsx
+++ b/dashboard/components/FeeFlowChart.tsx
@@ -4,14 +4,19 @@ import useSWR from 'swr';
 import { fetchDashboardData } from '../services/apiService';
 import { useEthPrice } from '../services/priceService';
 import { TimeRange } from '../types';
+import { rangeToHours } from '../utils/timeRange';
 
 interface FeeFlowChartProps {
   timeRange: TimeRange;
+  cloudCost: number;
+  proverCost: number;
   address?: string;
 }
 
 export const FeeFlowChart: React.FC<FeeFlowChartProps> = ({
   timeRange,
+  cloudCost,
+  proverCost,
   address,
 }) => {
   const { data: dashRes } = useSWR(['dashboardData', timeRange, address], () =>
@@ -31,13 +36,63 @@ export const FeeFlowChart: React.FC<FeeFlowChartProps> = ({
 
   const priorityUsd = ((priority ?? 0) / 1e18) * ethPrice;
   const baseUsd = ((base ?? 0) / 1e18) * ethPrice;
+  const hours = rangeToHours(timeRange);
+  const MONTH_HOURS = 30 * 24;
+  const cloudCostScaled = (cloudCost / MONTH_HOURS) * hours;
+  const proverCostScaled = (proverCost / MONTH_HOURS) * hours;
 
   const data = {
-    nodes: [{ name: 'Users' }, { name: 'Sequencers' }, { name: 'Taiko DAO' }],
-    links: [
-      { source: 0, target: 1, value: priorityUsd },
-      { source: 0, target: 2, value: baseUsd },
+    nodes: [
+      { name: 'Users' },
+      { name: 'Sequencers' },
+      { name: 'Taiko DAO' },
+      { name: 'Cloud Providers' },
+      { name: 'Provers' },
     ],
+    links: [
+      { source: 0, target: 1, value: priorityUsd, name: 'Priority Fee' },
+      { source: 0, target: 2, value: baseUsd, name: 'Base Fee' },
+      { source: 1, target: 3, value: cloudCostScaled, name: 'Cloud Cost' },
+      { source: 1, target: 4, value: proverCostScaled, name: 'Prover Cost' },
+    ],
+  };
+
+  const renderLink = (props: any) => {
+    const {
+      sourceX,
+      targetX,
+      sourceY,
+      targetY,
+      sourceControlX,
+      targetControlX,
+      linkWidth,
+      index,
+    } = props;
+    const { name, value } = data.links[index];
+    const path = `M${sourceX},${sourceY} C${sourceControlX},${sourceY} ${targetControlX},${targetY} ${targetX},${targetY}`;
+    const midX = (sourceX + targetX) / 2;
+    const midY = (sourceY + targetY) / 2;
+    return (
+      <g>
+        <path
+          d={path}
+          fill="none"
+          stroke="#333"
+          strokeWidth={linkWidth}
+          strokeOpacity="0.2"
+        />
+        <text
+          x={midX}
+          y={midY - 4}
+          textAnchor="middle"
+          fontSize={10}
+          fill="#333"
+          pointerEvents="none"
+        >
+          {`${name}: $${value.toFixed(2)}`}
+        </text>
+      </g>
+    );
   };
 
   return (
@@ -47,7 +102,7 @@ export const FeeFlowChart: React.FC<FeeFlowChartProps> = ({
           data={data}
           nodePadding={10}
           node={{ stroke: '#888' }}
-          link={{ stroke: '#ccc' }}
+          link={renderLink}
         >
           <Tooltip
             formatter={(v: number) => `$${v.toFixed(2)}`}

--- a/dashboard/components/views/DashboardView.tsx
+++ b/dashboard/components/views/DashboardView.tsx
@@ -336,6 +336,8 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
             />
             <FeeFlowChart
               timeRange={timeRange}
+              cloudCost={cloudCost}
+              proverCost={proverCost}
               address={selectedSequencer || undefined}
             />
           </>


### PR DESCRIPTION
## Summary
- add cloud and prover cost flows to FeeFlowChart
- label all flows in the economics Sankey diagram
- pass cloudCost and proverCost to the flow chart

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68517439af608328a84d2e60f14da6d0