### PR TITLE
Add block profit tables

### DIFF
--- a/crates/api-types/src/lib.rs
+++ b/crates/api-types/src/lib.rs
@@ -306,6 +306,22 @@ pub struct BlockTransactionsResponse {
     pub blocks: Vec<BlockTransactionsItem>,
 }
 
+/// Profit information for a block.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct BlockProfitItem {
+    /// Block number.
+    pub block: u64,
+    /// Profit in wei (priority + base - L1 cost).
+    pub profit: i128,
+}
+
+/// Collection of block profit entries.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct BlockProfitsResponse {
+    /// Profit entries for the requested range.
+    pub blocks: Vec<BlockProfitItem>,
+}
+
 /// Aggregated L2 fees for a sequencer.
 #[derive(Debug, Serialize, ToSchema)]
 pub struct SequencerFeeRow {

--- a/crates/api/src/routes/mod.rs
+++ b/crates/api/src/routes/mod.rs
@@ -46,7 +46,8 @@ pub fn router(state: ApiState) -> Router {
         .route("/l2-fee-components", get(l2_fee_components))
         .route("/l2-fee-components/aggregated", get(l2_fee_components_aggregated))
         .route("/dashboard-data", get(dashboard_data))
-        .route("/l1-data-cost", get(l1_data_cost));
+        .route("/l1-data-cost", get(l1_data_cost))
+        .route("/block-profits", get(block_profits));
 
     Router::new()
         .merge(SwaggerUi::new("/swagger-ui").url("/api-doc/openapi.json", ApiDoc::openapi()))

--- a/crates/api/src/validation.rs
+++ b/crates/api/src/validation.rs
@@ -53,6 +53,18 @@ pub struct PaginatedQuery {
     pub ending_before: Option<u64>,
 }
 
+/// Query parameters for block profit ranking endpoints
+#[derive(Debug, Deserialize, ToSchema, IntoParams)]
+pub struct ProfitQuery {
+    /// Common query parameters
+    #[serde(flatten)]
+    pub common: CommonQuery,
+    /// Maximum number of items to return
+    pub limit: Option<u64>,
+    /// Sort order for profits ("asc" or "desc")
+    pub order: Option<String>,
+}
+
 /// Validate time range parameters for logical consistency
 pub fn validate_time_range(params: &TimeRangeParams) -> Result<(), ErrorResponse> {
     // Check for mutually exclusive parameters

--- a/dashboard/components/BlockProfitTables.tsx
+++ b/dashboard/components/BlockProfitTables.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import useSWR from 'swr';
+import { fetchBlockProfits, fetchFeeComponents } from '../services/apiService';
+import { useEthPrice } from '../services/priceService';
+import { TimeRange } from '../types';
+import { rangeToHours } from '../utils/timeRange';
+
+interface BlockProfitTablesProps {
+  timeRange: TimeRange;
+  cloudCost: number;
+  proverCost: number;
+  address?: string;
+}
+
+const formatUsd = (value: number): string => {
+  const abs = Math.abs(value);
+  if (abs >= 1000) return Math.trunc(value).toLocaleString();
+  return value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+};
+
+export const BlockProfitTables: React.FC<BlockProfitTablesProps> = ({
+  timeRange,
+  cloudCost,
+  proverCost,
+  address,
+}) => {
+  const { data: ethPrice = 0 } = useEthPrice();
+  const { data: topRes } = useSWR(['topProfits', timeRange, address], () =>
+    fetchBlockProfits(timeRange, 'desc', 5, address),
+  );
+  const { data: bottomRes } = useSWR(['bottomProfits', timeRange, address], () =>
+    fetchBlockProfits(timeRange, 'asc', 5, address),
+  );
+  const { data: feeRes } = useSWR(['feeComponents', timeRange, address], () =>
+    fetchFeeComponents(timeRange, address),
+  );
+  const blockCount = feeRes?.data?.length ?? 0;
+  const HOURS_IN_MONTH = 30 * 24;
+  const hours = rangeToHours(timeRange);
+  const costPerBlock =
+    blockCount > 0 ? ((cloudCost + proverCost) / HOURS_IN_MONTH) * hours / blockCount : 0;
+
+  const calcProfit = (wei: number) => (wei / 1e18) * ethPrice - costPerBlock;
+
+  const renderTable = (title: string, items: { block: number; profit: number }[] | null) => (
+    <div>
+      <h3 className="text-lg font-semibold mb-2">{title}</h3>
+      <div className="overflow-x-auto">
+        <table className="min-w-full border border-gray-200 dark:border-gray-700 divide-y divide-gray-200 dark:divide-gray-700 bg-white dark:bg-gray-800">
+          <thead>
+            <tr>
+              <th className="px-2 py-1 text-left">Block</th>
+              <th className="px-2 py-1 text-left">Profit (USD)</th>
+            </tr>
+          </thead>
+          <tbody>
+            {items?.map((b) => (
+              <tr key={b.block} className="border-t border-gray-200 dark:border-gray-700">
+                <td className="px-2 py-1">{b.block}</td>
+                <td className="px-2 py-1">${formatUsd(calcProfit(b.profit))}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+
+  return (
+    <div className="mt-6 grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6">
+      {renderTable('Top 5 Profitable Blocks', topRes?.data ?? null)}
+      {renderTable('Least 5 Profitable Blocks', bottomRes?.data ?? null)}
+    </div>
+  );
+};

--- a/dashboard/components/views/DashboardView.tsx
+++ b/dashboard/components/views/DashboardView.tsx
@@ -6,6 +6,7 @@ import { IncomeChart } from '../IncomeChart';
 import { CostChart } from '../CostChart';
 import { ProfitabilityChart } from '../ProfitabilityChart';
 import { ProfitRankingTable } from '../ProfitRankingTable';
+import { BlockProfitTables } from '../BlockProfitTables';
 import { FeeFlowChart } from '../FeeFlowChart';
 import { ChartCard } from '../ChartCard';
 import { TAIKO_PINK } from '../../theme';
@@ -343,6 +344,12 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
               timeRange={timeRange}
               cloudCost={cloudCost}
               proverCost={proverCost}
+            />
+            <BlockProfitTables
+              timeRange={timeRange}
+              cloudCost={cloudCost}
+              proverCost={proverCost}
+              address={selectedSequencer || undefined}
             />
           </>
         )}

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -901,6 +901,28 @@ export const fetchL2Tps = async (
   return { data, badRequest: res.badRequest, error: res.error };
 };
 
+export interface BlockProfit {
+  block: number;
+  profit: number;
+}
+
+export const fetchBlockProfits = async (
+  range: TimeRange,
+  order: 'asc' | 'desc' = 'desc',
+  limit = 5,
+  address?: string,
+): Promise<RequestResult<BlockProfit[]>> => {
+  const url =
+    `${API_BASE}/block-profits?${timeRangeToQuery(range)}&order=${order}&limit=${limit}` +
+    (address ? `&address=${address}` : '');
+  const res = await fetchJson<{ blocks: { block: number; profit: number }[] }>(url);
+  return {
+    data: res.data ? res.data.blocks.map((b) => ({ block: b.block, profit: b.profit })) : null,
+    badRequest: res.badRequest,
+    error: res.error,
+  };
+};
+
 export interface DashboardDataResponse {
   l2_block_cadence_ms: number | null;
   batch_posting_cadence_ms: number | null;

--- a/dashboard/types.ts
+++ b/dashboard/types.ts
@@ -56,3 +56,8 @@ export interface FeeComponent {
   base: number;
   l1Cost: number | null;
 }
+
+export interface BlockProfit {
+  block: number;
+  profit: number;
+}

--- a/tests/api_integration.rs
+++ b/tests/api_integration.rs
@@ -347,3 +347,39 @@ async fn blobs_per_batch_desc_order() {
 
     server.abort();
 }
+
+#[tokio::test]
+async fn block_profits_integration() {
+    let mock = Mock::new();
+    mock.add(handlers::provide(vec![
+        FeeRow { l2_block_number: 1, priority_fee: 5, base_fee: 10, l1_data_cost: Some(3) },
+        FeeRow { l2_block_number: 2, priority_fee: 2, base_fee: 2, l1_data_cost: Some(10) },
+    ]));
+
+    let url = Url::parse(mock.url()).unwrap();
+    let client =
+        ClickhouseReader::new(url, "test-db".to_owned(), "user".into(), "pass".into()).unwrap();
+
+    let (addr, server) = spawn_server(client).await;
+    wait_for_server(addr).await;
+
+    let resp = reqwest::get(
+        format!("http://{addr}/{API_VERSION}/block-profits?created[gte]=0&created[lte]=3600000&limit=1&order=desc"),
+    )
+    .await
+    .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body, serde_json::json!({ "blocks": [ { "block": 1, "profit": 12 } ] }));
+
+    let resp = reqwest::get(
+        format!("http://{addr}/{API_VERSION}/block-profits?created[gte]=0&created[lte]=3600000&limit=1&order=asc"),
+    )
+    .await
+    .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body, serde_json::json!({ "blocks": [ { "block": 2, "profit": -6 } ] }));
+
+    server.abort();
+}


### PR DESCRIPTION
## Summary
- add `BlockProfitItem` and `BlockProfitsResponse` structs
- implement `/block-profits` endpoint and wire it in router
- support block profit ranking queries
- provide dashboard fetcher and `BlockProfitTables` component
- show the new tables in Economics view
- test `/block-profits` endpoint

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68595545c5848328ad84896b87b9a6f3