### PR TITLE
Add chart to Tx count table

### DIFF
--- a/dashboard/config/tableConfig.ts
+++ b/dashboard/config/tableConfig.ts
@@ -15,6 +15,7 @@ import {
   fetchProveTimes,
   fetchVerifyTimes,
   fetchAllBlockTransactions,
+  fetchBlockTransactionsAggregated,
   fetchL2BlockTimes,
   fetchL2GasUsed,
   fetchL2GasUsedAggregated,
@@ -225,6 +226,7 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
     title: 'Tx Count Per L2 Block',
     description: 'Transactions included in each L2 block.',
     fetcher: fetchAllBlockTransactions,
+    aggregatedFetcher: fetchBlockTransactionsAggregated,
     columns: [
       { key: 'block', label: 'L2 Block Number' },
       { key: 'txs', label: 'Tx Count' },
@@ -238,6 +240,17 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
           sequencer: addressLink(d.sequencer),
         }),
       ),
+    chart: (data) => {
+      const BlockTxChart = React.lazy(() =>
+        import('../components/BlockTxChart').then((m) => ({
+          default: m.BlockTxChart,
+        })),
+      );
+      return React.createElement(BlockTxChart, {
+        data,
+        lineColor: '#4E79A7',
+      });
+    },
     urlKey: 'block-tx',
   },
 


### PR DESCRIPTION
## Summary
- show BlockTxChart above Tx Count Per L2 Block table

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6851865cbb04832886580eb5aaff4cb9