### PR TITLE
Add batch fee endpoints

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -41,6 +41,7 @@ use utoipa::OpenApi;
         routes::core::sequencer_distribution,
         routes::core::sequencer_blocks,
         routes::aggregated::l2_fees,
+        routes::aggregated::batch_fees,
         routes::aggregated::l2_fee_components,
         routes::aggregated::batch_fee_components,
         routes::aggregated::batch_fee_components_aggregated,

--- a/crates/api/src/routes/mod.rs
+++ b/crates/api/src/routes/mod.rs
@@ -43,6 +43,7 @@ pub fn router(state: ApiState) -> Router {
         .route("/block-transactions", get(block_transactions))
         .route("/block-transactions/aggregated", get(block_transactions_aggregated))
         .route("/l2-fees", get(l2_fees))
+        .route("/batch-fees", get(batch_fees))
         .route("/l2-fee-components", get(l2_fee_components))
         .route("/l2-fee-components/aggregated", get(l2_fee_components_aggregated))
         .route("/batch-fee-components", get(batch_fee_components))


### PR DESCRIPTION
## Summary
- support batch fee metrics in Clickhouse reader
- expose `/batch-fees` API endpoint
- register the new endpoint in router and OpenAPI
- test batch fee helpers

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685a9ecd41e483288620cda0fc7b3f5a