### PR TITLE
Merge l2 fee endpoints

### DIFF
--- a/crates/api-types/src/lib.rs
+++ b/crates/api-types/src/lib.rs
@@ -175,6 +175,8 @@ pub struct L2FeesResponse {
     pub base_fee: Option<u128>,
     /// Total L1 data posting cost for the range.
     pub l1_data_cost: Option<u128>,
+    /// Fee breakdown for each sequencer.
+    pub sequencers: Vec<SequencerFeeRow>,
 }
 
 /// Estimated cloud infrastructure cost in USD.
@@ -305,13 +307,6 @@ pub struct SequencerFeeRow {
     pub base_fee: u128,
     /// Total L1 data posting cost for the sequencer.
     pub l1_data_cost: Option<u128>,
-}
-
-/// L2 fees grouped by sequencer.
-#[derive(Debug, Serialize, ToSchema)]
-pub struct L2FeesBySequencerResponse {
-    /// Fees aggregated for each sequencer.
-    pub sequencers: Vec<SequencerFeeRow>,
 }
 
 /// Blob count per batch.

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -1369,22 +1369,18 @@ async fn l2_fees(
         )
     })?;
 
+    // Filter using the raw `AddressBytes` value to avoid discrepancies caused by
+    // different textual representations of the same address (e.g. case, missing
+    // "0x" prefix). Only after filtering do we convert addresses to their
+    // canonical hex string form.
     let sequencers: Vec<SequencerFeeRow> = rows
         .into_iter()
+        .filter(|r| if let Some(target) = address { r.sequencer == target } else { true })
         .map(|r| SequencerFeeRow {
             address: format!("0x{}", encode(r.sequencer)),
             priority_fee: r.priority_fee,
             base_fee: r.base_fee,
             l1_data_cost: r.l1_data_cost,
-        })
-        .filter(|r| {
-            if let Some(target_address) = address {
-                // Compare against the normalized address format for consistency
-                let target_address_str = format!("0x{}", encode(target_address));
-                r.address == target_address_str
-            } else {
-                true
-            }
         })
         .collect();
 

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -666,10 +666,18 @@ export const fetchAvgL2Tps = async (
   };
 };
 
+export interface SequencerFee {
+  address: string;
+  priority_fee: number;
+  base_fee: number;
+  l1_data_cost: number | null;
+}
+
 export interface L2FeesResponse {
   priority_fee: number | null;
   base_fee: number | null;
   l1_data_cost: number | null;
+  sequencers: SequencerFee[];
 }
 
 export const fetchL2Fees = async (

--- a/dashboard/tests/app.integration.test.ts
+++ b/dashboard/tests/app.integration.test.ts
@@ -136,8 +136,18 @@ const responses: Record<string, Record<string, unknown>> = {
       { l2_block_number: 2, block_time: '1970-01-01T00:00:02Z', gas_used: 150 },
     ],
   },
-  [`/v1/l2-fees?${q1h}`]: { priority_fee: 600, base_fee: 400 },
-  [`/v1/l2-fees?${q15m}`]: { priority_fee: 600, base_fee: 400 },
+  [`/v1/l2-fees?${q1h}`]: {
+    priority_fee: 600,
+    base_fee: 400,
+    l1_data_cost: null,
+    sequencers: [],
+  },
+  [`/v1/l2-fees?${q15m}`]: {
+    priority_fee: 600,
+    base_fee: 400,
+    l1_data_cost: null,
+    sequencers: [],
+  },
   [`/v1/sequencer-distribution?${q1h}`]: {
     sequencers: [{ address: 'addr1', blocks: 10 }],
   },
@@ -146,7 +156,12 @@ const responses: Record<string, Record<string, unknown>> = {
   },
   '/v1/l2-head-block': { l2_head_block: 123 },
   '/v1/l1-head-block': { l1_head_block: 456 },
-  [`/v1/l2-fees?${q24h}`]: { priority_fee: 1200, base_fee: 800 },
+  [`/v1/l2-fees?${q24h}`]: {
+    priority_fee: 1200,
+    base_fee: 800,
+    l1_data_cost: null,
+    sequencers: [],
+  },
 };
 
 (

--- a/dashboard/tests/dataFetcher.test.ts
+++ b/dashboard/tests/dataFetcher.test.ts
@@ -82,7 +82,7 @@ describe('dataFetcher', () => {
 
   it('fetches economics data', async () => {
     setAll({
-      fetchL2Fees: ok({ priority_fee: 1, base_fee: 2, l1_data_cost: 4 }),
+      fetchL2Fees: ok({ priority_fee: 1, base_fee: 2, l1_data_cost: 4, sequencers: [] }),
       fetchL2HeadBlock: ok(2),
       fetchL1HeadBlock: ok(3),
       fetchSequencerDistribution: ok([{ name: 'foo', value: 1, tps: null }]),

--- a/dashboard/tests/profitRankingTable.test.ts
+++ b/dashboard/tests/profitRankingTable.test.ts
@@ -19,6 +19,7 @@ describe('ProfitRankingTable', () => {
             priority_fee: 2e18,
             base_fee: 1e18,
             l1_data_cost: 0,
+            sequencers: [],
           },
         ],
       } as any);
@@ -28,7 +29,7 @@ describe('ProfitRankingTable', () => {
       error: null,
     } as any);
     vi.spyOn(api, 'fetchL2Fees').mockResolvedValue({
-      data: { priority_fee: 2e18, base_fee: 1e18, l1_data_cost: 0 },
+      data: { priority_fee: 2e18, base_fee: 1e18, l1_data_cost: 0, sequencers: [] },
       badRequest: false,
       error: null,
     } as any);

--- a/docs/api.md
+++ b/docs/api.md
@@ -25,6 +25,6 @@ All time range parameters are in milliseconds. Time range parameters cannot be u
 | `created[lt]`  | integer | No       | Return results created **before** this Unix timestamp       |
 | `created[lte]` | integer | No       | Return results created **at or before** this Unix timestamp |
 
-### `/l2-fees/by-sequencer`
+### `/l2-fees`
 
-Returns total priority fee, base fee, and optional L1 data cost grouped by sequencer for the selected time range.
+Returns total priority fee, base fee and optional L1 data cost for the selected address (or all sequencers). The response also includes a `sequencers` array with the fee breakdown for each sequencer.


### PR DESCRIPTION
## Summary
- expose `/l2-fees` with aggregated and per‑sequencer data
- remove old `/l2-fees/by-sequencer` endpoint
- document new response format
- update dashboard types and tests

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68527ada63d88328bc3ccdcc889d2bf4