### PR TITLE
Add profit metric to Network Economics

### DIFF
--- a/dashboard/hooks/useDataFetcher.ts
+++ b/dashboard/hooks/useDataFetcher.ts
@@ -72,6 +72,12 @@ export const useDataFetcher = ({
         priorityFee: data.priorityFee,
         baseFee: data.baseFee,
         l1DataCost: data.l1DataCost,
+        profit:
+          data.priorityFee != null &&
+          data.baseFee != null &&
+          data.l1DataCost != null
+            ? data.priorityFee + data.baseFee - data.l1DataCost
+            : null,
         l2Block: data.l2Block,
         l1Block: data.l1Block,
       };
@@ -109,6 +115,7 @@ export const useDataFetcher = ({
       priorityFee: data.priorityFee,
       baseFee: data.baseFee,
       l1DataCost: null,
+      profit: null,
       l2Block: data.l2Block,
       l1Block: data.l1Block,
     };

--- a/dashboard/tests/helpers.test.ts
+++ b/dashboard/tests/helpers.test.ts
@@ -18,6 +18,7 @@ const metrics = createMetrics({
   priorityFee: 41e18,
   baseFee: 1e18,
   l1DataCost: 2e18,
+  profit: 40e18,
 });
 
 const results = [
@@ -42,6 +43,7 @@ const metricsAllNull = createMetrics({
   priorityFee: null,
   baseFee: null,
   l1DataCost: null,
+  profit: null,
 });
 
 describe('helpers', () => {
@@ -68,18 +70,20 @@ describe('helpers', () => {
     expect(metrics[9].group).toBe('Network Health');
     expect(metrics[10].value).toBe('0');
     expect(metrics[10].group).toBe('Network Health');
-    expect(metrics[11].value).toBe('41.0 ETH');
+    expect(metrics[11].value).toBe('40.0 ETH');
     expect(metrics[11].group).toBe('Network Economics');
-    expect(metrics[12].value).toBe('1.00 ETH');
+    expect(metrics[12].value).toBe('41.0 ETH');
     expect(metrics[12].group).toBe('Network Economics');
-    expect(metrics[13].value).toBe('2.00 ETH');
+    expect(metrics[13].value).toBe('1.00 ETH');
     expect(metrics[13].group).toBe('Network Economics');
-    expect(metrics[14].value).toBe('100');
-    expect(metrics[14].link).toContain('/block/100');
-    expect(metrics[14].group).toBe('Block Information');
-    expect(metrics[15].value).toBe('50');
-    expect(metrics[15].link).toContain('/block/50');
+    expect(metrics[14].value).toBe('2.00 ETH');
+    expect(metrics[14].group).toBe('Network Economics');
+    expect(metrics[15].value).toBe('100');
+    expect(metrics[15].link).toContain('/block/100');
     expect(metrics[15].group).toBe('Block Information');
+    expect(metrics[16].value).toBe('50');
+    expect(metrics[16].link).toContain('/block/50');
+    expect(metrics[16].group).toBe('Block Information');
   });
 
   it('detects bad requests', () => {
@@ -107,8 +111,9 @@ describe('helpers', () => {
     expect(metricsAllNull[11].group).toBe('Network Economics');
     expect(metricsAllNull[12].group).toBe('Network Economics');
     expect(metricsAllNull[13].group).toBe('Network Economics');
-    expect(metricsAllNull[14].group).toBe('Block Information');
+    expect(metricsAllNull[14].group).toBe('Network Economics');
     expect(metricsAllNull[15].group).toBe('Block Information');
+    expect(metricsAllNull[16].group).toBe('Block Information');
   });
 
   it('handles all successful requests', () => {

--- a/dashboard/tests/metricsCreator.test.ts
+++ b/dashboard/tests/metricsCreator.test.ts
@@ -21,11 +21,12 @@ describe('metricsCreator', () => {
       priorityFee: 40e18,
       baseFee: 2e18,
       l1DataCost: 3e18,
+      profit: 39e18,
       l2Block: 100,
       l1Block: 50,
     });
 
-    expect(metrics).toHaveLength(16);
+    expect(metrics).toHaveLength(17);
     expect(metrics[0].value).toBe('1.23');
 
     const proveMetric = metrics.find((m) => m.title === 'Avg. Prove Time');
@@ -62,6 +63,7 @@ describe('metricsCreator', () => {
       priorityFee: null,
       baseFee: null,
       l1DataCost: null,
+      profit: null,
       l2Block: null,
       l1Block: null,
     });

--- a/dashboard/utils/metricsCreator.ts
+++ b/dashboard/utils/metricsCreator.ts
@@ -25,6 +25,7 @@ export interface MetricInputData {
   priorityFee: number | null;
   baseFee: number | null;
   l1DataCost?: number | null;
+  profit?: number | null;
 }
 
 export const createMetrics = (data: MetricInputData): MetricData[] => [
@@ -105,11 +106,16 @@ export const createMetrics = (data: MetricInputData): MetricData[] => [
   },
   {
     title: 'Forced Inclusions',
-    value:
-      data.forcedInclusions != null
-        ? formatWithCommas(data.forcedInclusions)
-        : 'N/A',
+      value:
+        data.forcedInclusions != null
+          ? formatWithCommas(data.forcedInclusions)
+          : 'N/A',
     group: 'Network Health',
+  },
+  {
+    title: 'Profit',
+    value: data.profit != null ? formatEth(data.profit) : 'N/A',
+    group: 'Network Economics',
   },
   {
     title: 'Priority Fee',


### PR DESCRIPTION
## Summary
- compute network profit from L2 fees and display in metrics
- support new `profit` field in data fetcher
- adjust metrics tests for new metric placement

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685ab4aec3f48328ab7e17e4a11f110d