### PR TITLE
Fix gas usage table ordering

### DIFF
--- a/dashboard/config/tableConfig.ts
+++ b/dashboard/config/tableConfig.ts
@@ -318,7 +318,7 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
       });
     },
     urlKey: 'l2-gas-used',
-    reverseOrder: true,
+    reverseOrder: false,
     supportsPagination: true,
   },
 


### PR DESCRIPTION
## Summary
- show L2 gas used table in descending order

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685ab5781a1c8328bf863b34304e8e93