### PR TITLE
Fix React error on economics view

### DIFF
--- a/dashboard/index.tsx
+++ b/dashboard/index.tsx
@@ -17,13 +17,13 @@ const root = ReactDOM.createRoot(rootElement);
 
 const app = (
   <ToastProvider>
-    <ErrorBoundary>
-      <ErrorProvider>
+    <ErrorProvider>
+      <ErrorBoundary>
         <BrowserRouter>
           <App />
         </BrowserRouter>
-      </ErrorProvider>
-    </ErrorBoundary>
+      </ErrorBoundary>
+    </ErrorProvider>
   </ToastProvider>
 );
 


### PR DESCRIPTION
## Summary
- prevent the error boundary from unmounting ErrorProvider by wrapping ErrorBoundary inside ErrorProvider

## Testing
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_68591a0d895483288009dfc5548b5eb8