### PR TITLE
Fix Sankey link crossings

### DIFF
--- a/dashboard/components/FeeFlowChart.tsx
+++ b/dashboard/components/FeeFlowChart.tsx
@@ -103,7 +103,7 @@ export const FeeFlowChart: React.FC<FeeFlowChartProps> = ({
           nodePadding={10}
           node={{ stroke: '#888' }}
           link={renderLink}
-          sort={false}
+          sort={true}
         >
           <Tooltip
             formatter={(v: number) => `$${v.toFixed(2)}`}


### PR DESCRIPTION
## Summary
- set Sankey chart sorting back to true so flows don't cross

## Testing
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_685185744af08328b5e3ee214207f3d8