### PR TITLE
Adjust economics charts layout

### DIFF
--- a/dashboard/components/layout/MetricsGrid.tsx
+++ b/dashboard/components/layout/MetricsGrid.tsx
@@ -33,7 +33,7 @@ export const MetricsGrid: React.FC<MetricsGridProps> = ({
   const regularGrid =
     'grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 gap-4 md:gap-6';
   const economicsGrid =
-    'grid grid-cols-2 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-2 2xl:grid-cols-2 gap-4 md:gap-6';
+    'grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-2 2xl:grid-cols-2 gap-4 md:gap-6';
   const chartsGrid = 'grid grid-cols-1 lg:grid-cols-2 gap-4 md:gap-6 mt-4';
 
   return (

--- a/dashboard/components/views/DashboardView.tsx
+++ b/dashboard/components/views/DashboardView.tsx
@@ -305,7 +305,7 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
               onCloudCostChange={setCloudCost}
               onProverCostChange={setProverCost}
             />
-            <div className="mt-6 grid grid-cols-2 gap-4 md:gap-6">
+            <div className="mt-6 grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6">
               <div>
                 <IncomeChart
                   timeRange={timeRange}


### PR DESCRIPTION
## Summary
- ensure only one chart per line on mobile in Economics view

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6851799399208328b862ec3820961a4d