### PR TITLE
Add per-sequencer fee data support

### DIFF
--- a/dashboard/components/FeeFlowChart.tsx
+++ b/dashboard/components/FeeFlowChart.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ResponsiveContainer, Sankey, Tooltip } from 'recharts';
 import useSWR from 'swr';
-import { fetchDashboardData } from '../services/apiService';
+import { fetchL2Fees } from '../services/apiService';
 import { useEthPrice } from '../services/priceService';
 import { TimeRange } from '../types';
 import { rangeToHours } from '../utils/timeRange';
@@ -60,13 +60,13 @@ export const FeeFlowChart: React.FC<FeeFlowChartProps> = ({
   proverCost,
   address,
 }) => {
-  const { data: dashRes } = useSWR(['dashboardData', timeRange, address], () =>
-    fetchDashboardData(timeRange, address),
+  const { data: feeRes } = useSWR(['l2FeesFlow', timeRange, address], () =>
+    fetchL2Fees(timeRange, address),
   );
   const { data: ethPrice = 0 } = useEthPrice();
 
-  const priorityFee = dashRes?.data?.priority_fee ?? null;
-  const baseFee = dashRes?.data?.base_fee ?? null;
+  const priorityFee = feeRes?.data?.priority_fee ?? null;
+  const baseFee = feeRes?.data?.base_fee ?? null;
 
   if (priorityFee == null && baseFee == null) {
     return (

--- a/dashboard/tests/profitRankingTable.test.ts
+++ b/dashboard/tests/profitRankingTable.test.ts
@@ -5,6 +5,7 @@ import * as swr from 'swr';
 vi.mock('swr', () => ({ default: vi.fn() }));
 import * as api from '../services/apiService';
 import * as priceService from '../services/priceService';
+import * as seqCfg from '../sequencerConfig';
 import { ProfitRankingTable } from '../components/ProfitRankingTable';
 
 describe('ProfitRankingTable', () => {
@@ -14,14 +15,21 @@ describe('ProfitRankingTable', () => {
         data: { data: [{ name: 'SeqA', value: 10, tps: null }] },
       } as any)
       .mockReturnValueOnce({
-        data: [
-          {
+        data: {
+          data: {
             priority_fee: 2e18,
             base_fee: 1e18,
             l1_data_cost: 0,
-            sequencers: [],
+            sequencers: [
+              {
+                address: '0xseq',
+                priority_fee: 2e18,
+                base_fee: 1e18,
+                l1_data_cost: 0,
+              },
+            ],
           },
-        ],
+        },
       } as any);
     vi.spyOn(api, 'fetchSequencerDistribution').mockResolvedValue({
       data: [{ name: 'SeqA', value: 10, tps: null }],
@@ -29,13 +37,26 @@ describe('ProfitRankingTable', () => {
       error: null,
     } as any);
     vi.spyOn(api, 'fetchL2Fees').mockResolvedValue({
-      data: { priority_fee: 2e18, base_fee: 1e18, l1_data_cost: 0, sequencers: [] },
+      data: {
+        priority_fee: 2e18,
+        base_fee: 1e18,
+        l1_data_cost: 0,
+        sequencers: [
+          {
+            address: '0xseq',
+            priority_fee: 2e18,
+            base_fee: 1e18,
+            l1_data_cost: 0,
+          },
+        ],
+      },
       badRequest: false,
       error: null,
     } as any);
     vi.spyOn(priceService, 'useEthPrice').mockReturnValue({
       data: 1000,
     } as any);
+    vi.spyOn(seqCfg, 'getSequencerAddress').mockReturnValue('0xseq');
 
     const html = renderToStaticMarkup(
       React.createElement(ProfitRankingTable, {


### PR DESCRIPTION
## Summary
- use `l2-fees` endpoint for FeeFlowChart
- retrieve all sequencer fee info for ProfitRankingTable
- update ProfitRankingTable test to cover new data shape

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68528c1df880832897ffbd9dae849c05