### PR TITLE
Reduce chart padding on mobile

### DIFF
--- a/dashboard/components/BatchProcessChart.tsx
+++ b/dashboard/components/BatchProcessChart.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useIsMobile } from '../hooks/useIsMobile';
 import {
   LineChart,
   Line,
@@ -35,12 +36,18 @@ const BatchProcessChartComponent: React.FC<BatchProcessChartProps> = ({
   const { showHours, showMinutes } = computeBatchDurationFlags(data);
   const formatValue = (value: number) =>
     formatBatchDuration(value, showHours, showMinutes);
+  const isMobile = useIsMobile();
 
   return (
     <ResponsiveContainer width="100%" height="100%">
       <LineChart
         data={data}
-        margin={{ top: 5, right: 20, left: 20, bottom: 40 }}
+        margin={{
+          top: 5,
+          right: isMobile ? 10 : 20,
+          left: isMobile ? 10 : 20,
+          bottom: 40,
+        }}
       >
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis

--- a/dashboard/components/BlobsPerBatchChart.tsx
+++ b/dashboard/components/BlobsPerBatchChart.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useIsMobile } from '../hooks/useIsMobile';
 import {
   BarChart,
   Bar,
@@ -27,11 +28,18 @@ const BlobsPerBatchChartComponent: React.FC<BlobsPerBatchChartProps> = ({
     );
   }
 
+  const isMobile = useIsMobile();
+
   return (
     <ResponsiveContainer width="100%" height="100%">
       <BarChart
         data={data}
-        margin={{ top: 5, right: 20, left: 20, bottom: 40 }}
+        margin={{
+          top: 5,
+          right: isMobile ? 10 : 20,
+          left: isMobile ? 10 : 20,
+          bottom: 40,
+        }}
       >
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis

--- a/dashboard/components/BlockTimeChart.tsx
+++ b/dashboard/components/BlockTimeChart.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useIsMobile } from '../hooks/useIsMobile';
 import {
   LineChart,
   Line,
@@ -40,11 +41,17 @@ const BlockTimeChartComponent: React.FC<BlockTimeChartProps> = ({
   }
   const { showHours, showMinutes } = computeIntervalFlags(data, seconds);
   const ChartComponent = histogram ? BarChart : LineChart;
+  const isMobile = useIsMobile();
   return (
     <ResponsiveContainer width="100%" height="100%">
       <ChartComponent
         data={data}
-        margin={{ top: 5, right: 20, left: 20, bottom: 40 }}
+        margin={{
+          top: 5,
+          right: isMobile ? 10 : 20,
+          left: isMobile ? 10 : 20,
+          bottom: 40,
+        }}
       >
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis

--- a/dashboard/components/BlockTimeDistributionChart.tsx
+++ b/dashboard/components/BlockTimeDistributionChart.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import { useIsMobile } from '../hooks/useIsMobile';
 import {
   BarChart,
   Bar,
@@ -16,7 +17,7 @@ const MIN_BIN_COUNT = 5;
 const MAX_BIN_COUNT = 20;
 const MIN_REASONABLE_BLOCK_TIME_MS = 0;
 const MAX_REASONABLE_BLOCK_TIME_MS = 24 * 60 * 60 * 1000; // 24 hours in milliseconds
-const CHART_MARGINS = { top: 5, right: 20, left: 20, bottom: 40 };
+const BASE_MARGINS = { top: 5, right: 20, left: 20, bottom: 40 };
 
 interface BlockTimeDistributionChartProps {
   data: TimeSeriesData[];
@@ -35,6 +36,7 @@ const BlockTimeDistributionChartComponent: React.FC<
   }
 
   const showMinutes = shouldShowMinutes(data);
+  const isMobile = useIsMobile();
 
   const distributionData = useMemo(() => {
     // Extract block times (timestamps) and filter for reasonable bounds
@@ -89,6 +91,13 @@ const BlockTimeDistributionChartComponent: React.FC<
       </div>
     );
   }
+
+  const CHART_MARGINS = {
+    top: BASE_MARGINS.top,
+    right: isMobile ? 10 : BASE_MARGINS.right,
+    left: isMobile ? 10 : BASE_MARGINS.left,
+    bottom: BASE_MARGINS.bottom,
+  };
 
   return (
     <ResponsiveContainer width="100%" height="100%">

--- a/dashboard/components/BlockTxChart.tsx
+++ b/dashboard/components/BlockTxChart.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import { useIsMobile } from '../hooks/useIsMobile';
 import {
   LineChart,
   Line,
@@ -31,11 +32,17 @@ const BlockTxChartComponent: React.FC<BlockTxChartProps> = ({
     () => [...data].sort((a, b) => a.block - b.block),
     [data],
   );
+  const isMobile = useIsMobile();
   return (
     <ResponsiveContainer width="100%" height="100%">
       <LineChart
         data={sortedData}
-        margin={{ top: 5, right: 20, left: 20, bottom: 40 }}
+        margin={{
+          top: 5,
+          right: isMobile ? 10 : 20,
+          left: isMobile ? 10 : 20,
+          bottom: 40,
+        }}
       >
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis

--- a/dashboard/components/ChartCard.tsx
+++ b/dashboard/components/ChartCard.tsx
@@ -14,7 +14,7 @@ export const ChartCard: React.FC<ChartCardProps> = ({
   loading,
 }) => {
   return (
-    <div className="bg-white dark:bg-gray-800 p-4 md:p-6 rounded-lg border border-gray-200 dark:border-gray-700 relative">
+    <div className="bg-white dark:bg-gray-800 px-2 py-4 md:p-6 rounded-lg border border-gray-200 dark:border-gray-700 relative">
       <div className="flex justify-between items-start mb-4">
         <h3 className="text-lg font-semibold text-gray-700 dark:text-gray-300">
           {title}

--- a/dashboard/components/CostChart.tsx
+++ b/dashboard/components/CostChart.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useIsMobile } from '../hooks/useIsMobile';
 import {
   LineChart,
   Line,
@@ -30,6 +31,7 @@ export const CostChart: React.FC<CostChartProps> = ({
     fetchFeeComponents(timeRange, address),
   );
   const feeData: FeeComponent[] | null = feeRes?.data ?? null;
+  const isMobile = useIsMobile();
 
   if (!feeData || feeData.length === 0) {
     return (
@@ -50,7 +52,12 @@ export const CostChart: React.FC<CostChartProps> = ({
     <ResponsiveContainer width="100%" height={240}>
       <LineChart
         data={data}
-        margin={{ top: 5, right: 20, left: 20, bottom: 40 }}
+        margin={{
+          top: 5,
+          right: isMobile ? 10 : 20,
+          left: isMobile ? 10 : 20,
+          bottom: 40,
+        }}
       >
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis

--- a/dashboard/components/FeeFlowChart.tsx
+++ b/dashboard/components/FeeFlowChart.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useIsMobile } from '../hooks/useIsMobile';
 import { ResponsiveContainer, Sankey, Tooltip } from 'recharts';
 import { TAIKO_PINK } from '../theme';
 
@@ -108,6 +109,7 @@ export const FeeFlowChart: React.FC<FeeFlowChartProps> = ({
     fetchL2Fees(timeRange, address),
   );
   const { data: ethPrice = 0 } = useEthPrice();
+  const isMobile = useIsMobile();
 
   const priorityFee = feeRes?.data?.priority_fee ?? null;
   const baseFee = feeRes?.data?.base_fee ?? null;
@@ -309,7 +311,12 @@ export const FeeFlowChart: React.FC<FeeFlowChartProps> = ({
           node={SankeyNode}
           nodePadding={10}
           nodeWidth={10}
-          margin={{ top: 10, right: 120, bottom: 10, left: 10 }}
+          margin={{
+            top: 10,
+            right: isMobile ? 60 : 120,
+            bottom: 10,
+            left: 10,
+          }}
           sort={false}
           iterations={32}
           link={SankeyLink}

--- a/dashboard/components/GasUsedChart.tsx
+++ b/dashboard/components/GasUsedChart.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useIsMobile } from '../hooks/useIsMobile';
 import {
   LineChart,
   Line,
@@ -27,11 +28,17 @@ const GasUsedChartComponent: React.FC<GasUsedChartProps> = ({
       </div>
     );
   }
+  const isMobile = useIsMobile();
   return (
     <ResponsiveContainer width="100%" height="100%">
       <LineChart
         data={data}
-        margin={{ top: 5, right: 20, left: 20, bottom: 40 }}
+        margin={{
+          top: 5,
+          right: isMobile ? 10 : 20,
+          left: isMobile ? 10 : 20,
+          bottom: 40,
+        }}
       >
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis

--- a/dashboard/components/IncomeChart.tsx
+++ b/dashboard/components/IncomeChart.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useIsMobile } from '../hooks/useIsMobile';
 import {
   LineChart,
   Line,
@@ -27,6 +28,7 @@ export const IncomeChart: React.FC<IncomeChartProps> = ({
   );
   const feeData: FeeComponent[] | null = feeRes?.data ?? null;
   const { data: ethPrice = 0, error: ethPriceError } = useEthPrice();
+  const isMobile = useIsMobile();
 
   if (!feeData || feeData.length === 0) {
     return (
@@ -50,7 +52,12 @@ export const IncomeChart: React.FC<IncomeChartProps> = ({
       <ResponsiveContainer width="100%" height={240}>
         <LineChart
           data={data}
-          margin={{ top: 5, right: 20, left: 20, bottom: 40 }}
+          margin={{
+            top: 5,
+            right: isMobile ? 10 : 20,
+            left: isMobile ? 10 : 20,
+            bottom: 40,
+          }}
         >
           <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
           <XAxis

--- a/dashboard/components/MissedBlockChart.tsx
+++ b/dashboard/components/MissedBlockChart.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import { useIsMobile } from '../hooks/useIsMobile';
 import {
   BarChart,
   Bar,
@@ -30,12 +31,18 @@ const MissedBlockChartComponent: React.FC<MissedBlockChartProps> = ({
     () => [...data].sort((a, b) => a.slot - b.slot),
     [data],
   );
+  const isMobile = useIsMobile();
 
   return (
     <ResponsiveContainer width="100%" height="100%">
       <BarChart
         data={sortedData}
-        margin={{ top: 5, right: 20, left: 20, bottom: 40 }}
+        margin={{
+          top: 5,
+          right: isMobile ? 10 : 20,
+          left: isMobile ? 10 : 20,
+          bottom: 40,
+        }}
       >
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis

--- a/dashboard/components/ProfitabilityChart.tsx
+++ b/dashboard/components/ProfitabilityChart.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useIsMobile } from '../hooks/useIsMobile';
 import {
   LineChart,
   Line,
@@ -32,6 +33,7 @@ export const ProfitabilityChart: React.FC<ProfitabilityChartProps> = ({
   );
   const feeData: FeeComponent[] | null = feeRes?.data ?? null;
   const { data: ethPrice = 0, error: ethPriceError } = useEthPrice();
+  const isMobile = useIsMobile();
 
   if (!feeData || feeData.length === 0) {
     return (
@@ -60,7 +62,12 @@ export const ProfitabilityChart: React.FC<ProfitabilityChartProps> = ({
       <ResponsiveContainer width="100%" height={240}>
         <LineChart
           data={data}
-          margin={{ top: 5, right: 20, left: 20, bottom: 40 }}
+          margin={{
+            top: 5,
+            right: isMobile ? 10 : 20,
+            left: isMobile ? 10 : 20,
+            bottom: 40,
+          }}
         >
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis

--- a/dashboard/components/ReorgDepthChart.tsx
+++ b/dashboard/components/ReorgDepthChart.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useIsMobile } from '../hooks/useIsMobile';
 import {
   BarChart,
   Bar,
@@ -25,11 +26,18 @@ const ReorgDepthChartComponent: React.FC<ReorgDepthChartProps> = ({ data }) => {
     );
   }
 
+  const isMobile = useIsMobile();
+
   return (
     <ResponsiveContainer width="100%" height="100%">
       <BarChart
         data={data}
-        margin={{ top: 5, right: 20, left: 20, bottom: 40 }}
+        margin={{
+          top: 5,
+          right: isMobile ? 10 : 20,
+          left: isMobile ? 10 : 20,
+          bottom: 40,
+        }}
       >
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis

--- a/dashboard/components/TpsChart.tsx
+++ b/dashboard/components/TpsChart.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useIsMobile } from '../hooks/useIsMobile';
 import {
   LineChart,
   Line,
@@ -27,11 +28,17 @@ const TpsChartComponent: React.FC<TpsChartProps> = ({ data, lineColor }) => {
       </div>
     );
   }
+  const isMobile = useIsMobile();
   return (
     <ResponsiveContainer width="100%" height="100%">
       <LineChart
         data={data}
-        margin={{ top: 5, right: 20, left: 20, bottom: 40 }}
+        margin={{
+          top: 5,
+          right: isMobile ? 10 : 20,
+          left: isMobile ? 10 : 20,
+          bottom: 40,
+        }}
       >
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis

--- a/dashboard/hooks/useIsMobile.ts
+++ b/dashboard/hooks/useIsMobile.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+
+export const useIsMobile = (breakpoint: number = 768): boolean => {
+  const [isMobile, setIsMobile] = useState(
+    typeof window !== 'undefined' && window.innerWidth < breakpoint,
+  );
+
+  useEffect(() => {
+    const handleResize = () => {
+      if (typeof window !== 'undefined') {
+        setIsMobile(window.innerWidth < breakpoint);
+      }
+    };
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [breakpoint]);
+
+  return isMobile;
+};


### PR DESCRIPTION
## Summary
- make chart card padding more compact on small screens
- add `useIsMobile` hook
- use `useIsMobile` to shrink chart margins on mobile

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68554ffd98f483288b6c9511e456f7c9