### PR TITLE
Enable economics button on Hekla

### DIFF
--- a/dashboard/components/DashboardHeader.tsx
+++ b/dashboard/components/DashboardHeader.tsx
@@ -27,6 +27,7 @@ const NETWORK_NAME =
   rawNetworkName.charAt(0).toUpperCase() +
   rawNetworkName.slice(1).toLowerCase();
 const SHOW_CUSTOM_TIME_PICKER = rawNetworkName.toLowerCase() !== 'hekla';
+const SHOW_ECONOMICS_BUTTON = rawNetworkName.toLowerCase() === 'hekla';
 const DASHBOARD_TITLE = `Taikoscope ${NETWORK_NAME}`;
 
 interface DashboardHeaderProps {
@@ -54,7 +55,7 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({
   selectedSequencer,
   onSequencerChange,
 }) => {
-  const { navigateToDashboard } = useRouterNavigation();
+  const { navigateToDashboard, updateSearchParams } = useRouterNavigation();
   const { errorMessage } = useErrorHandler();
   const [searchParams] = useSearchParams();
   const isEconomicsView = searchParams.get('view') === 'economics';
@@ -79,8 +80,22 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({
         </h1>
       </div>
       <div className="flex flex-wrap items-center gap-2 mt-4 md:mt-0 justify-center md:justify-end">
-        {/* Economics view is still supported via URL parameters, but the
-            navigation button is hidden. */}
+        {SHOW_ECONOMICS_BUTTON && (
+          <button
+            onClick={() => {
+              const params = new URLSearchParams(searchParams);
+              if (params.get('view') === 'economics') {
+                navigateToDashboard(true);
+                return;
+              }
+              updateSearchParams({ view: 'economics', table: null });
+            }}
+            className="text-sm hover:underline"
+            style={{ color: TAIKO_PINK }}
+          >
+            Economics
+          </button>
+        )}
         <a
           href="https://status.taiko.xyz/"
           target="_blank"


### PR DESCRIPTION
## Summary
- show economics view button when running on Hekla network

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6852bab775ec83288f4946df4ce2fceb