### PR TITLE
Add sortable Profit Ranking table

### DIFF
--- a/dashboard/components/ProfitRankingTable.tsx
+++ b/dashboard/components/ProfitRankingTable.tsx
@@ -94,9 +94,10 @@ export const ProfitRankingTable: React.FC<ProfitRankingTableProps> = ({
       const aVal = a[sortBy];
       const bVal = b[sortBy];
       let cmp = 0;
-      if (typeof aVal === 'number' && typeof bVal === 'number') {
-        const safeA = aVal ?? -Infinity;
-        const safeB = bVal ?? -Infinity;
+      // Handle numeric columns (blocks and profit) including null values
+      if (sortBy === 'blocks' || sortBy === 'profit') {
+        const safeA = (typeof aVal === 'number' ? aVal : null) ?? -Infinity;
+        const safeB = (typeof bVal === 'number' ? bVal : null) ?? -Infinity;
         cmp = safeA - safeB;
       } else {
         cmp = String(aVal).localeCompare(String(bVal), undefined, {

--- a/dashboard/components/ProfitRankingTable.tsx
+++ b/dashboard/components/ProfitRankingTable.tsx
@@ -95,7 +95,9 @@ export const ProfitRankingTable: React.FC<ProfitRankingTableProps> = ({
       const bVal = b[sortBy];
       let cmp = 0;
       if (typeof aVal === 'number' && typeof bVal === 'number') {
-        cmp = (aVal ?? -Infinity) - (bVal ?? -Infinity);
+        const safeA = aVal ?? -Infinity;
+        const safeB = bVal ?? -Infinity;
+        cmp = safeA - safeB;
       } else {
         cmp = String(aVal).localeCompare(String(bVal), undefined, {
           numeric: true,


### PR DESCRIPTION
## Summary
- add sorting logic to ProfitRankingTable
- show sort indicators and click handlers
- update tests to cover default sort order

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68529daed0f48328951e4fce42f8351a