### PR TITLE
Add pagination for reorg events

### DIFF
--- a/dashboard/config/tableConfig.ts
+++ b/dashboard/config/tableConfig.ts
@@ -79,6 +79,7 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
       })),
     urlKey: 'reorgs',
     reverseOrder: true,
+    supportsPagination: true,
   },
 
   slashings: {


### PR DESCRIPTION
## Summary
- support pagination on `/reorgs` API
- allow dashboard to paginate reorg table
- expose pagination control in table config

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68528c9477048328aca43b244828c013