### PR TITLE
Fix React hook order in ProfitRankingTable

### DIFF
--- a/dashboard/components/ProfitRankingTable.tsx
+++ b/dashboard/components/ProfitRankingTable.tsx
@@ -50,6 +50,9 @@ export const ProfitRankingTable: React.FC<ProfitRankingTableProps> = ({
     return map;
   }, [feeRes]);
 
+  const [sortBy, setSortBy] = React.useState<'name' | 'blocks' | 'profit'>('profit');
+  const [sortDirection, setSortDirection] = React.useState<'asc' | 'desc'>('desc');
+
   if (!feeRes) {
     return (
       <div className="flex items-center justify-center h-20 text-gray-500 dark:text-gray-400">
@@ -81,12 +84,6 @@ export const ProfitRankingTable: React.FC<ProfitRankingTableProps> = ({
     return { name: seq.name, blocks: seq.value, profit };
   });
 
-  const [sortBy, setSortBy] = React.useState<'name' | 'blocks' | 'profit'>(
-    'profit',
-  );
-  const [sortDirection, setSortDirection] = React.useState<'asc' | 'desc'>(
-    'desc',
-  );
 
   const sorted = React.useMemo(() => {
     const data = [...rows];

--- a/dashboard/components/ProfitRankingTable.tsx
+++ b/dashboard/components/ProfitRankingTable.tsx
@@ -53,14 +53,6 @@ export const ProfitRankingTable: React.FC<ProfitRankingTableProps> = ({
   const [sortBy, setSortBy] = React.useState<'name' | 'blocks' | 'profit'>('profit');
   const [sortDirection, setSortDirection] = React.useState<'asc' | 'desc'>('desc');
 
-  if (!feeRes) {
-    return (
-      <div className="flex items-center justify-center h-20 text-gray-500 dark:text-gray-400">
-        Loading...
-      </div>
-    );
-  }
-
   const hours = rangeToHours(timeRange);
   const MONTH_HOURS = 30 * 24;
   const costPerSeq = ((cloudCost + proverCost) / MONTH_HOURS) * hours;
@@ -105,6 +97,14 @@ export const ProfitRankingTable: React.FC<ProfitRankingTableProps> = ({
     });
     return data;
   }, [rows, sortBy, sortDirection]);
+
+  if (!feeRes) {
+    return (
+      <div className="flex items-center justify-center h-20 text-gray-500 dark:text-gray-400">
+        Loading...
+      </div>
+    );
+  }
 
   const handleSort = (column: 'name' | 'blocks' | 'profit') => {
     if (sortBy === column) {


### PR DESCRIPTION
## Summary
- ensure consistent hook execution in ProfitRankingTable by declaring state before conditional return
- run CI checks

## Testing
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_685907cddaac8328acd463bf8c0ee044