### PR TITLE
Update economics view sequencer links

### DIFF
--- a/dashboard/components/ProfitRankingTable.tsx
+++ b/dashboard/components/ProfitRankingTable.tsx
@@ -7,6 +7,7 @@ import {
 } from '../services/apiService';
 import * as apiService from '../services/apiService';
 import { getSequencerAddress } from '../sequencerConfig';
+import { addressLink } from '../utils';
 import { useEthPrice } from '../services/priceService';
 import { rangeToHours } from '../utils/timeRange';
 
@@ -50,8 +51,12 @@ export const ProfitRankingTable: React.FC<ProfitRankingTableProps> = ({
     return map;
   }, [feeRes]);
 
-  const [sortBy, setSortBy] = React.useState<'name' | 'blocks' | 'profit'>('profit');
-  const [sortDirection, setSortDirection] = React.useState<'asc' | 'desc'>('desc');
+  const [sortBy, setSortBy] = React.useState<'name' | 'blocks' | 'profit'>(
+    'profit',
+  );
+  const [sortDirection, setSortDirection] = React.useState<'asc' | 'desc'>(
+    'desc',
+  );
 
   const hours = rangeToHours(timeRange);
   const MONTH_HOURS = 30 * 24;
@@ -63,6 +68,7 @@ export const ProfitRankingTable: React.FC<ProfitRankingTableProps> = ({
     if (!fees) {
       return {
         name: seq.name,
+        address: addr,
         blocks: seq.value,
         profit: null as number | null,
       };
@@ -73,9 +79,8 @@ export const ProfitRankingTable: React.FC<ProfitRankingTableProps> = ({
         (fees.l1_data_cost ?? 0)) /
       1e18;
     const profit = revenueEth * ethPrice - costPerSeq;
-    return { name: seq.name, blocks: seq.value, profit };
+    return { name: seq.name, address: addr, blocks: seq.value, profit };
   });
-
 
   const sorted = React.useMemo(() => {
     const data = [...rows];
@@ -160,10 +165,10 @@ export const ProfitRankingTable: React.FC<ProfitRankingTableProps> = ({
           <tbody>
             {sorted.map((row) => (
               <tr
-                key={row.name}
+                key={row.address}
                 className="border-t border-gray-200 dark:border-gray-700"
               >
-                <td className="px-2 py-1">{row.name}</td>
+                <td className="px-2 py-1">{addressLink(row.address)}</td>
                 <td className="px-2 py-1">{row.blocks.toLocaleString()}</td>
                 <td className="px-2 py-1">
                   {row.profit != null ? `$${formatProfit(row.profit)}` : 'N/A'}

--- a/dashboard/tests/profitRankingTable.test.ts
+++ b/dashboard/tests/profitRankingTable.test.ts
@@ -14,8 +14,8 @@ describe('ProfitRankingTable', () => {
         data: {
           data: [
             { name: 'SeqA', address: '0xseqA', value: 10, tps: null },
-            { name: 'SeqB', address: '0xseqB', value: 5, tps: null }
-          ]
+            { name: 'SeqB', address: '0xseqB', value: 5, tps: null },
+          ],
         },
       } as any)
       .mockReturnValueOnce({
@@ -44,7 +44,7 @@ describe('ProfitRankingTable', () => {
     vi.spyOn(api, 'fetchSequencerDistribution').mockResolvedValue({
       data: [
         { name: 'SeqA', address: '0xseqA', value: 10, tps: null },
-        { name: 'SeqB', address: '0xseqB', value: 5, tps: null }
+        { name: 'SeqB', address: '0xseqB', value: 5, tps: null },
       ],
       badRequest: false,
       error: null,
@@ -85,8 +85,8 @@ describe('ProfitRankingTable', () => {
     );
     expect(html.includes('Sequencer Profit Ranking')).toBe(true);
     expect(html.includes('2,750')).toBe(true);
-    const firstSeqIdx = html.indexOf('SeqA');
-    const secondSeqIdx = html.indexOf('SeqB');
+    const firstSeqIdx = html.indexOf('0xseqA');
+    const secondSeqIdx = html.indexOf('0xseqB');
     expect(firstSeqIdx).toBeGreaterThan(-1);
     expect(secondSeqIdx).toBeGreaterThan(firstSeqIdx);
     expect(html.includes('Profit (USD)')).toBe(true);


### PR DESCRIPTION
## Summary
- link sequencer addresses in ProfitRankingTable to Taikoscan
- update ProfitRankingTable tests to check for address links

## Testing
- `just ci` *(fails: TypeScript check errors)*

------
https://chatgpt.com/codex/tasks/task_b_685a652aeb408328a51e52d76951d656