### PR TITLE
Fix L2 TPS table order

### DIFF
--- a/dashboard/config/tableConfig.ts
+++ b/dashboard/config/tableConfig.ts
@@ -353,7 +353,7 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
         tps: d.tps.toFixed(2),
       })),
     urlKey: 'l2-tps',
-    reverseOrder: true,
+    reverseOrder: false,
     supportsPagination: true,
   },
 };


### PR DESCRIPTION
## Summary
- display newest blocks at top for L2 TPS table

## Testing
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_68591b9b8f948328b015c4c57e356160