### PR TITLE
Shorten addresses on mobile

### DIFF
--- a/dashboard/hooks/useIsMobile.ts
+++ b/dashboard/hooks/useIsMobile.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+
+export const useIsMobile = (
+  maxWidth: number = 640,
+  landscapeHeight: number = 450,
+): boolean => {
+  const [isMobile, setIsMobile] = useState(() => {
+    if (typeof window === 'undefined') {
+      return false;
+    }
+    return (
+      window.innerWidth <= maxWidth ||
+      window.innerHeight <= landscapeHeight
+    );
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    const query = `(max-width: ${maxWidth}px), (max-height: ${landscapeHeight}px)`;
+    const mql = window.matchMedia(query);
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    setIsMobile(mql.matches);
+    mql.addEventListener('change', handler);
+    return () => mql.removeEventListener('change', handler);
+  }, [maxWidth, landscapeHeight]);
+
+  return isMobile;
+};


### PR DESCRIPTION
## Summary
- add hook to detect mobile screens
- shorten sequencer addresses in FeeFlowChart when viewing on mobile
- detect landscape mobile screens too

## Testing
- `npm --prefix dashboard run lint:whitespace`
- `npm --prefix dashboard run check`
- `npm --prefix dashboard run test`
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_685550f26fac83288d5e1f2bb554976b