### PR TITLE
Move flow chart on economics page

### DIFF
--- a/dashboard/components/views/DashboardView.tsx
+++ b/dashboard/components/views/DashboardView.tsx
@@ -301,6 +301,12 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
 
         {isEconomicsView && (
           <>
+            <FeeFlowChart
+              timeRange={timeRange}
+              cloudCost={cloudCost}
+              proverCost={proverCost}
+              address={selectedSequencer || undefined}
+            />
             <ProfitCalculator
               metrics={metricsData.metrics}
               timeRange={timeRange}
@@ -337,12 +343,6 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
               timeRange={timeRange}
               cloudCost={cloudCost}
               proverCost={proverCost}
-            />
-            <FeeFlowChart
-              timeRange={timeRange}
-              cloudCost={cloudCost}
-              proverCost={proverCost}
-              address={selectedSequencer || undefined}
             />
           </>
         )}


### PR DESCRIPTION
## Summary
- move FeeFlowChart component to the top of the economics view

## Testing
- `just lint-dashboard`
- `just check-dashboard`
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68593b1db1fc8328897bb76965b26718