### PR TITLE
Implement pagination for batch posting cadence

### DIFF
--- a/dashboard/config/tableConfig.ts
+++ b/dashboard/config/tableConfig.ts
@@ -165,6 +165,7 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
       })),
     urlKey: 'batch-posting-cadence',
     reverseOrder: true,
+    supportsPagination: true,
   },
 
   'prove-time': {

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -468,8 +468,21 @@ export const fetchL2BlockTimesAggregated = async (
 
 export const fetchBatchPostingTimes = async (
   range: TimeRange,
+  limit = 50,
+  startingAfter?: number,
+  endingBefore?: number,
 ): Promise<RequestResult<TimeSeriesData[]>> => {
-  const url = `${API_BASE}/batch-posting-times?${timeRangeToQuery(range)}`;
+  let url = `${API_BASE}/batch-posting-times?`;
+  if (startingAfter === undefined && endingBefore === undefined) {
+    url += `${timeRangeToQuery(range)}&limit=${limit}`;
+  } else {
+    url += `limit=${limit}`;
+  }
+  if (startingAfter !== undefined) {
+    url += `&starting_after=${startingAfter}`;
+  } else if (endingBefore !== undefined) {
+    url += `&ending_before=${endingBefore}`;
+  }
   const res = await fetchJson<{
     batches: { batch_id: number; ms_since_prev_batch: number }[];
   }>(url);


### PR DESCRIPTION
## Summary
- enable server pagination for batch posting cadence data
- expose new paginated API endpoint
- support pagination in dashboard fetcher
- turn on pagination in dashboard table config

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68593760243483289ccc0c0158b1aa6b