### PR TITLE
Fix Gas Used table ordering

### DIFF
--- a/dashboard/config/tableConfig.ts
+++ b/dashboard/config/tableConfig.ts
@@ -284,7 +284,7 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
       });
     },
     urlKey: 'l2-gas-used',
-    reverseOrder: true,
+    reverseOrder: false,
     supportsPagination: true,
   },
 


### PR DESCRIPTION
## Summary
- ensure Gas Used Per Block table displays newest blocks first

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6851863c279c83289a3f96d699ccc5eb