### PR TITLE
Return full base fee in API

### DIFF
--- a/crates/api-types/src/lib.rs
+++ b/crates/api-types/src/lib.rs
@@ -171,7 +171,7 @@ pub struct AvgL2TpsResponse {
 pub struct L2FeesResponse {
     /// Sum of priority fees for the range.
     pub priority_fee: Option<u128>,
-    /// 75% of the sum of base fees for the range.
+    /// Sum of base fees for the range.
     pub base_fee: Option<u128>,
     /// Total L1 data posting cost for the range.
     pub l1_data_cost: Option<u128>,
@@ -301,7 +301,7 @@ pub struct SequencerFeeRow {
     pub address: String,
     /// Sum of priority fees for the sequencer.
     pub priority_fee: u128,
-    /// 75% of the sum of base fees for the sequencer.
+    /// Sum of base fees for the sequencer.
     pub base_fee: u128,
     /// Total L1 data posting cost for the sequencer.
     pub l1_data_cost: Option<u128>,
@@ -376,7 +376,7 @@ pub struct DashboardDataResponse {
     pub l1_block: Option<u64>,
     /// Sum of priority fees for the range.
     pub priority_fee: Option<u128>,
-    /// 75% of the sum of base fees for the range.
+    /// Sum of base fees for the range.
     pub base_fee: Option<u128>,
     /// Estimated infrastructure cost in USD for the requested range.
     pub cloud_cost: Option<f64>,

--- a/crates/clickhouse/src/models.rs
+++ b/crates/clickhouse/src/models.rs
@@ -248,7 +248,7 @@ pub struct BlockFeeComponentRow {
     pub l2_block_number: u64,
     /// Total priority fee for the block
     pub priority_fee: u128,
-    /// 75% of the total base fee for the block
+    /// Total base fee for the block
     pub base_fee: u128,
     /// L1 data posting cost associated with the block, if available
     pub l1_data_cost: Option<u128>,
@@ -261,7 +261,7 @@ pub struct SequencerFeeRow {
     pub sequencer: AddressBytes,
     /// Sum of priority fees paid by the sequencer
     pub priority_fee: u128,
-    /// 75% of the sum of base fees paid by the sequencer
+    /// Sum of base fees paid by the sequencer
     pub base_fee: u128,
     /// Total L1 data posting cost attributed to the sequencer
     pub l1_data_cost: Option<u128>,

--- a/crates/clickhouse/src/reader.rs
+++ b/crates/clickhouse/src/reader.rs
@@ -1297,7 +1297,7 @@ impl ClickhouseReader {
         let mut query = format!(
             "SELECT h.l2_block_number, \
                     sum_priority_fee AS priority_fee, \
-                    toUInt128(sum_base_fee * 3 / 4) AS base_fee, \
+                    sum_base_fee AS base_fee, \
                     toNullable(dc.cost) AS l1_data_cost \
              FROM {db}.l2_head_events h \
              LEFT JOIN {db}.l1_data_costs dc \
@@ -1382,7 +1382,7 @@ impl ClickhouseReader {
         }
 
         let mut query = format!(
-            "SELECT sum(sum_priority_fee + toUInt128(sum_base_fee * 3 / 4)) AS total \
+            "SELECT sum(sum_priority_fee + sum_base_fee) AS total \
              FROM {db}.l2_head_events h \
              WHERE h.block_ts >= toUnixTimestamp(now64() - INTERVAL {interval}) \
                AND {filter}",
@@ -1434,7 +1434,7 @@ impl ClickhouseReader {
         Ok(Some(row.total))
     }
 
-    /// Get 75% of the total base fee for the given range
+    /// Get the total base fee for the given range
     pub async fn get_l2_base_fee(
         &self,
         sequencer: Option<AddressBytes>,
@@ -1446,7 +1446,7 @@ impl ClickhouseReader {
         }
 
         let mut query = format!(
-            "SELECT sum(toUInt128(sum_base_fee * 3 / 4)) AS total \
+            "SELECT sum(sum_base_fee) AS total \
              FROM {db}.l2_head_events h \
              WHERE h.block_ts >= toUnixTimestamp(now64() - INTERVAL {interval}) \
                AND {filter}",
@@ -1479,7 +1479,7 @@ impl ClickhouseReader {
         let query = format!(
             "SELECT h.sequencer,\
                     sum(sum_priority_fee) AS priority_fee,\
-                    sum(toUInt128(sum_base_fee * 3 / 4)) AS base_fee,\
+                    sum(sum_base_fee) AS base_fee,\
                     sum(dc.cost) AS l1_data_cost\
              FROM {db}.l2_head_events h\
              LEFT JOIN {db}.l1_data_costs dc\

--- a/dashboard/components/FeeFlowChart.tsx
+++ b/dashboard/components/FeeFlowChart.tsx
@@ -45,7 +45,8 @@ const SankeyNode = ({ x, y, width, height, payload }: any) => {
         {payload.name}
         {formattedValue && (
           <tspan fill="#6b7280" fontSize={11}>
-            {' '}({formattedValue})
+            {' '}
+            ({formattedValue})
           </tspan>
         )}
       </text>
@@ -78,6 +79,8 @@ export const FeeFlowChart: React.FC<FeeFlowChartProps> = ({
   // Convert fees to USD
   const priorityFeeUsd = ((priorityFee ?? 0) / WEI_TO_ETH) * ethPrice;
   const baseFeeUsd = ((baseFee ?? 0) / WEI_TO_ETH) * ethPrice;
+  const baseFeeSeqUsd = baseFeeUsd * 0.75;
+  const baseFeeDaoUsd = baseFeeUsd * 0.25;
 
   // Scale operational costs to the selected time range
   const hours = rangeToHours(timeRange);
@@ -85,7 +88,7 @@ export const FeeFlowChart: React.FC<FeeFlowChartProps> = ({
   const proverCostScaled = (proverCost / MONTH_HOURS) * hours;
 
   // Calculate sequencer profit
-  const totalRevenue = priorityFeeUsd + baseFeeUsd;
+  const totalRevenue = priorityFeeUsd + baseFeeSeqUsd;
   const totalCosts = cloudCostScaled + proverCostScaled;
   const sequencerProfit = Math.max(0, totalRevenue - totalCosts);
 
@@ -98,6 +101,7 @@ export const FeeFlowChart: React.FC<FeeFlowChartProps> = ({
       { name: 'Cloud Cost', value: cloudCostScaled },
       { name: 'Prover Cost', value: proverCostScaled },
       { name: 'Profit', value: sequencerProfit },
+      { name: 'Taiko DAO', value: baseFeeDaoUsd },
     ],
     links: [
       {
@@ -108,7 +112,12 @@ export const FeeFlowChart: React.FC<FeeFlowChartProps> = ({
       {
         source: 1,
         target: 2,
-        value: baseFeeUsd,
+        value: baseFeeSeqUsd,
+      },
+      {
+        source: 1,
+        target: 6,
+        value: baseFeeDaoUsd,
       },
       {
         source: 2,
@@ -125,7 +134,7 @@ export const FeeFlowChart: React.FC<FeeFlowChartProps> = ({
         target: 5,
         value: sequencerProfit,
       },
-    ].filter(link => link.value > 0), // Only show links with positive values
+    ].filter((link) => link.value > 0), // Only show links with positive values
   };
 
   const formatTooltipValue = (value: number) => formatUsd(value);

--- a/dashboard/components/ProfitRankingTable.tsx
+++ b/dashboard/components/ProfitRankingTable.tsx
@@ -73,7 +73,7 @@ export const ProfitRankingTable: React.FC<ProfitRankingTableProps> = ({
     }
     const revenueEth =
       ((fees.priority_fee ?? 0) +
-        (fees.base_fee ?? 0) -
+        (fees.base_fee ?? 0) * 0.75 -
         (fees.l1_data_cost ?? 0)) /
       1e18;
     const profit = revenueEth * ethPrice - costPerSeq;

--- a/dashboard/tests/profitRankingTable.test.ts
+++ b/dashboard/tests/profitRankingTable.test.ts
@@ -14,11 +14,13 @@ describe('ProfitRankingTable', () => {
         data: { data: [{ name: 'SeqA', value: 10, tps: null }] },
       } as any)
       .mockReturnValueOnce({
-        data: [{
-          priority_fee: 2e18,
-          base_fee: 1e18,
-          l1_data_cost: 0,
-        }],
+        data: [
+          {
+            priority_fee: 2e18,
+            base_fee: 1e18,
+            l1_data_cost: 0,
+          },
+        ],
       } as any);
     vi.spyOn(api, 'fetchSequencerDistribution').mockResolvedValue({
       data: [{ name: 'SeqA', value: 10, tps: null }],
@@ -42,6 +44,6 @@ describe('ProfitRankingTable', () => {
       }),
     );
     expect(html.includes('Sequencer Profit Ranking')).toBe(true);
-    expect(html.includes('3,000')).toBe(true);
+    expect(html.includes('2,750')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- remove `* 3 / 4` reduction when fetching base fee from ClickHouse
- document base fee fields as full value
- update profit ranking and fee flow chart to apply 75% split in dashboard
- adjust profit ranking test

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6852810363688328ab1ea4cc56691675