### PR TITLE
Set default prover cost to 200

### DIFF
--- a/dashboard/components/views/DashboardView.tsx
+++ b/dashboard/components/views/DashboardView.tsx
@@ -84,7 +84,7 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
   const [searchParams] = useSearchParams();
   const isEconomicsView = searchParams.get('view') === 'economics';
   const [cloudCost, setCloudCost] = useState(100);
-  const [proverCost, setProverCost] = useState(100);
+  const [proverCost, setProverCost] = useState(200);
 
   const visibleMetrics = React.useMemo(
     () =>


### PR DESCRIPTION
## Summary
- increase default prover cost in the dashboard Profit Calculator to 200

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68527b15cea88328907a831e0e27ade2