### PR TITLE
feat: link sequencer metrics

### DIFF
--- a/dashboard/tests/metricsCreator.test.ts
+++ b/dashboard/tests/metricsCreator.test.ts
@@ -40,7 +40,9 @@ describe('metricsCreator', () => {
     const current = metrics.find((m) => m.title === 'Current Sequencer');
     const next = metrics.find((m) => m.title === 'Next Sequencer');
     expect(current?.value).toBe('Chainbound A');
+    expect(current?.link).toContain('/address/');
     expect(next?.value).toBe('Chainbound B');
+    expect(next?.link).toContain('/address/');
 
     const l2BlockMetric = metrics.find((m) => m.title === 'L2 Block');
     expect(l2BlockMetric?.link).toContain('/block/100');

--- a/dashboard/utils/metricsCreator.ts
+++ b/dashboard/utils/metricsCreator.ts
@@ -87,12 +87,20 @@ export const createMetrics = (data: MetricInputData): MetricData[] => [
       data.currentOperator != null
         ? getSequencerName(data.currentOperator)
         : 'N/A',
+    link:
+      data.currentOperator != null
+        ? `${TAIKOSCAN_BASE}/address/${data.currentOperator}`
+        : undefined,
     group: 'Sequencers',
   },
   {
     title: 'Next Sequencer',
     value:
       data.nextOperator != null ? getSequencerName(data.nextOperator) : 'N/A',
+    link:
+      data.nextOperator != null
+        ? `${TAIKOSCAN_BASE}/address/${data.nextOperator}`
+        : undefined,
     group: 'Sequencers',
   },
   {


### PR DESCRIPTION
## Summary
- add address links for current and next sequencer metrics
- test for presence of address links

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685174fa84808328997681679bb82ca8