### PR TITLE
Update economics charts to use batch data

### DIFF
--- a/dashboard/components/BlockProfitTables.tsx
+++ b/dashboard/components/BlockProfitTables.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import useSWR from 'swr';
-import { fetchBlockProfits, fetchFeeComponents } from '../services/apiService';
+import { fetchBatchFeeComponents } from '../services/apiService';
 import { useEthPrice } from '../services/priceService';
 import { TimeRange } from '../types';
 import { rangeToHours } from '../utils/timeRange';
@@ -25,38 +25,41 @@ export const BlockProfitTables: React.FC<BlockProfitTablesProps> = ({
   address,
 }) => {
   const { data: ethPrice = 0 } = useEthPrice();
-  const { data: topRes } = useSWR(['topProfits', timeRange, address], () =>
-    fetchBlockProfits(timeRange, 'desc', 5, address),
+  const { data: feeRes } = useSWR(
+    ['batchFeeComponents', timeRange, address],
+    () => fetchBatchFeeComponents(timeRange, address),
   );
-  const { data: bottomRes } = useSWR(['bottomProfits', timeRange, address], () =>
-    fetchBlockProfits(timeRange, 'asc', 5, address),
-  );
-  const { data: feeRes } = useSWR(['feeComponents', timeRange, address], () =>
-    fetchFeeComponents(timeRange, address),
-  );
-  const blockCount = feeRes?.data?.length ?? 0;
+  const batchData = feeRes?.data ?? [];
+  const batchCount = batchData.length;
   const HOURS_IN_MONTH = 30 * 24;
   const hours = rangeToHours(timeRange);
-  const costPerBlock =
-    blockCount > 0 ? ((cloudCost + proverCost) / HOURS_IN_MONTH) * hours / blockCount : 0;
+  const costPerBatch =
+    batchCount > 0 ? ((cloudCost + proverCost) / HOURS_IN_MONTH) * hours / batchCount : 0;
 
-  const calcProfit = (wei: number) => (wei / 1e18) * ethPrice - costPerBlock;
+  const calcProfit = (wei: number) => (wei / 1e18) * ethPrice - costPerBatch;
 
-  const renderTable = (title: string, items: { block: number; profit: number }[] | null) => (
+  const profits = batchData.map((b) => ({
+    batch: b.batch,
+    profit: b.priority + b.base - (b.l1Cost ?? 0),
+  }));
+  const topBatches = [...profits].sort((a, b) => b.profit - a.profit).slice(0, 5);
+  const bottomBatches = [...profits].sort((a, b) => a.profit - b.profit).slice(0, 5);
+
+  const renderTable = (title: string, items: { batch: number; profit: number }[] | null) => (
     <div>
       <h3 className="text-lg font-semibold mb-2">{title}</h3>
       <div className="overflow-x-auto">
         <table className="min-w-full border border-gray-200 dark:border-gray-700 divide-y divide-gray-200 dark:divide-gray-700 bg-white dark:bg-gray-800">
           <thead>
             <tr>
-              <th className="px-2 py-1 text-left">Block</th>
+              <th className="px-2 py-1 text-left">Batch</th>
               <th className="px-2 py-1 text-left">Profit (USD)</th>
             </tr>
           </thead>
           <tbody>
             {items?.map((b) => (
-              <tr key={b.block} className="border-t border-gray-200 dark:border-gray-700">
-                <td className="px-2 py-1">{b.block}</td>
+              <tr key={b.batch} className="border-t border-gray-200 dark:border-gray-700">
+                <td className="px-2 py-1">{b.batch}</td>
                 <td className="px-2 py-1">${formatUsd(calcProfit(b.profit))}</td>
               </tr>
             ))}
@@ -68,8 +71,8 @@ export const BlockProfitTables: React.FC<BlockProfitTablesProps> = ({
 
   return (
     <div className="mt-6 grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6">
-      {renderTable('Top 5 Profitable Blocks', topRes?.data ?? null)}
-      {renderTable('Least 5 Profitable Blocks', bottomRes?.data ?? null)}
+      {renderTable('Top 5 Profitable Batches', topBatches)}
+      {renderTable('Least 5 Profitable Batches', bottomBatches)}
     </div>
   );
 };

--- a/dashboard/components/CostChart.tsx
+++ b/dashboard/components/CostChart.tsx
@@ -9,8 +9,8 @@ import {
   ResponsiveContainer,
 } from 'recharts';
 import useSWR from 'swr';
-import { fetchFeeComponents } from '../services/apiService';
-import { TimeRange, FeeComponent } from '../types';
+import { fetchBatchFeeComponents } from '../services/apiService';
+import { TimeRange, BatchFeeComponent } from '../types';
 import { rangeToHours } from '../utils/timeRange';
 import { useEthPrice } from '../services/priceService';
 
@@ -27,11 +27,12 @@ export const CostChart: React.FC<CostChartProps> = ({
   proverCost,
   address,
 }) => {
-  const { data: feeRes } = useSWR(['feeComponents', timeRange, address], () =>
-    fetchFeeComponents(timeRange, address),
+  const { data: feeRes } = useSWR(
+    ['batchFeeComponents', timeRange, address],
+    () => fetchBatchFeeComponents(timeRange, address),
   );
   const { data: ethPrice = 0, error: ethPriceError } = useEthPrice();
-  const feeData: FeeComponent[] | null = feeRes?.data ?? null;
+  const feeData: BatchFeeComponent[] | null = feeRes?.data ?? null;
 
   if (!feeData || feeData.length === 0) {
     return (
@@ -44,11 +45,11 @@ export const CostChart: React.FC<CostChartProps> = ({
   const hours = rangeToHours(timeRange);
   const HOURS_IN_MONTH = 30 * 24;
   const baseCost = ((cloudCost + proverCost) / HOURS_IN_MONTH) * hours;
-  const baseCostPerBlock = baseCost / feeData.length;
+  const baseCostPerBatch = baseCost / feeData.length;
 
   const data = feeData.map((b) => {
     const l1CostUsd = ((b.l1Cost ?? 0) / 1e18) * ethPrice;
-    return { block: b.block, cost: baseCostPerBlock + l1CostUsd };
+    return { batch: b.batch, cost: baseCostPerBatch + l1CostUsd };
   });
 
   return (
@@ -63,11 +64,11 @@ export const CostChart: React.FC<CostChartProps> = ({
         >
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis
-          dataKey="block"
+          dataKey="batch"
           stroke="#666666"
           fontSize={12}
           label={{
-            value: 'L2 Block',
+            value: 'Batch',
             position: 'insideBottom',
             offset: -10,
             fontSize: 10,
@@ -89,7 +90,7 @@ export const CostChart: React.FC<CostChartProps> = ({
           }}
         />
         <Tooltip
-          labelFormatter={(v: number) => `Block ${v}`}
+          labelFormatter={(v: number) => `Batch ${v}`}
           formatter={(value: number) => [`$${value.toFixed(2)}`, 'Cost']}
           contentStyle={{
             backgroundColor: 'rgba(255,255,255,0.8)',

--- a/dashboard/components/IncomeChart.tsx
+++ b/dashboard/components/IncomeChart.tsx
@@ -10,8 +10,8 @@ import {
 } from 'recharts';
 import useSWR from 'swr';
 import { useEthPrice } from '../services/priceService';
-import { fetchFeeComponents } from '../services/apiService';
-import { TimeRange, FeeComponent } from '../types';
+import { fetchBatchFeeComponents } from '../services/apiService';
+import { TimeRange, BatchFeeComponent } from '../types';
 
 interface IncomeChartProps {
   timeRange: TimeRange;
@@ -22,10 +22,11 @@ export const IncomeChart: React.FC<IncomeChartProps> = ({
   timeRange,
   address,
 }) => {
-  const { data: feeRes } = useSWR(['feeComponents', timeRange, address], () =>
-    fetchFeeComponents(timeRange, address),
+  const { data: feeRes } = useSWR(
+    ['batchFeeComponents', timeRange, address],
+    () => fetchBatchFeeComponents(timeRange, address),
   );
-  const feeData: FeeComponent[] | null = feeRes?.data ?? null;
+  const feeData: BatchFeeComponent[] | null = feeRes?.data ?? null;
   const { data: ethPrice = 0, error: ethPriceError } = useEthPrice();
 
   if (!feeData || feeData.length === 0) {
@@ -39,7 +40,7 @@ export const IncomeChart: React.FC<IncomeChartProps> = ({
   const data = feeData.map((b) => {
     const revenueEth = (b.priority + b.base) / 1e18;
     const income = revenueEth * ethPrice;
-    return { block: b.block, income };
+    return { batch: b.batch, income };
   });
 
   return (
@@ -54,11 +55,11 @@ export const IncomeChart: React.FC<IncomeChartProps> = ({
         >
           <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
           <XAxis
-            dataKey="block"
+            dataKey="batch"
             stroke="#666666"
             fontSize={12}
             label={{
-              value: 'L2 Block',
+              value: 'Batch',
               position: 'insideBottom',
               offset: -10,
               fontSize: 10,
@@ -80,7 +81,7 @@ export const IncomeChart: React.FC<IncomeChartProps> = ({
             }}
           />
           <Tooltip
-            labelFormatter={(v: number) => `Block ${v}`}
+            labelFormatter={(v: number) => `Batch ${v}`}
             formatter={(value: number) => [`$${value.toFixed(2)}`, 'Income']}
             contentStyle={{
               backgroundColor: 'rgba(255,255,255,0.8)',

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -801,6 +801,13 @@ export interface FeeComponent {
   l1Cost: number | null;
 }
 
+export interface BatchFeeComponent {
+  batch: number;
+  priority: number;
+  base: number;
+  l1Cost: number | null;
+}
+
 export const fetchFeeComponents = async (
   range: TimeRange,
   address?: string,
@@ -824,6 +831,35 @@ export const fetchFeeComponents = async (
         base: b.base_fee,
         l1Cost: b.l1_data_cost ?? null,
       }))
+      : null,
+    badRequest: res.badRequest,
+    error: res.error,
+  };
+};
+
+export const fetchBatchFeeComponents = async (
+  range: TimeRange,
+  address?: string,
+): Promise<RequestResult<BatchFeeComponent[]>> => {
+  const url =
+    `${API_BASE}/batch-fee-components/aggregated?${timeRangeToQuery(range)}` +
+    (address ? `&address=${address}` : '');
+  const res = await fetchJson<{
+    batches: {
+      batch_id: number;
+      priority_fee: number;
+      base_fee: number;
+      l1_data_cost: number | null;
+    }[];
+  }>(url);
+  return {
+    data: res.data
+      ? res.data.batches.map((b) => ({
+          batch: b.batch_id,
+          priority: b.priority_fee,
+          base: b.base_fee,
+          l1Cost: b.l1_data_cost ?? null,
+        }))
       : null,
     badRequest: res.badRequest,
     error: res.error,

--- a/dashboard/tests/costChart.test.ts
+++ b/dashboard/tests/costChart.test.ts
@@ -7,7 +7,7 @@ import { CostChart } from '../components/CostChart';
 import * as priceService from '../services/priceService';
 
 const feeData = [
-  { block: 1, priority: 1, base: 1, l1Cost: 0 },
+  { batch: 1, priority: 1, base: 1, l1Cost: 0 },
 ];
 
 describe('CostChart', () => {

--- a/dashboard/tests/incomeChart.test.ts
+++ b/dashboard/tests/incomeChart.test.ts
@@ -7,7 +7,7 @@ import * as priceService from '../services/priceService';
 import { IncomeChart } from '../components/IncomeChart';
 
 const feeData = [
-  { block: 1, priority: 1, base: 1, l1Cost: 0 },
+  { batch: 1, priority: 1, base: 1, l1Cost: 0 },
 ];
 
 describe('IncomeChart', () => {

--- a/dashboard/tests/profitabilityChart.test.ts
+++ b/dashboard/tests/profitabilityChart.test.ts
@@ -8,7 +8,7 @@ import { ProfitabilityChart } from '../components/ProfitabilityChart';
 
 // Helper data with negative profit
 const feeData = [
-  { block: 1, priority: 0, base: 0, l1Cost: 0 },
+  { batch: 1, priority: 0, base: 0, l1Cost: 0 },
 ];
 
 describe('ProfitabilityChart', () => {

--- a/dashboard/types.ts
+++ b/dashboard/types.ts
@@ -57,6 +57,13 @@ export interface FeeComponent {
   l1Cost: number | null;
 }
 
+export interface BatchFeeComponent {
+  batch: number;
+  priority: number;
+  base: number;
+  l1Cost: number | null;
+}
+
 export interface BlockProfit {
   block: number;
   profit: number;


### PR DESCRIPTION
## Summary
- support batch fee components in API service
- query batches in Cost, Income, and Profitability charts
- compute profit tables by batch
- adjust tests for batch-based metrics

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685ab30371a08328ba08c21853d8ec61