### PR TITLE
Add batch economics API queries

### DIFF
--- a/crates/api-types/src/lib.rs
+++ b/crates/api-types/src/lib.rs
@@ -5,9 +5,9 @@
 //! depend on them without pulling in the rest of the server implementation.
 
 use clickhouse_lib::{
-    BatchBlobCountRow, BatchPostingTimeRow, BatchProveTimeRow, BatchVerifyTimeRow,
-    BlockFeeComponentRow, ForcedInclusionProcessedRow, L1BlockTimeRow, L1DataCostRow,
-    L2BlockTimeRow, L2GasUsedRow, L2ReorgRow, L2TpsRow, SlashingEventRow,
+    BatchBlobCountRow, BatchFeeComponentRow, BatchPostingTimeRow, BatchProveTimeRow,
+    BatchVerifyTimeRow, BlockFeeComponentRow, ForcedInclusionProcessedRow, L1BlockTimeRow,
+    L1DataCostRow, L2BlockTimeRow, L2GasUsedRow, L2ReorgRow, L2TpsRow, SlashingEventRow,
 };
 
 use axum::{Json, http::StatusCode, response::IntoResponse};
@@ -243,6 +243,13 @@ pub struct L1DataCostResponse {
 pub struct FeeComponentsResponse {
     /// Fee components per block
     pub blocks: Vec<BlockFeeComponentRow>,
+}
+
+/// Fee components for each batch
+#[derive(Debug, Serialize, ToSchema)]
+pub struct BatchFeeComponentsResponse {
+    /// Fee components per batch
+    pub batches: Vec<BatchFeeComponentRow>,
 }
 
 /// TPS values for each L2 block.

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -42,6 +42,8 @@ use utoipa::OpenApi;
         routes::core::sequencer_blocks,
         routes::aggregated::l2_fees,
         routes::aggregated::l2_fee_components,
+        routes::aggregated::batch_fee_components,
+        routes::aggregated::batch_fee_components_aggregated,
         routes::aggregated::dashboard_data,
         routes::core::l1_data_cost
     ),
@@ -86,7 +88,9 @@ use utoipa::OpenApi;
             PreconfDataResponse,
             L2FeesResponse,
             FeeComponentsResponse,
+            BatchFeeComponentsResponse,
             SequencerFeeRow,
+            clickhouse_lib::BatchFeeComponentRow,
             DashboardDataResponse,
             api_types::ErrorResponse,
             L1DataCostResponse

--- a/crates/api/src/routes/mod.rs
+++ b/crates/api/src/routes/mod.rs
@@ -45,6 +45,8 @@ pub fn router(state: ApiState) -> Router {
         .route("/l2-fees", get(l2_fees))
         .route("/l2-fee-components", get(l2_fee_components))
         .route("/l2-fee-components/aggregated", get(l2_fee_components_aggregated))
+        .route("/batch-fee-components", get(batch_fee_components))
+        .route("/batch-fee-components/aggregated", get(batch_fee_components_aggregated))
         .route("/dashboard-data", get(dashboard_data))
         .route("/l1-data-cost", get(l1_data_cost))
         .route("/block-profits", get(block_profits));

--- a/crates/clickhouse/src/models.rs
+++ b/crates/clickhouse/src/models.rs
@@ -299,6 +299,19 @@ pub struct SequencerFeeRow {
     pub l1_data_cost: Option<u128>,
 }
 
+/// Row representing the fee components for a batch
+#[derive(Debug, Row, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+pub struct BatchFeeComponentRow {
+    /// Batch ID
+    pub batch_id: u64,
+    /// Total priority fee for the batch
+    pub priority_fee: u128,
+    /// Total base fee for the batch
+    pub base_fee: u128,
+    /// L1 data posting cost associated with the batch, if available
+    pub l1_data_cost: Option<u128>,
+}
+
 /// Row representing the transactions per second for an L2 block
 #[derive(Debug, Serialize, Deserialize, PartialEq, ToSchema)]
 pub struct L2TpsRow {

--- a/dashboard/components/ProfitCalculator.tsx
+++ b/dashboard/components/ProfitCalculator.tsx
@@ -40,7 +40,7 @@ export const ProfitCalculator: React.FC<ProfitCalculatorProps> = ({
 
   const totalFee = priority + base - l1DataCost;
 
-  const { data: ethPrice = 0, error: ethPriceError } = useEthPrice();
+  const { data: ethPrice = 0, error: _ethPriceError } = useEthPrice();
 
   const HOURS_IN_MONTH = 30 * 24;
   const hours = rangeToHours(timeRange);
@@ -89,6 +89,9 @@ export const ProfitCalculator: React.FC<ProfitCalculatorProps> = ({
           />
         </label>
       </div>
+      <p className="mt-4 text-sm">
+        Profit ({formatTimeRangeLabel(timeRange)}): {formatProfit(profit)}
+      </p>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- support batch economics queries in Clickhouse reader and API
- expose new batch fee component endpoints in router and OpenAPI
- aggregate batch fee components
- update integration tests for new endpoint
- show profit in dashboard ProfitCalculator

## Testing
- `just lint-dashboard`
- `just check-dashboard`
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685a97d250248328ad8ba16da05c0870