### PR TITLE
Add L2 fee breakdown per sequencer

### DIFF
--- a/crates/api-types/src/lib.rs
+++ b/crates/api-types/src/lib.rs
@@ -294,6 +294,26 @@ pub struct BlockTransactionsResponse {
     pub blocks: Vec<BlockTransactionsItem>,
 }
 
+/// Aggregated L2 fees for a sequencer.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct SequencerFeeRow {
+    /// Sequencer address.
+    pub address: String,
+    /// Sum of priority fees for the sequencer.
+    pub priority_fee: u128,
+    /// 75% of the sum of base fees for the sequencer.
+    pub base_fee: u128,
+    /// Total L1 data posting cost for the sequencer.
+    pub l1_data_cost: Option<u128>,
+}
+
+/// L2 fees grouped by sequencer.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct L2FeesBySequencerResponse {
+    /// Fees aggregated for each sequencer.
+    pub sequencers: Vec<SequencerFeeRow>,
+}
+
 /// Blob count per batch.
 #[derive(Debug, Serialize, ToSchema)]
 pub struct BatchBlobsResponse {

--- a/crates/clickhouse/src/models.rs
+++ b/crates/clickhouse/src/models.rs
@@ -254,6 +254,19 @@ pub struct BlockFeeComponentRow {
     pub l1_data_cost: Option<u128>,
 }
 
+/// Row representing aggregated L2 fees for a sequencer
+#[derive(Debug, Row, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+pub struct SequencerFeeRow {
+    /// Sequencer address
+    pub sequencer: AddressBytes,
+    /// Sum of priority fees paid by the sequencer
+    pub priority_fee: u128,
+    /// 75% of the sum of base fees paid by the sequencer
+    pub base_fee: u128,
+    /// Total L1 data posting cost attributed to the sequencer
+    pub l1_data_cost: Option<u128>,
+}
+
 /// Row representing the transactions per second for an L2 block
 #[derive(Debug, Serialize, Deserialize, PartialEq, ToSchema)]
 pub struct L2TpsRow {

--- a/docs/api.md
+++ b/docs/api.md
@@ -24,3 +24,7 @@ All time range parameters are in milliseconds. Time range parameters cannot be u
 | `created[gte]` | integer | No       | Return results created **at or after** this Unix timestamp  |
 | `created[lt]`  | integer | No       | Return results created **before** this Unix timestamp       |
 | `created[lte]` | integer | No       | Return results created **at or before** this Unix timestamp |
+
+### `/l2-fees/by-sequencer`
+
+Returns total priority fee, base fee, and optional L1 data cost grouped by sequencer for the selected time range.


### PR DESCRIPTION
## Summary
- support fee queries grouped by sequencer
- expose `/l2-fees/by-sequencer` API endpoint
- document the new endpoint

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685185ad2d988328a8ae1b35d776d277