### PR TITLE
Fix clickhouse schema

### DIFF
--- a/crates/clickhouse/src/schema.rs
+++ b/crates/clickhouse/src/schema.rs
@@ -77,6 +77,7 @@ pub const TABLE_SCHEMAS: &[TableSchema] = &[
         columns: "l1_block_number UInt64,
                  batch_id UInt64,
                  batch_size UInt16,
+                 last_l2_block_number UInt64,
                  proposer_addr FixedString(20),
                  blob_count UInt8,
                  blob_total_bytes UInt32,


### PR DESCRIPTION
## Summary
- add missing `last_l2_block_number` column to batches table schema

## Testing
- `just ci` *(fails: check-dashboard)*

------
https://chatgpt.com/codex/tasks/task_b_685a977f0e1c8328b16f5f7f5470babf