### PR TITLE
Fix negative revenue in ProfitRankingTable

### DIFF
--- a/dashboard/components/ProfitRankingTable.tsx
+++ b/dashboard/components/ProfitRankingTable.tsx
@@ -76,12 +76,11 @@ export const ProfitRankingTable: React.FC<ProfitRankingTableProps> = ({
       };
     }
     const revenueEth =
-      ((fees.priority_fee ?? 0) +
-        (fees.base_fee ?? 0) * 0.75 -
-        (fees.l1_data_cost ?? 0)) /
-      1e18;
+      ((fees.priority_fee ?? 0) + (fees.base_fee ?? 0) * 0.75) / 1e18;
+    const l1CostEth = (fees.l1_data_cost ?? 0) / 1e18;
     const revenue = revenueEth * ethPrice;
-    const profit = revenue - costPerSeq;
+    const l1CostUsd = l1CostEth * ethPrice;
+    const profit = revenue - l1CostUsd - costPerSeq;
     return {
       name: seq.name,
       address: addr,


### PR DESCRIPTION
## Summary
- fix revenue computation to avoid negative results in Profit Ranking table

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685a9f609c888328a78c377202aeec00