### PR TITLE
Add L1 data cost table

### DIFF
--- a/dashboard/components/views/DashboardView.tsx
+++ b/dashboard/components/views/DashboardView.tsx
@@ -154,6 +154,7 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
         'Batch Posting Cadence': () => onOpenTable('batch-posting-cadence'),
         'Avg. Prove Time': () => onOpenTable('prove-time', timeRange),
         'Avg. Verify Time': () => onOpenTable('verify-time', timeRange),
+        'L1 Data Cost': () => onOpenTable('l1-data-cost', timeRange),
       };
       return actions[title];
     },

--- a/dashboard/config/tableConfig.ts
+++ b/dashboard/config/tableConfig.ts
@@ -20,11 +20,12 @@ import {
   fetchL2BlockTimesAggregated,
   fetchL2GasUsed,
   fetchL2GasUsedAggregated,
+  fetchL1DataCost,
   fetchSequencerDistribution,
   fetchL2Tps,
 } from '../services/apiService';
 import { getSequencerName } from '../sequencerConfig';
-import { bytesToHex, blockLink, addressLink, formatDateTime } from '../utils';
+import { bytesToHex, blockLink, addressLink, formatDateTime, formatEth } from '../utils';
 import { TAIKO_PINK } from '../theme';
 import React from 'react';
 
@@ -317,6 +318,23 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
     },
     urlKey: 'l2-gas-used',
     reverseOrder: false,
+    supportsPagination: true,
+  },
+
+  'l1-data-cost': {
+    title: 'L1 Data Cost',
+    description: 'Data posting cost for each L1 block.',
+    fetcher: fetchL1DataCost,
+    columns: [
+      { key: 'block', label: 'L1 Block' },
+      { key: 'cost', label: 'Cost' },
+    ],
+    mapData: (data) =>
+      (data as { block: number; cost: number }[]).map((d) => ({
+        block: blockLink(d.block),
+        cost: formatEth(d.cost),
+      })),
+    urlKey: 'l1-data-cost',
     supportsPagination: true,
   },
 

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -817,6 +817,40 @@ export const fetchFeeComponents = async (
   };
 };
 
+export interface L1DataCostItem {
+  block: number;
+  cost: number;
+}
+
+export const fetchL1DataCost = async (
+  range: TimeRange,
+  limit = 50,
+  startingAfter?: number,
+  endingBefore?: number,
+): Promise<RequestResult<L1DataCostItem[]>> => {
+  let url = `${API_BASE}/l1-data-cost?`;
+  if (startingAfter === undefined && endingBefore === undefined) {
+    url += `${timeRangeToQuery(range)}&limit=${limit}`;
+  } else {
+    url += `limit=${limit}`;
+  }
+  if (startingAfter !== undefined) {
+    url += `&starting_after=${startingAfter}`;
+  } else if (endingBefore !== undefined) {
+    url += `&ending_before=${endingBefore}`;
+  }
+  const res = await fetchJson<{
+    blocks: { l1_block_number: number; cost: number }[];
+  }>(url);
+  return {
+    data: res.data
+      ? res.data.blocks.map((b) => ({ block: b.l1_block_number, cost: b.cost }))
+      : null,
+    badRequest: res.badRequest,
+    error: res.error,
+  };
+};
+
 export const fetchL2Tps = async (
   range: TimeRange,
   address?: string,

--- a/dashboard/tests/l1DataCostMap.test.ts
+++ b/dashboard/tests/l1DataCostMap.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { TABLE_CONFIGS } from '../config/tableConfig';
+
+describe('l1-data-cost mapData', () => {
+  const mapData = TABLE_CONFIGS['l1-data-cost'].mapData!;
+
+  it('formats block number as link and cost as ETH', () => {
+    const rows = mapData([{ block: 100, cost: 42e18 }]);
+
+    // value should be React element from blockLink
+    expect(typeof rows[0].block).toBe('object');
+    expect(rows[0].block).toHaveProperty('props');
+    expect(rows[0].cost).toBe('42.0 ETH');
+  });
+});


### PR DESCRIPTION
## Summary
- add `fetchL1DataCost` service
- add `l1-data-cost` table config
- expose new table from the Economics view
- test L1 data cost mapData

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685933ff8e98832898f0c7f8f37f218c