### PR TITLE
Link prove/verify metrics to table view

### DIFF
--- a/dashboard/components/views/DashboardView.tsx
+++ b/dashboard/components/views/DashboardView.tsx
@@ -151,10 +151,12 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
         'Forced Inclusions': () => onOpenTable('forced-inclusions'),
         'Active Sequencers': () => onOpenTable('gateways'),
         'Batch Posting Cadence': () => onOpenTable('batch-posting-cadence'),
+        'Avg. Prove Time': () => onOpenTable('prove-time', timeRange),
+        'Avg. Verify Time': () => onOpenTable('verify-time', timeRange),
       };
       return actions[title];
     },
-    [onOpenTable, onOpenTpsTable],
+    [onOpenTable, onOpenTpsTable, timeRange],
   );
 
   const groupedCharts = React.useMemo(() => {

--- a/dashboard/tests/metricsCreator.test.ts
+++ b/dashboard/tests/metricsCreator.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect } from 'vitest';
-import React from 'react';
 import { createMetrics } from '../utils/metricsCreator';
 
 const addressA = '0x00a00800c28f2616360dcfadee02d761d14ad94e';
@@ -29,13 +28,10 @@ describe('metricsCreator', () => {
     expect(metrics).toHaveLength(16);
     expect(metrics[0].value).toBe('1.23');
 
-    const verifyMetric = metrics.find((m) => React.isValidElement(m.title));
-    expect(verifyMetric).toBeDefined();
-    const link = verifyMetric!.title as React.ReactElement;
-    expect(link.type).toBe('a');
-    expect((link as any).props.href).toContain('block-states');
-    expect((link as any).props.children).toBe('Avg. Verify Time');
-    expect(verifyMetric!.value).toBe('3.00s');
+    const proveMetric = metrics.find((m) => m.title === 'Avg. Prove Time');
+    const verifyMetric = metrics.find((m) => m.title === 'Avg. Verify Time');
+    expect(proveMetric?.value).toBe('2.00s');
+    expect(verifyMetric?.value).toBe('3.00s');
 
     const current = metrics.find((m) => m.title === 'Current Sequencer');
     const next = metrics.find((m) => m.title === 'Next Sequencer');

--- a/dashboard/utils/metricsCreator.ts
+++ b/dashboard/utils/metricsCreator.ts
@@ -1,4 +1,3 @@
-import React from 'react';
 import { type MetricData } from '../types';
 import {
   formatSeconds,
@@ -57,16 +56,7 @@ export const createMetrics = (data: MetricInputData): MetricData[] => [
     group: 'Network Health',
   },
   {
-    title: React.createElement(
-      'a',
-      {
-        href: 'https://docs.taiko.xyz/taiko-alethia-protocol/protocol-architecture/block-states',
-        target: '_blank',
-        rel: 'noopener noreferrer',
-        className: 'hover:underline',
-      },
-      'Avg. Verify Time',
-    ),
+    title: 'Avg. Verify Time',
     value:
       data.avgVerify != null && data.avgVerify > 0
         ? formatSeconds(data.avgVerify / 1000)


### PR DESCRIPTION
## Summary
- update `Avg. Prove Time` and `Avg. Verify Time` metrics to plain text
- allow metrics to open the same tables as their charts
- adjust tests for metrics creator

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685174e75c088328a4b5b80d11e62b91