### PR TITLE
Fix inconsistent hook usage in dashboard charts

### DIFF
--- a/dashboard/components/BlockTimeDistributionChart.tsx
+++ b/dashboard/components/BlockTimeDistributionChart.tsx
@@ -26,17 +26,10 @@ interface BlockTimeDistributionChartProps {
 const BlockTimeDistributionChartComponent: React.FC<
   BlockTimeDistributionChartProps
 > = ({ data, barColor }) => {
-  if (!data || data.length === 0) {
-    return (
-      <div className="flex items-center justify-center h-full text-gray-500">
-        No data available
-      </div>
-    );
-  }
-
-  const showMinutes = shouldShowMinutes(data);
-
   const distributionData = useMemo(() => {
+    if (!data) {
+      return [];
+    }
     // Extract block times (timestamps) and filter for reasonable bounds
     const times = data
       .map((d) => d.timestamp)
@@ -81,6 +74,16 @@ const BlockTimeDistributionChartComponent: React.FC<
 
     return bins;
   }, [data]);
+
+  if (!data || data.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-full text-gray-500">
+        No data available
+      </div>
+    );
+  }
+
+  const showMinutes = shouldShowMinutes(data);
 
   if (distributionData.length === 0) {
     return (

--- a/dashboard/components/BlockTxChart.tsx
+++ b/dashboard/components/BlockTxChart.tsx
@@ -22,17 +22,17 @@ const BlockTxChartComponent: React.FC<BlockTxChartProps> = ({
   lineColor,
 }) => {
   const isMobile = useIsMobile();
-  if (!data || data.length === 0) {
+  const sortedData = useMemo(
+    () => (data ? [...data].sort((a, b) => a.block - b.block) : []),
+    [data],
+  );
+  if (sortedData.length === 0) {
     return (
       <div className="flex items-center justify-center h-full text-gray-500">
         No data available
       </div>
     );
   }
-  const sortedData = useMemo(
-    () => [...data].sort((a, b) => a.block - b.block),
-    [data],
-  );
   return (
     <ResponsiveContainer width="100%" height="100%">
       <LineChart

--- a/dashboard/components/MissedBlockChart.tsx
+++ b/dashboard/components/MissedBlockChart.tsx
@@ -20,18 +20,17 @@ const MissedBlockChartComponent: React.FC<MissedBlockChartProps> = ({
   data,
 }) => {
   const isMobile = useIsMobile();
-  if (!data || data.length === 0) {
+  const sortedData = useMemo(
+    () => (data ? [...data].sort((a, b) => a.slot - b.slot) : []),
+    [data],
+  );
+  if (sortedData.length === 0) {
     return (
       <div className="flex items-center justify-center h-full text-gray-500">
         No data available
       </div>
     );
   }
-
-  const sortedData = useMemo(
-    () => [...data].sort((a, b) => a.slot - b.slot),
-    [data],
-  );
 
   return (
     <ResponsiveContainer width="100%" height="100%">


### PR DESCRIPTION
## Summary
- ensure BlockTxChart always calls `useMemo`
- fix conditional hook issue in MissedBlockChart
- compute distributionData before early returns in BlockTimeDistributionChart

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6859628c84c4832893e1dcf7fedf1be7