### PR TITLE
Show toast when ETH price fetch fails

### DIFF
--- a/dashboard/services/priceService.ts
+++ b/dashboard/services/priceService.ts
@@ -22,6 +22,7 @@ export const getEthPrice = async (): Promise<number> => {
   const data = await res.json();
   const price = data?.ethereum?.usd;
   if (typeof price !== 'number') {
+    showToast('Failed to fetch ETH price');
     throw new Error('Invalid ETH price response format');
   }
 
@@ -33,25 +34,25 @@ export const useEthPrice = () => {
     typeof localStorage === 'undefined'
       ? undefined
       : (() => {
-          const cached = localStorage.getItem(CACHE_KEY);
-          if (cached) {
-            try {
-              const { price, timestamp } = JSON.parse(cached) as {
-                price: number;
-                timestamp: number;
-              };
-              if (
-                Date.now() - timestamp < 3600_000 &&
-                typeof price === 'number'
-              ) {
-                return price;
-              }
-            } catch {
-              // ignore malformed cache
+        const cached = localStorage.getItem(CACHE_KEY);
+        if (cached) {
+          try {
+            const { price, timestamp } = JSON.parse(cached) as {
+              price: number;
+              timestamp: number;
+            };
+            if (
+              Date.now() - timestamp < 3600_000 &&
+              typeof price === 'number'
+            ) {
+              return price;
             }
+          } catch {
+            // ignore malformed cache
           }
-          return undefined;
-        })();
+        }
+        return undefined;
+      })();
 
   const swr = useSWR<number>('ethPrice', getEthPrice, {
     revalidateOnFocus: false,

--- a/dashboard/services/priceService.ts
+++ b/dashboard/services/priceService.ts
@@ -1,73 +1,79 @@
-import useSWR from 'swr'
-import { useEffect } from 'react'
+import useSWR from 'swr';
+import { useEffect } from 'react';
+import { showToast } from '../utils/toast';
 
-const CACHE_KEY = 'ethPrice'
+const CACHE_KEY = 'ethPrice';
 const API_URL =
-  'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd'
+  'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd';
 
 export const getEthPrice = async (): Promise<number> => {
-  let res: Response
+  let res: Response;
   try {
-    res = await fetch(API_URL)
+    res = await fetch(API_URL);
   } catch {
-    return 0
+    showToast('Failed to fetch ETH price');
+    return 0;
   }
   if (!res.ok) {
-    throw new Error(`Failed to fetch ETH price: ${res.status}`)
+    showToast('Failed to fetch ETH price');
+    throw new Error(`Failed to fetch ETH price: ${res.status}`);
   }
 
-  const data = await res.json()
-  const price = data?.ethereum?.usd
+  const data = await res.json();
+  const price = data?.ethereum?.usd;
   if (typeof price !== 'number') {
-    throw new Error('Invalid ETH price response format')
+    throw new Error('Invalid ETH price response format');
   }
 
-  return price
-}
+  return price;
+};
 
 export const useEthPrice = () => {
-  const fallbackData = typeof localStorage === 'undefined'
-    ? undefined
-    : (() => {
-        const cached = localStorage.getItem(CACHE_KEY)
-        if (cached) {
-          try {
-            const { price, timestamp } = JSON.parse(cached) as {
-              price: number
-              timestamp: number
+  const fallbackData =
+    typeof localStorage === 'undefined'
+      ? undefined
+      : (() => {
+          const cached = localStorage.getItem(CACHE_KEY);
+          if (cached) {
+            try {
+              const { price, timestamp } = JSON.parse(cached) as {
+                price: number;
+                timestamp: number;
+              };
+              if (
+                Date.now() - timestamp < 3600_000 &&
+                typeof price === 'number'
+              ) {
+                return price;
+              }
+            } catch {
+              // ignore malformed cache
             }
-            if (
-              Date.now() - timestamp < 3600_000 &&
-              typeof price === 'number'
-            ) {
-              return price
-            }
-          } catch {
-            // ignore malformed cache
           }
-        }
-        return undefined
-      })()
+          return undefined;
+        })();
 
   const swr = useSWR<number>('ethPrice', getEthPrice, {
     revalidateOnFocus: false,
     fallbackData,
-  })
+  });
 
   useEffect(() => {
     if (typeof localStorage !== 'undefined' && swr.data !== undefined) {
       try {
         localStorage.setItem(
           CACHE_KEY,
-          JSON.stringify({ price: swr.data, timestamp: Date.now() })
-        )
+          JSON.stringify({ price: swr.data, timestamp: Date.now() }),
+        );
       } catch {
         // ignore storage errors
       }
     }
-  }, [swr.data])
+  }, [swr.data]);
 
-  const error = swr.error ?? (swr.data === 0 ? new Error('ETH price unavailable') : undefined)
+  const error =
+    swr.error ??
+    (swr.data === 0 ? new Error('ETH price unavailable') : undefined);
 
-  return { ...swr, error }
-}
+  return { ...swr, error };
+};

--- a/dashboard/tests/priceService.test.ts
+++ b/dashboard/tests/priceService.test.ts
@@ -1,53 +1,70 @@
-import { describe, it, expect, afterEach, vi } from 'vitest'
-import { getEthPrice } from '../services/priceService.ts'
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import * as toast from '../utils/toast';
+import { getEthPrice } from '../services/priceService.ts';
 
-const originalFetch = globalThis.fetch
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  vi.stubGlobal('window', {
+    dispatchEvent: vi.fn(),
+  });
+});
 
 function mockFetch(price: number, ok = true) {
   return vi.fn(async () => ({
     ok,
     status: ok ? 200 : 500,
     json: async () => ({ ethereum: { usd: price } }),
-  })) as unknown as typeof fetch
+  })) as unknown as typeof fetch;
 }
 
 function mockFetchWithInvalidResponse() {
   return vi.fn(async () => ({
     ok: true,
     json: async () => ({ invalid: 'response' }),
-  })) as unknown as typeof fetch
+  })) as unknown as typeof fetch;
 }
 
 function mockFetchWithNetworkError() {
   return vi.fn(async () => {
-    throw new Error('network error')
-  }) as unknown as typeof fetch
+    throw new Error('network error');
+  }) as unknown as typeof fetch;
 }
 
 afterEach(() => {
-  globalThis.fetch = originalFetch
-})
+  globalThis.fetch = originalFetch;
+});
 
 describe('getEthPrice', () => {
   it('fetches price successfully', async () => {
-    globalThis.fetch = mockFetch(2000)
-    const price = await getEthPrice()
-    expect(price).toBe(2000)
-  })
+    globalThis.fetch = mockFetch(2000);
+    const price = await getEthPrice();
+    expect(price).toBe(2000);
+  });
 
   it('handles fetch failure', async () => {
-    globalThis.fetch = mockFetch(0, false)
-    await expect(getEthPrice()).rejects.toThrow('Failed to fetch ETH price: 500')
-  })
+    globalThis.fetch = mockFetch(0, false);
+    const spy = vi.spyOn(toast, 'showToast').mockImplementation(() => {});
+    await expect(getEthPrice()).rejects.toThrow(
+      'Failed to fetch ETH price: 500',
+    );
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
 
   it('returns 0 on network error', async () => {
-    globalThis.fetch = mockFetchWithNetworkError()
-    const price = await getEthPrice()
-    expect(price).toBe(0)
-  })
+    globalThis.fetch = mockFetchWithNetworkError();
+    const spy = vi.spyOn(toast, 'showToast').mockImplementation(() => {});
+    const price = await getEthPrice();
+    expect(price).toBe(0);
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
 
   it('handles invalid response format', async () => {
-    globalThis.fetch = mockFetchWithInvalidResponse()
-    await expect(getEthPrice()).rejects.toThrow('Invalid ETH price response format')
-  })
-})
+    globalThis.fetch = mockFetchWithInvalidResponse();
+    await expect(getEthPrice()).rejects.toThrow(
+      'Invalid ETH price response format',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- notify users when ETH price fetch fails
- update ETH price tests to expect toast messages

## Testing
- `npm run lint:whitespace`
- `npm run format`
- `npm run check`
- `npm run test`
- `just ci` *(fails: `cargo` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685282593bf88328860e4a88e18846ba