### PR TITLE
Fix batch posting time query

### DIFF
--- a/crates/clickhouse/src/reader.rs
+++ b/crates/clickhouse/src/reader.rs
@@ -1073,7 +1073,7 @@ impl ClickhouseReader {
 
         let query = format!(
             "SELECT batch_id, ts, \
-                    toUInt64OrNull(toString(toInt128(ts) - toInt128(prev_ts))) AS ms_since_prev_batch \
+                    if(ts > prev_ts, CAST(ts - prev_ts AS UInt64), NULL) AS ms_since_prev_batch \
              FROM ( \
                  SELECT b.batch_id AS batch_id, \
                         toUInt64(l1_events.block_ts * 1000) AS ts, \
@@ -1124,7 +1124,7 @@ impl ClickhouseReader {
 
         let mut query = format!(
             "SELECT batch_id, ts, \
-                    toUInt64OrNull(toString(toInt128(ts) - toInt128(prev_ts))) AS ms_since_prev_batch \
+                    if(ts > prev_ts, CAST(ts - prev_ts AS UInt64), NULL) AS ms_since_prev_batch \
              FROM ( \
                  SELECT b.batch_id AS batch_id, \
                         toUInt64(l1_events.block_ts * 1000) AS ts, \


### PR DESCRIPTION
## Summary
- avoid negative deltas when selecting batch posting times

## Testing
- `just ci` *(fails: check-dashboard)*

------
https://chatgpt.com/codex/tasks/task_b_685a99c3e72c8328893eb6e927c0ce06