### PR TITLE
Add theme toggle to dashboard

### DIFF
--- a/dashboard/components/DashboardHeader.tsx
+++ b/dashboard/components/DashboardHeader.tsx
@@ -10,6 +10,7 @@ import { useSearchParams } from 'react-router-dom';
 import { showToast } from '../utils/toast';
 import { DayPicker } from 'react-day-picker';
 import * as Popover from '@radix-ui/react-popover';
+import { ThemeToggle } from './ThemeToggle';
 
 interface ImportMetaEnv {
   readonly VITE_NETWORK_NAME?: string;
@@ -126,6 +127,7 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({
             onChange={onSequencerChange}
           />
         )}
+        <ThemeToggle />
         {/* Export button removed as per request */}
       </div>
     </header>
@@ -144,7 +146,15 @@ export const TimeRangeSelector: React.FC<TimeRangeSelectorProps> = ({
   isChanging,
 }) => {
   const { updateSearchParams } = useRouterNavigation();
-  const presetRanges: TimeRange[] = ['15m', '1h', '3h', '6h', '12h', '24h', '7d'];
+  const presetRanges: TimeRange[] = [
+    '15m',
+    '1h',
+    '3h',
+    '6h',
+    '12h',
+    '24h',
+    '7d',
+  ];
   const isCustom = /^\d+-\d+$/.test(currentTimeRange);
   const [open, setOpen] = React.useState(false);
   const [date, setDate] = React.useState<Date | undefined>(() => {

--- a/dashboard/components/ThemeToggle.tsx
+++ b/dashboard/components/ThemeToggle.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { useTheme } from '../contexts/ThemeContext';
+
+export const ThemeToggle: React.FC = () => {
+  const { theme, toggleTheme } = useTheme();
+  const label = theme === 'dark' ? 'Light Mode' : 'Dark Mode';
+  return (
+    <button
+      onClick={toggleTheme}
+      aria-label="Toggle dark mode"
+      className="p-1 border rounded-md text-sm bg-white dark:bg-gray-800"
+    >
+      {label}
+    </button>
+  );
+};

--- a/dashboard/tests/dashboardHeader.test.ts
+++ b/dashboard/tests/dashboardHeader.test.ts
@@ -20,14 +20,14 @@ describe('DashboardHeader', () => {
             null,
             React.createElement(DashboardHeader, {
               timeRange: '1h',
-              onTimeRangeChange: () => { },
+              onTimeRangeChange: () => {},
               refreshRate: 60000,
-              onRefreshRateChange: () => { },
+              onRefreshRateChange: () => {},
               lastRefresh: Date.now(),
-              onManualRefresh: () => { },
+              onManualRefresh: () => {},
               sequencers: ['seq1', 'seq2'],
               selectedSequencer: null,
-              onSequencerChange: () => { },
+              onSequencerChange: () => {},
             }),
           ),
         ),
@@ -39,6 +39,7 @@ describe('DashboardHeader', () => {
     expect(html.includes('Status')).toBe(true);
     expect(html.includes('All Sequencers')).toBe(true);
     expect(html.includes('Economics')).toBe(false);
+    expect(html.includes('Dark Mode')).toBe(true);
   });
 
   it('hides sequencer selector in economics view', () => {
@@ -68,5 +69,6 @@ describe('DashboardHeader', () => {
       ),
     );
     expect(html.includes('All Sequencers')).toBe(false);
+    expect(html.includes('Dark Mode')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- add ThemeToggle component
- include toggle in DashboardHeader
- test dark mode toggle

## Testing
- `npm run check`
- `npm run test`
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_685a5ab2f1e883288df0c2fc3962099a