### PR TITLE
Fix Avg Gas tooltip label

### DIFF
--- a/dashboard/components/GasUsedChart.tsx
+++ b/dashboard/components/GasUsedChart.tsx
@@ -70,7 +70,7 @@ const GasUsedChartComponent: React.FC<GasUsedChartProps> = ({
             const timeStr = ts ? formatDateTime(ts) : '';
             return `Block ${label.toLocaleString()} (${timeStr})`;
           }}
-          formatter={(value: number) => [formatLargeNumber(value), 'gas']}
+          formatter={(value: number) => [formatLargeNumber(value), 'avg gas']}
           contentStyle={{
             backgroundColor: 'rgba(255, 255, 255, 0.8)',
             borderColor: lineColor,


### PR DESCRIPTION
## Summary
- standardize tooltip label for Avg Gas Used chart

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685942baff908328843352850b1abd27