### PR TITLE
Reduce whitespace around dashboard charts

### DIFF
--- a/dashboard/components/BatchProcessChart.tsx
+++ b/dashboard/components/BatchProcessChart.tsx
@@ -40,7 +40,7 @@ const BatchProcessChartComponent: React.FC<BatchProcessChartProps> = ({
     <ResponsiveContainer width="100%" height="100%">
       <LineChart
         data={data}
-        margin={{ top: 5, right: 70, left: 80, bottom: 40 }}
+        margin={{ top: 5, right: 20, left: 20, bottom: 40 }}
       >
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis

--- a/dashboard/components/BlobsPerBatchChart.tsx
+++ b/dashboard/components/BlobsPerBatchChart.tsx
@@ -31,7 +31,7 @@ const BlobsPerBatchChartComponent: React.FC<BlobsPerBatchChartProps> = ({
     <ResponsiveContainer width="100%" height="100%">
       <BarChart
         data={data}
-        margin={{ top: 5, right: 70, left: 80, bottom: 40 }}
+        margin={{ top: 5, right: 20, left: 20, bottom: 40 }}
       >
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis

--- a/dashboard/components/BlockTimeChart.tsx
+++ b/dashboard/components/BlockTimeChart.tsx
@@ -44,7 +44,7 @@ const BlockTimeChartComponent: React.FC<BlockTimeChartProps> = ({
     <ResponsiveContainer width="100%" height="100%">
       <ChartComponent
         data={data}
-        margin={{ top: 5, right: 90, left: 80, bottom: 40 }}
+        margin={{ top: 5, right: 20, left: 20, bottom: 40 }}
       >
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis

--- a/dashboard/components/BlockTimeDistributionChart.tsx
+++ b/dashboard/components/BlockTimeDistributionChart.tsx
@@ -16,7 +16,7 @@ const MIN_BIN_COUNT = 5;
 const MAX_BIN_COUNT = 20;
 const MIN_REASONABLE_BLOCK_TIME_MS = 0;
 const MAX_REASONABLE_BLOCK_TIME_MS = 24 * 60 * 60 * 1000; // 24 hours in milliseconds
-const CHART_MARGINS = { top: 5, right: 70, left: 80, bottom: 40 };
+const CHART_MARGINS = { top: 5, right: 20, left: 20, bottom: 40 };
 
 interface BlockTimeDistributionChartProps {
   data: TimeSeriesData[];

--- a/dashboard/components/BlockTxChart.tsx
+++ b/dashboard/components/BlockTxChart.tsx
@@ -35,7 +35,7 @@ const BlockTxChartComponent: React.FC<BlockTxChartProps> = ({
     <ResponsiveContainer width="100%" height="100%">
       <LineChart
         data={sortedData}
-        margin={{ top: 5, right: 70, left: 80, bottom: 40 }}
+        margin={{ top: 5, right: 20, left: 20, bottom: 40 }}
       >
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis

--- a/dashboard/components/CostChart.tsx
+++ b/dashboard/components/CostChart.tsx
@@ -50,7 +50,7 @@ export const CostChart: React.FC<CostChartProps> = ({
     <ResponsiveContainer width="100%" height={240}>
       <LineChart
         data={data}
-        margin={{ top: 5, right: 40, left: 20, bottom: 40 }}
+        margin={{ top: 5, right: 20, left: 20, bottom: 40 }}
       >
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis

--- a/dashboard/components/GasUsedChart.tsx
+++ b/dashboard/components/GasUsedChart.tsx
@@ -31,7 +31,7 @@ const GasUsedChartComponent: React.FC<GasUsedChartProps> = ({
     <ResponsiveContainer width="100%" height="100%">
       <LineChart
         data={data}
-        margin={{ top: 5, right: 70, left: 80, bottom: 40 }}
+        margin={{ top: 5, right: 20, left: 20, bottom: 40 }}
       >
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis

--- a/dashboard/components/IncomeChart.tsx
+++ b/dashboard/components/IncomeChart.tsx
@@ -50,7 +50,7 @@ export const IncomeChart: React.FC<IncomeChartProps> = ({
       <ResponsiveContainer width="100%" height={240}>
         <LineChart
           data={data}
-          margin={{ top: 5, right: 40, left: 20, bottom: 40 }}
+          margin={{ top: 5, right: 20, left: 20, bottom: 40 }}
         >
           <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
           <XAxis

--- a/dashboard/components/MissedBlockChart.tsx
+++ b/dashboard/components/MissedBlockChart.tsx
@@ -35,7 +35,7 @@ const MissedBlockChartComponent: React.FC<MissedBlockChartProps> = ({
     <ResponsiveContainer width="100%" height="100%">
       <BarChart
         data={sortedData}
-        margin={{ top: 5, right: 70, left: 80, bottom: 40 }}
+        margin={{ top: 5, right: 20, left: 20, bottom: 40 }}
       >
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis

--- a/dashboard/components/ProfitabilityChart.tsx
+++ b/dashboard/components/ProfitabilityChart.tsx
@@ -60,7 +60,7 @@ export const ProfitabilityChart: React.FC<ProfitabilityChartProps> = ({
       <ResponsiveContainer width="100%" height={240}>
         <LineChart
           data={data}
-          margin={{ top: 5, right: 40, left: 20, bottom: 40 }}
+          margin={{ top: 5, right: 20, left: 20, bottom: 40 }}
         >
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis

--- a/dashboard/components/ReorgDepthChart.tsx
+++ b/dashboard/components/ReorgDepthChart.tsx
@@ -29,7 +29,7 @@ const ReorgDepthChartComponent: React.FC<ReorgDepthChartProps> = ({ data }) => {
     <ResponsiveContainer width="100%" height="100%">
       <BarChart
         data={data}
-        margin={{ top: 5, right: 70, left: 60, bottom: 40 }}
+        margin={{ top: 5, right: 20, left: 20, bottom: 40 }}
       >
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis

--- a/dashboard/components/TpsChart.tsx
+++ b/dashboard/components/TpsChart.tsx
@@ -31,7 +31,7 @@ const TpsChartComponent: React.FC<TpsChartProps> = ({ data, lineColor }) => {
     <ResponsiveContainer width="100%" height="100%">
       <LineChart
         data={data}
-        margin={{ top: 5, right: 70, left: 20, bottom: 40 }}
+        margin={{ top: 5, right: 20, left: 20, bottom: 40 }}
       >
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis


### PR DESCRIPTION
## Summary
- reduce left/right margins across dashboard charts

## Testing
- `just ci`
- `npm run test` in `dashboard/`

------
https://chatgpt.com/codex/tasks/task_b_6851806ec10c8328bf595636cd08f96e