### PR TITLE
Add pagination for prove & verify times

### DIFF
--- a/dashboard/config/tableConfig.ts
+++ b/dashboard/config/tableConfig.ts
@@ -193,6 +193,7 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
     },
     urlKey: 'prove-time',
     reverseOrder: true,
+    supportsPagination: true,
   },
 
   'verify-time': {
@@ -222,6 +223,7 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
     },
     urlKey: 'verify-time',
     reverseOrder: true,
+    supportsPagination: true,
   },
 
   'block-tx': {

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -299,8 +299,21 @@ export const fetchL1HeadNumber = async (): Promise<RequestResult<number>> => {
 
 export const fetchProveTimes = async (
   range: TimeRange,
+  limit = 50,
+  startingAfter?: number,
+  endingBefore?: number,
 ): Promise<RequestResult<TimeSeriesData[]>> => {
-  const url = `${API_BASE}/prove-times?${timeRangeToQuery(range)}`;
+  let url = `${API_BASE}/prove-times?`;
+  if (startingAfter === undefined && endingBefore === undefined) {
+    url += `${timeRangeToQuery(range)}&limit=${limit}`;
+  } else {
+    url += `limit=${limit}`;
+  }
+  if (startingAfter !== undefined) {
+    url += `&starting_after=${startingAfter}`;
+  } else if (endingBefore !== undefined) {
+    url += `&ending_before=${endingBefore}`;
+  }
   const res = await fetchJson<{
     batches: { batch_id: number; seconds_to_prove: number }[];
   }>(url);
@@ -319,8 +332,21 @@ export const fetchProveTimes = async (
 
 export const fetchVerifyTimes = async (
   range: TimeRange,
+  limit = 50,
+  startingAfter?: number,
+  endingBefore?: number,
 ): Promise<RequestResult<TimeSeriesData[]>> => {
-  const url = `${API_BASE}/verify-times?${timeRangeToQuery(range)}`;
+  let url = `${API_BASE}/verify-times?`;
+  if (startingAfter === undefined && endingBefore === undefined) {
+    url += `${timeRangeToQuery(range)}&limit=${limit}`;
+  } else {
+    url += `limit=${limit}`;
+  }
+  if (startingAfter !== undefined) {
+    url += `&starting_after=${startingAfter}`;
+  } else if (endingBefore !== undefined) {
+    url += `&ending_before=${endingBefore}`;
+  }
   const res = await fetchJson<{
     batches: { batch_id: number; seconds_to_verify: number }[];
   }>(url);

--- a/dashboard/tests/app.integration.test.ts
+++ b/dashboard/tests/app.integration.test.ts
@@ -112,16 +112,16 @@ const responses: Record<string, Record<string, unknown>> = {
       { block_number: 52, minute: 2 },
     ],
   },
-  [`/v1/prove-times?${q1h}`]: {
+  [`/v1/prove-times?${q1h}&limit=50`]: {
     batches: [{ batch_id: 1, seconds_to_prove: 3 }],
   },
-  [`/v1/prove-times?${q15m}`]: {
+  [`/v1/prove-times?${q15m}&limit=50`]: {
     batches: [{ batch_id: 1, seconds_to_prove: 3 }],
   },
-  [`/v1/verify-times?${q1h}`]: {
+  [`/v1/verify-times?${q1h}&limit=50`]: {
     batches: [{ batch_id: 1, seconds_to_verify: 4 }],
   },
-  [`/v1/verify-times?${q15m}`]: {
+  [`/v1/verify-times?${q15m}&limit=50`]: {
     batches: [{ batch_id: 1, seconds_to_verify: 4 }],
   },
   [`/v1/l2-gas-used?${q1h}&limit=50`]: {


### PR DESCRIPTION
## Summary
- support pagination for prove/verify times in API
- expose new paginated queries in ClickHouse reader
- update dashboard API service helpers and table config
- adjust integration tests for new endpoints

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6852b5bec9fc832897d70a45ffe663ac