### PR TITLE
Fix tooltip format in FeeFlowChart

### DIFF
--- a/dashboard/components/FeeFlowChart.tsx
+++ b/dashboard/components/FeeFlowChart.tsx
@@ -292,11 +292,11 @@ export const FeeFlowChart: React.FC<FeeFlowChartProps> = ({
   const formatTooltipValue = (value: number, itemData?: any) => {
     const usd = formatUsd(value);
     if (itemData?.wei != null) {
-      return `${usd} (${formatEth(itemData.wei)})`;
+      return `${formatEth(itemData.wei)} (${usd})`;
     }
     if (!itemData?.usd && ethPrice) {
       const wei = (value / ethPrice) * WEI_TO_ETH;
-      return `${usd} (${formatEth(wei)})`;
+      return `${formatEth(wei)} (${usd})`;
     }
     return usd;
   };


### PR DESCRIPTION
## Summary
- reverse order of ETH and USD values in FeeFlowChart tooltip

## Testing
- `just lint`
- `just test`
- `just check-dashboard`
- `just lint-dashboard`
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_685968818eb48328a045e3a48c60eb90