### PR TITLE
Show small L1 data costs in gwei and wei

### DIFF
--- a/dashboard/tests/utils.test.ts
+++ b/dashboard/tests/utils.test.ts
@@ -129,8 +129,8 @@ describe('utils', () => {
 
   it('formats ETH amounts', () => {
     expect(formatEth(42e18)).toBe('42.0 ETH');
-    expect(formatEth(0)).toBe('0.00 ETH');
-    expect(formatEth(1e8)).toBe('0.10 Gwei');
+    expect(formatEth(0)).toBe('0 wei');
+    expect(formatEth(1e8)).toBe('100,000,000 wei');
     expect(formatEth(1334501e9)).toBe('1,334,501 Gwei');
     expect(formatEth(1422636.1e9)).toBe('1,422,636 Gwei');
     expect(formatEth(1422636.1e18)).toBe('1,422,636 ETH');

--- a/dashboard/utils.ts
+++ b/dashboard/utils.ts
@@ -88,6 +88,9 @@ export const formatWithCommas = (value: number): string =>
   value.toLocaleString();
 
 export const formatEth = (wei: number): string => {
+  if (Math.abs(wei) < 1e9) {
+    return `${wei.toLocaleString()} wei`;
+  }
   const eth = wei / 1e18;
   if (Math.abs(eth) >= 1000) {
     return `${Math.trunc(eth).toLocaleString()} ETH`;


### PR DESCRIPTION
## Summary
- display Gwei amounts when `formatEth` receives a value below 0.01 ETH
- display wei for values under 1 Gwei
- update tests for the new formatting behavior

## Testing
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_68594159430c832885acfc3b9749aff3