### PR TITLE
Fix Sankey node values

### DIFF
--- a/dashboard/components/FeeFlowChart.tsx
+++ b/dashboard/components/FeeFlowChart.tsx
@@ -16,10 +16,13 @@ interface FeeFlowChartProps {
 const MONTH_HOURS = 30 * 24;
 const WEI_TO_ETH = 1e18;
 
-// Simple node component that renders label with value
+// Format numbers as USD without grouping
+const formatUsd = (value: number) => `$${value.toFixed(2)}`;
+
+// Simple node component that renders label with USD value
 const SankeyNode = ({ x, y, width, height, payload }: any) => {
   const nodeValue = payload?.value;
-  const formattedValue = nodeValue != null ? nodeValue.toFixed(2) : '';
+  const formattedValue = nodeValue != null ? formatUsd(nodeValue) : '';
 
   return (
     <g>
@@ -125,7 +128,7 @@ export const FeeFlowChart: React.FC<FeeFlowChartProps> = ({
     ].filter(link => link.value > 0), // Only show links with positive values
   };
 
-  const formatTooltipValue = (value: number) => `$${value.toFixed(2)}`;
+  const formatTooltipValue = (value: number) => formatUsd(value);
 
   const tooltipContent = ({ active, payload }: any) => {
     if (!active || !payload?.[0]) return null;


### PR DESCRIPTION
## Summary
- show node value in FeeFlowChart nodes

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6852730022448328a33b596a230b654b