### PR TITLE
Implement pagination for Blobs per Batch table

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -27,7 +27,7 @@ use utoipa::OpenApi;
         routes::core::active_gateways,
         routes::core::batch_posting_times,
         routes::core::avg_blobs_per_batch,
-        routes::core::blobs_per_batch,
+        routes::table::blobs_per_batch,
         routes::core::prove_times,
         routes::core::verify_times,
         routes::core::l1_block_times,

--- a/crates/api/src/routes/core.rs
+++ b/crates/api/src/routes/core.rs
@@ -9,11 +9,11 @@ use crate::{
 };
 use alloy_primitives::Address;
 use api_types::{
-    ActiveGatewaysResponse, AvgBlobsPerBatchResponse, BatchBlobsResponse,
-    BatchPostingTimesResponse, ErrorResponse, L1BlockTimesResponse, L1DataCostResponse,
-    L1HeadBlockResponse, L1HeadResponse, L2HeadBlockResponse, L2HeadResponse, ProveTimesResponse,
-    SequencerBlocksItem, SequencerBlocksResponse, SequencerDistributionItem,
-    SequencerDistributionResponse, VerifyTimesResponse,
+    ActiveGatewaysResponse, AvgBlobsPerBatchResponse, BatchPostingTimesResponse, ErrorResponse,
+    L1BlockTimesResponse, L1DataCostResponse, L1HeadBlockResponse, L1HeadResponse,
+    L2HeadBlockResponse, L2HeadResponse, ProveTimesResponse, SequencerBlocksItem,
+    SequencerBlocksResponse, SequencerDistributionItem, SequencerDistributionResponse,
+    VerifyTimesResponse,
 };
 use axum::{
     Json,
@@ -209,42 +209,6 @@ pub async fn avg_blobs_per_batch(
     };
     tracing::info!(avg_blobs_per_batch = ?avg, "Returning avg blobs per batch");
     Ok(Json(AvgBlobsPerBatchResponse { avg_blobs: avg }))
-}
-
-#[utoipa::path(
-    get,
-    path = "/blobs-per-batch",
-    params(
-        RangeQuery
-    ),
-    responses(
-        (status = 200, description = "Blobs per batch", body = BatchBlobsResponse),
-        (status = 500, description = "Database error", body = ErrorResponse)
-    ),
-    tag = "taikoscope"
-)]
-/// Get detailed blob count information for each batch in the specified time range
-pub async fn blobs_per_batch(
-    Query(params): Query<RangeQuery>,
-    State(state): State<ApiState>,
-) -> Result<Json<BatchBlobsResponse>, ErrorResponse> {
-    // Validate time range parameters
-    validate_time_range(&params.time_range)?;
-
-    // Check for range exclusivity
-    let has_time_range = has_time_range_params(&params.time_range);
-    validate_range_exclusivity(has_time_range, false)?;
-
-    let time_range = resolve_time_range_enum(&params.range, &params.time_range);
-    let batches = match state.client.get_blobs_per_batch(time_range).await {
-        Ok(rows) => rows,
-        Err(e) => {
-            tracing::error!(error = %e, "Failed to get blobs per batch");
-            return Err(ErrorResponse::database_error());
-        }
-    };
-    tracing::info!(count = batches.len(), "Returning blobs per batch");
-    Ok(Json(BatchBlobsResponse { batches }))
 }
 
 #[utoipa::path(

--- a/crates/clickhouse/src/reader.rs
+++ b/crates/clickhouse/src/reader.rs
@@ -1578,6 +1578,37 @@ impl ClickhouseReader {
         Ok(rows)
     }
 
+    /// Get the blob count per batch since the given cutoff time with cursor-based pagination.
+    /// Results are returned in descending order by batch id.
+    pub async fn get_blobs_per_batch_paginated(
+        &self,
+        since: DateTime<Utc>,
+        limit: u64,
+        starting_after: Option<u64>,
+        ending_before: Option<u64>,
+    ) -> Result<Vec<BatchBlobCountRow>> {
+        let mut query = format!(
+            "SELECT b.l1_block_number, b.batch_id, b.blob_count \
+             FROM {db}.batches b \
+             INNER JOIN {db}.l1_head_events l1_events \
+               ON b.l1_block_number = l1_events.l1_block_number \
+             WHERE l1_events.block_ts >= {since}",
+            since = since.timestamp(),
+            db = self.db_name,
+        );
+        if let Some(start) = starting_after {
+            query.push_str(&format!(" AND b.batch_id < {}", start));
+        }
+        if let Some(end) = ending_before {
+            query.push_str(&format!(" AND b.batch_id > {}", end));
+        }
+        query.push_str(" ORDER BY b.batch_id DESC");
+        query.push_str(&format!(" LIMIT {}", limit));
+
+        let rows = self.execute::<BatchBlobCountRow>(&query).await?;
+        Ok(rows)
+    }
+
     /// Get the average number of blobs per batch for the given range
     pub async fn get_avg_blobs_per_batch(&self, range: TimeRange) -> Result<Option<f64>> {
         #[derive(Row, Deserialize)]

--- a/dashboard/config/tableConfig.ts
+++ b/dashboard/config/tableConfig.ts
@@ -147,6 +147,7 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
         blobs: d.blobs.toLocaleString(),
       })),
     urlKey: 'blobs-per-batch',
+    supportsPagination: true,
   },
 
   'batch-posting-cadence': {

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -664,8 +664,21 @@ export interface BatchBlobCount {
 
 export const fetchBatchBlobCounts = async (
   range: TimeRange,
+  limit = 50,
+  startingAfter?: number,
+  endingBefore?: number,
 ): Promise<RequestResult<BatchBlobCount[]>> => {
-  const url = `${API_BASE}/blobs-per-batch?${timeRangeToQuery(range)}`;
+  let url = `${API_BASE}/blobs-per-batch?`;
+  if (startingAfter === undefined && endingBefore === undefined) {
+    url += `${timeRangeToQuery(range)}&limit=${limit}`;
+  } else {
+    url += `limit=${limit}`;
+  }
+  if (startingAfter !== undefined) {
+    url += `&starting_after=${startingAfter}`;
+  } else if (endingBefore !== undefined) {
+    url += `&ending_before=${endingBefore}`;
+  }
   const res = await fetchJson<{
     batches: {
       l1_block_number?: number;


### PR DESCRIPTION
## Summary
- add paginated `get_blobs_per_batch_paginated` query
- expose `/blobs-per-batch` via paginated API route
- use new endpoint in OpenAPI router
- support pagination in dashboard API service
- enable pagination in table config

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6852b5ab358c83289f6afa4f608ede0e