### PR TITLE
Fix error page navigation

### DIFF
--- a/dashboard/components/ErrorBoundary.tsx
+++ b/dashboard/components/ErrorBoundary.tsx
@@ -34,12 +34,26 @@ export const ErrorBoundary: React.FC<
     return (
       <div className="p-4 bg-red-50 border border-red-200 rounded text-red-700 space-y-2">
         <div>Oops! Something went wrong.</div>
-        <button
-          onClick={resetErrorBoundary}
-          className="text-sm bg-red-600 text-white px-2 py-1 rounded hover:bg-red-700"
-        >
-          Retry
-        </button>
+        <div className="flex space-x-2">
+          <button
+            onClick={() => {
+              if (window.history.length > 1) {
+                window.history.back();
+              } else {
+                window.location.assign('/');
+              }
+            }}
+            className="text-sm bg-gray-200 text-gray-800 px-2 py-1 rounded hover:bg-gray-300"
+          >
+            Back
+          </button>
+          <button
+            onClick={resetErrorBoundary}
+            className="text-sm bg-red-600 text-white px-2 py-1 rounded hover:bg-red-700"
+          >
+            Retry
+          </button>
+        </div>
       </div>
     );
   };


### PR DESCRIPTION
## Summary
- add a back navigation button to the dashboard error fallback

## Testing
- `npm run lint:whitespace`
- `npm run check`
- `npm run test`
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_68591c0c056c8328bde0ad51876729a1