### PR TITLE
Fix crossing flows in economics view

### DIFF
--- a/dashboard/components/FeeFlowChart.tsx
+++ b/dashboard/components/FeeFlowChart.tsx
@@ -103,6 +103,7 @@ export const FeeFlowChart: React.FC<FeeFlowChartProps> = ({
           nodePadding={10}
           node={{ stroke: '#888' }}
           link={renderLink}
+          sort={false}
         >
           <Tooltip
             formatter={(v: number) => `$${v.toFixed(2)}`}


### PR DESCRIPTION
## Summary
- add `sort={false}` to keep the FeeFlowChart layout stable
- run CI

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685179dc72a48328a59fe695c4d47a49