### PR TITLE
Fix apt list cleanup in Docker build images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     clang \
     llvm-19 \
     libclang-19-dev \
-    cmake
+    cmake \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN cargo install sccache --locked
 RUN cargo install cargo-chef --locked

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -14,7 +14,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     clang \
     llvm-19 \
     libclang-19-dev \
-    cmake
+    cmake \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN cargo install sccache --locked
 RUN cargo install cargo-chef --locked


### PR DESCRIPTION
## Summary
- drop apt cache from `Dockerfile`
- drop apt cache from `Dockerfile.api`

## Testing
- `just ci` *(fails: Recipe `check-dashboard` failed on line 234)*

------
https://chatgpt.com/codex/tasks/task_b_685a9a0209608328910ca8f30455e67c