### PR TITLE
Fix import.meta.env typing in dashboard

### DIFF
--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -1,4 +1,4 @@
-const metaEnv = import.meta.env as any;
+const metaEnv = import.meta.env as ImportMetaEnv;
 export const API_BASE: string =
   (metaEnv.VITE_API_BASE ?? metaEnv.API_BASE ?? '') + '/v1';
 


### PR DESCRIPTION
## Summary
- use `ImportMetaEnv` instead of `any` for API service env

## Testing
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_6852826eabfc8328b2cda71e858e86de