### PR TITLE
Fix time-range and reorg filtering edge cases

### DIFF
--- a/crates/api/src/validation.rs
+++ b/crates/api/src/validation.rs
@@ -189,18 +189,18 @@ pub fn resolve_time_range_enum(range: &Option<String>, time_params: &TimeRangePa
     if has_time_range_params(time_params) {
         let now = Utc::now();
 
-        let start = time_params
-            .created_gt
-            .map(|v| v + 1)
-            .or(time_params.created_gte)
-            .and_then(|ms| Utc.timestamp_millis_opt(ms as i64).single())
-            .unwrap_or_else(|| now - ChronoDuration::hours(1));
-
         let end = time_params
             .created_lt
             .or(time_params.created_lte)
             .and_then(|ms| Utc.timestamp_millis_opt(ms as i64).single())
             .unwrap_or(now);
+
+        let start = time_params
+            .created_gt
+            .map(|v| v + 1)
+            .or(time_params.created_gte)
+            .and_then(|ms| Utc.timestamp_millis_opt(ms as i64).single())
+            .unwrap_or_else(|| end - ChronoDuration::hours(1));
 
         let duration = end.signed_duration_since(start).max(ChronoDuration::zero());
         return TimeRange::from_duration(duration);


### PR DESCRIPTION
## Summary
- ensure `resolve_time_range_enum` uses end timestamp when inferring start
- fix reorg filter to exclude full reorg depth
- clarify duration variable in average TPS query

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6851876d394883288e5d862442fc7737