### PR TITLE
Update L2 block time chart

### DIFF
--- a/dashboard/config/tableConfig.ts
+++ b/dashboard/config/tableConfig.ts
@@ -277,14 +277,14 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
         timestamp: d.timestamp.toLocaleString(),
       })),
     chart: (data) => {
-      const BlockTimeChart = React.lazy(() =>
-        import('../components/BlockTimeChart').then((m) => ({
-          default: m.BlockTimeChart,
+      const BlockTimeDistributionChart = React.lazy(() =>
+        import('../components/BlockTimeDistributionChart').then((m) => ({
+          default: m.BlockTimeDistributionChart,
         })),
       );
-      return React.createElement(BlockTimeChart, {
+      return React.createElement(BlockTimeDistributionChart, {
         data,
-        lineColor: '#FAA43A',
+        barColor: '#FAA43A',
       });
     },
     urlKey: 'l2-block-times',


### PR DESCRIPTION
## Summary
- display `BlockTimeDistributionChart` on the L2 Block Times table page

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68594bc0485c8328a7486a5fc074de81