### PR TITLE
Include L1 data cost in sequencer cost

### DIFF
--- a/dashboard/components/ProfitRankingTable.tsx
+++ b/dashboard/components/ProfitRankingTable.tsx
@@ -80,13 +80,14 @@ export const ProfitRankingTable: React.FC<ProfitRankingTableProps> = ({
     const l1CostEth = (fees.l1_data_cost ?? 0) / 1e18;
     const revenue = revenueEth * ethPrice;
     const l1CostUsd = l1CostEth * ethPrice;
-    const profit = revenue - l1CostUsd - costPerSeq;
+    const cost = costPerSeq + l1CostUsd;
+    const profit = revenue - cost;
     return {
       name: seq.name,
       address: addr,
       blocks: seq.value,
       revenue,
-      cost: costPerSeq,
+      cost,
       profit,
     };
   });

--- a/dashboard/tests/profitRankingTable.test.ts
+++ b/dashboard/tests/profitRankingTable.test.ts
@@ -94,4 +94,67 @@ describe('ProfitRankingTable', () => {
     expect(html.includes('Profit (USD)')).toBe(true);
     expect(html.includes('↓')).toBe(true);
   });
+
+  it('adds l1 cost to cost column', async () => {
+    vi.mocked(swr.default)
+      .mockReturnValueOnce({
+        data: {
+          data: [
+            { name: 'SeqA', address: '0xseqA', value: 1, tps: null },
+          ],
+        },
+      } as any)
+      .mockReturnValueOnce({
+        data: {
+          data: {
+            priority_fee: 1e18,
+            base_fee: 0,
+            l1_data_cost: 5e17,
+            sequencers: [
+              {
+                address: '0xseqA',
+                priority_fee: 1e18,
+                base_fee: 0,
+                l1_data_cost: 5e17,
+              },
+            ],
+          },
+        },
+      } as any);
+
+    vi.spyOn(api, 'fetchSequencerDistribution').mockResolvedValue({
+      data: [{ name: 'SeqA', address: '0xseqA', value: 1, tps: null }],
+      badRequest: false,
+      error: null,
+    } as any);
+    vi.spyOn(api, 'fetchL2Fees').mockResolvedValue({
+      data: {
+        priority_fee: 1e18,
+        base_fee: 0,
+        l1_data_cost: 5e17,
+        sequencers: [
+          {
+            address: '0xseqA',
+            priority_fee: 1e18,
+            base_fee: 0,
+            l1_data_cost: 5e17,
+          },
+        ],
+      },
+      badRequest: false,
+      error: null,
+    } as any);
+    vi.spyOn(priceService, 'useEthPrice').mockReturnValue({
+      data: 100,
+    } as any);
+
+    const html = renderToStaticMarkup(
+      React.createElement(ProfitRankingTable, {
+        timeRange: '1h',
+        cloudCost: 0,
+        proverCost: 0,
+      }),
+    );
+    expect(html.includes('$50.00')).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- include L1 data cost when computing sequencer costs
- test that cost column includes L1 data cost

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685aa22e69108328b6cb95f568de6410