### PR TITLE
Add L1 data cost to economics cost chart

### DIFF
--- a/dashboard/tests/costChart.test.ts
+++ b/dashboard/tests/costChart.test.ts
@@ -4,6 +4,7 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import * as swr from 'swr';
 vi.mock('swr', () => ({ default: vi.fn() }));
 import { CostChart } from '../components/CostChart';
+import * as priceService from '../services/priceService';
 
 const feeData = [
   { block: 1, priority: 1, base: 1, l1Cost: 0 },
@@ -12,6 +13,7 @@ const feeData = [
 describe('CostChart', () => {
   it('renders with cost data', () => {
     vi.mocked(swr.default).mockReturnValue({ data: { data: feeData } } as any);
+    vi.spyOn(priceService, 'useEthPrice').mockReturnValue({ data: 1 } as any);
 
     const html = renderToStaticMarkup(
       React.createElement(CostChart, {


### PR DESCRIPTION
## Summary
- include L1 data cost in `CostChart`
- show ETH price errors
- update unit test for `CostChart`

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685a5674346c8328bb110e8222dbcf3a