### PR TITLE
Combine cargo tool installs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libclang-19-dev \
     cmake
 
-RUN cargo install sccache --locked
-RUN cargo install cargo-chef --locked
+RUN cargo install --locked sccache cargo-chef && \
+    rm -rf /usr/local/cargo/registry /usr/local/cargo/git
 
 ENV RUSTC_WRAPPER=sccache SCCACHE_DIR=/sccache
 

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -16,8 +16,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libclang-19-dev \
     cmake
 
-RUN cargo install sccache --locked
-RUN cargo install cargo-chef --locked
+RUN cargo install --locked sccache cargo-chef && \
+    rm -rf /usr/local/cargo/registry /usr/local/cargo/git
 
 ENV RUSTC_WRAPPER=sccache SCCACHE_DIR=/sccache
 


### PR DESCRIPTION
## Summary
- install sccache and cargo-chef together in Dockerfiles
- clear cargo cache during install

## Testing
- `just ci` *(fails: Recipe `check-dashboard` exited with code 2)*

------
https://chatgpt.com/codex/tasks/task_b_685a99f9632c8328a07f326246d3fe92