### PR TITLE
Fix subsidy nodes by address in FeeFlowChart

### DIFF
--- a/dashboard/components/FeeFlowChart.tsx
+++ b/dashboard/components/FeeFlowChart.tsx
@@ -285,7 +285,8 @@ export const FeeFlowChart: React.FC<FeeFlowChartProps> = ({
 
     nodes = [
       ...seqData.map((s) => ({
-        name: 'Subsidy',
+        // use a unique name per sequencer so nodes don't get aggregated
+        name: `${s.shortAddress} Subsidy`,
         address: s.address,
         addressLabel: `${s.shortAddress} Subsidy`,
         value: s.subsidyUsd,


### PR DESCRIPTION
## Summary
- ensure each sequencer has a unique subsidy node so that subsidies aren't aggregated

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685ab3fe90e08328b25b4fd3a7b0e8da