### PR TITLE
Add batch counts column to sequencer profit ranking

### DIFF
--- a/dashboard/tests/profitRankingTable.test.ts
+++ b/dashboard/tests/profitRankingTable.test.ts
@@ -40,7 +40,8 @@ describe('ProfitRankingTable', () => {
             ],
           },
         },
-      } as any);
+        } as any)
+      .mockReturnValueOnce({ data: new Map([['0xseqa', 1], ['0xseqb', 1]]) } as any);
     vi.spyOn(api, 'fetchSequencerDistribution').mockResolvedValue({
       data: [
         { name: 'SeqA', address: '0xseqA', value: 10, tps: null },
@@ -48,7 +49,8 @@ describe('ProfitRankingTable', () => {
       ],
       badRequest: false,
       error: null,
-    } as any);
+        } as any)
+      .mockReturnValueOnce({ data: new Map([['0xseqa', 1]]) } as any);
     vi.spyOn(api, 'fetchL2Fees').mockResolvedValue({
       data: {
         priority_fee: 3e18,
@@ -90,6 +92,7 @@ describe('ProfitRankingTable', () => {
     expect(firstSeqIdx).toBeGreaterThan(-1);
     expect(secondSeqIdx).toBeGreaterThan(firstSeqIdx);
     expect(html.includes('Revenue (USD)')).toBe(true);
+    expect(html.includes('Batches')).toBe(true);
     expect(html.includes('Cost (USD)')).toBe(true);
     expect(html.includes('Profit (USD)')).toBe(true);
     expect(html.includes('↓')).toBe(true);
@@ -120,7 +123,8 @@ describe('ProfitRankingTable', () => {
             ],
           },
         },
-      } as any);
+      } as any)
+      .mockReturnValueOnce({ data: new Map([['0xseqa', 1]]) } as any);
 
     vi.spyOn(api, 'fetchSequencerDistribution').mockResolvedValue({
       data: [{ name: 'SeqA', address: '0xseqA', value: 1, tps: null }],


### PR DESCRIPTION
## Summary
- display batches per sequencer in ProfitRankingTable
- test updated table output

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685ab69c1ad48328a69e2ff6e756fd09