### PR TITLE
Fix metric card mobile text size

### DIFF
--- a/dashboard/components/MetricCard.tsx
+++ b/dashboard/components/MetricCard.tsx
@@ -28,7 +28,7 @@ export const MetricCard: React.FC<MetricCardProps> = ({
       className={`bg-white dark:bg-gray-800 p-4 rounded-lg border border-gray-200 dark:border-gray-700 transition-shadow duration-200 ${isAddress ? 'min-w-0 w-full col-span-2 sm:col-span-2 md:col-span-2 lg:col-span-2 xl:col-span-2 2xl:col-span-2' : ''} ${className ?? ''}`.trim()}
     >
       <div className="relative">
-        <h3 className="text-sm font-medium text-gray-500 dark:text-gray-400 truncate pr-8">
+        <h3 className="text-xs sm:text-sm font-medium text-gray-500 dark:text-gray-400 truncate pr-8">
           {title}
         </h3>
         {onMore && (


### PR DESCRIPTION
## Summary
- make metric titles smaller on mobile so full name is visible

## Testing
- `npm run check`
- `npm run lint:whitespace`
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_68554dc91c0c8328bd0ab8511ee0bef3