### PR TITLE
Fix labels for sequencer nodes

### DIFF
--- a/dashboard/components/FeeFlowChart.tsx
+++ b/dashboard/components/FeeFlowChart.tsx
@@ -41,7 +41,7 @@ const SankeyNode = ({ x, y, width, height, payload }: any) => {
   const hideLabel = payload.hideLabel;
   const addressLabel = payload.addressLabel;
 
-  const label = isProfitNode && addressLabel ? addressLabel : payload.name;
+  const label = addressLabel ?? payload.name;
 
   return (
     <g>
@@ -252,7 +252,6 @@ export const FeeFlowChart: React.FC<FeeFlowChartProps> = ({
         addressLabel: s.shortAddress,
         value: s.revenue,
         wei: s.revenueWei,
-        hideLabel: true,
       })),
       { name: 'Cloud Cost', value: totalActualCloudCost, usd: true },
       { name: 'Prover Cost', value: totalActualProverCost, usd: true },


### PR DESCRIPTION
## Summary
- display address labels for sequencer nodes in `FeeFlowChart`

## Testing
- `just check-dashboard`
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_68591e1b972c8328af661a12d5749d34