### PR TITLE
Fix FeeFlowChart to skip zero-value nodes

### DIFF
--- a/dashboard/components/FeeFlowChart.tsx
+++ b/dashboard/components/FeeFlowChart.tsx
@@ -355,7 +355,27 @@ export const FeeFlowChart: React.FC<FeeFlowChartProps> = ({
     ].filter((l) => l.value > 0);
   }
 
-  const data = { nodes, links };
+  // Remove nodes that have no remaining links after filtering
+  const usedIndices = new Set<number>();
+  links.forEach((l) => {
+    usedIndices.add(l.source);
+    usedIndices.add(l.target);
+  });
+  const indexMap = new Map<number, number>();
+  const filteredNodes = nodes.filter((_, idx) => {
+    if (usedIndices.has(idx)) {
+      indexMap.set(idx, indexMap.size);
+      return true;
+    }
+    return false;
+  });
+  const remappedLinks = links.map((l) => ({
+    ...l,
+    source: indexMap.get(l.source) as number,
+    target: indexMap.get(l.target) as number,
+  }));
+
+  const data = { nodes: filteredNodes, links: remappedLinks };
 
   const formatTooltipValue = (value: number, itemData?: any) => {
     const usd = formatUsd(value);


### PR DESCRIPTION
## Summary
- prune nodes without edges so that sequencers with zero subsidy or profit don't appear in the flow chart

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685ab00bdcc48328a4ee4f85ce879516