### PR TITLE
Fix rounding of large fee values

### DIFF
--- a/dashboard/tests/utils.test.ts
+++ b/dashboard/tests/utils.test.ts
@@ -132,6 +132,9 @@ describe('utils', () => {
     expect(formatEth(0)).toBe('0.00 ETH');
     expect(formatEth(1e8)).toBe('0.10 Gwei');
     expect(formatEth(1334501e9)).toBe('1,334,501 Gwei');
+    expect(formatEth(1422636.1e9)).toBe('1,422,636 Gwei');
+    expect(formatEth(1422636.1e18)).toBe('1,422,636 ETH');
+    expect(formatEth(187788.9e9)).toBe('187,788 Gwei');
   });
 
   it('parses ETH and Gwei values', () => {

--- a/dashboard/utils.ts
+++ b/dashboard/utils.ts
@@ -89,9 +89,15 @@ export const formatWithCommas = (value: number): string =>
 
 export const formatEth = (wei: number): string => {
   const eth = wei / 1e18;
+  if (Math.abs(eth) >= 1000) {
+    return `${Math.trunc(eth).toLocaleString()} ETH`;
+  }
   const ethFormatted = formatDecimal(eth);
   if (wei !== 0 && ethFormatted === '0.00') {
     const gwei = wei / 1e9;
+    if (Math.abs(gwei) >= 1000) {
+      return `${Math.trunc(gwei).toLocaleString()} Gwei`;
+    }
     const gweiFormatted = Number.isInteger(gwei)
       ? gwei.toLocaleString()
       : formatDecimal(gwei);


### PR DESCRIPTION
## Summary
- round large ETH or gwei values in `formatEth`
- test rounding for large values

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6852b35d537c8328a396d5f1f3376d4e