### PR TITLE
Switch FeeFlowChart to use taiko pink

### DIFF
--- a/dashboard/components/FeeFlowChart.tsx
+++ b/dashboard/components/FeeFlowChart.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { ResponsiveContainer, Sankey, Tooltip } from 'recharts';
+import { TAIKO_PINK } from '../theme';
 import useSWR from 'swr';
 import { fetchL2Fees } from '../services/apiService';
 import { useEthPrice } from '../services/priceService';
@@ -31,7 +32,7 @@ const SankeyNode = ({ x, y, width, height, payload }: any) => {
         y={y}
         width={width}
         height={height}
-        fill="#10b981"
+        fill={TAIKO_PINK}
         fillOpacity={0.8}
       />
       <text


### PR DESCRIPTION
## Summary
- colorize FeeFlowChart nodes using the project pink instead of green

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68529dc66ef88328bcadc26d80bc47ef