### PR TITLE
Remove profit prefix in flow chart profit nodes

### DIFF
--- a/dashboard/components/FeeFlowChart.tsx
+++ b/dashboard/components/FeeFlowChart.tsx
@@ -43,7 +43,7 @@ const SankeyNode = ({ x, y, width, height, payload }: any) => {
   const addressLabel = payload.addressLabel;
 
   const label = isProfitNode && addressLabel
-    ? `${payload.name} ${addressLabel}`
+    ? addressLabel
     : payload.name;
 
   return (


### PR DESCRIPTION
## Summary
- show address only on profit nodes in FeeFlowChart

## Testing
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_68555d5ce09883288d6c3b8a5bd9ca32