### PR TITLE
Set default costs to $1000

### DIFF
--- a/dashboard/components/views/DashboardView.tsx
+++ b/dashboard/components/views/DashboardView.tsx
@@ -83,8 +83,9 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const isEconomicsView = searchParams.get('view') === 'economics';
-  const [cloudCost, setCloudCost] = useState(100);
-  const [proverCost, setProverCost] = useState(200);
+  // Default monthly costs in USD
+  const [cloudCost, setCloudCost] = useState(1000);
+  const [proverCost, setProverCost] = useState(1000);
 
   const visibleMetrics = React.useMemo(
     () =>


### PR DESCRIPTION
## Summary
- set default cloud and prover costs to $1000 per month

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6859231920688328bb4b5c2e3e9d9824