### PR TITLE
Ensure deterministic ordering for gateways

### DIFF
--- a/crates/clickhouse/src/reader.rs
+++ b/crates/clickhouse/src/reader.rs
@@ -7,7 +7,7 @@ use derive_more::Debug;
 use eyre::{Context, Result};
 use hex::encode;
 use serde::{Deserialize, Serialize};
-use std::time::Instant;
+use std::{collections::BTreeSet, time::Instant};
 use tracing::{debug, error};
 use url::Url;
 
@@ -592,7 +592,7 @@ impl ClickhouseReader {
         }
 
         let rows = result?;
-        let mut set = std::collections::HashSet::new();
+        let mut set = BTreeSet::new();
         for row in rows {
             for cand in row.candidates {
                 set.insert(cand);


### PR DESCRIPTION
## Summary
- use `BTreeSet` in `get_active_gateways_since`

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6852bc6176bc832887a189789eb4f4c4