### PR TITLE
Fix L2 TPS table order

### DIFF
--- a/dashboard/config/tableConfig.ts
+++ b/dashboard/config/tableConfig.ts
@@ -372,7 +372,6 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
         tps: d.tps.toFixed(2),
       })),
     urlKey: 'l2-tps',
-    reverseOrder: true,
     supportsPagination: true,
   },
 };


### PR DESCRIPTION
## Summary
- correct `l2-tps` table order so new blocks appear first

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685ab584d59c8328a3218fcde7c73524