### PR TITLE
Fix fee flow chart ordering

### DIFF
--- a/dashboard/components/FeeFlowChart.tsx
+++ b/dashboard/components/FeeFlowChart.tsx
@@ -44,16 +44,16 @@ export const FeeFlowChart: React.FC<FeeFlowChartProps> = ({
   const data = {
     nodes: [
       { name: 'Users' },
-      { name: 'Sequencers' },
       { name: 'Taiko DAO' },
+      { name: 'Sequencers' },
       { name: 'Cloud Providers' },
       { name: 'Provers' },
     ],
     links: [
-      { source: 0, target: 1, value: priorityUsd, name: 'Priority Fee' },
-      { source: 0, target: 2, value: baseUsd, name: 'Base Fee' },
-      { source: 1, target: 3, value: cloudCostScaled, name: 'Cloud Cost' },
-      { source: 1, target: 4, value: proverCostScaled, name: 'Prover Cost' },
+      { source: 0, target: 2, value: priorityUsd, name: 'Priority Fee' },
+      { source: 0, target: 1, value: baseUsd, name: 'Base Fee' },
+      { source: 2, target: 3, value: cloudCostScaled, name: 'Cloud Cost' },
+      { source: 2, target: 4, value: proverCostScaled, name: 'Prover Cost' },
     ],
   };
 


### PR DESCRIPTION
## Summary
- reorder economics flow chart nodes so flows don't cross

## Testing
- `npm --prefix dashboard run check`
- `npm --prefix dashboard run lint:whitespace`
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685185744af08328b5e3ee214207f3d8