### PR TITLE
feat(dashboard): link batches to sequenced blocks

### DIFF
--- a/crates/api/src/helpers/aggregation.rs
+++ b/crates/api/src/helpers/aggregation.rs
@@ -118,8 +118,10 @@ pub fn aggregate_batch_fee_components(
             let (sum_l1, any): (u128, bool) = rs.iter().fold((0, false), |(s, a), r| {
                 (s + r.l1_data_cost.unwrap_or(0), a || r.l1_data_cost.is_some())
             });
+            let first_block = rs.iter().map(|r| r.first_l2_block_number).min().unwrap_or(0);
             BatchFeeComponentRow {
                 batch_id: g * bucket,
+                first_l2_block_number: first_block,
                 priority_fee: sum_priority,
                 base_fee: sum_base,
                 l1_data_cost: any.then_some(sum_l1),

--- a/crates/clickhouse/src/models.rs
+++ b/crates/clickhouse/src/models.rs
@@ -313,6 +313,8 @@ pub struct SequencerFeeRow {
 pub struct BatchFeeComponentRow {
     /// Batch ID
     pub batch_id: u64,
+    /// First L2 block number in the batch
+    pub first_l2_block_number: u64,
     /// Total priority fee for the batch
     pub priority_fee: u128,
     /// Total base fee for the batch

--- a/dashboard/components/BlockProfitTables.tsx
+++ b/dashboard/components/BlockProfitTables.tsx
@@ -16,7 +16,10 @@ interface BlockProfitTablesProps {
 const formatUsd = (value: number): string => {
   const abs = Math.abs(value);
   if (abs >= 1000) return Math.trunc(value).toLocaleString();
-  return value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+  return value.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
 };
 
 export const BlockProfitTables: React.FC<BlockProfitTablesProps> = ({
@@ -35,18 +38,28 @@ export const BlockProfitTables: React.FC<BlockProfitTablesProps> = ({
   const HOURS_IN_MONTH = 30 * 24;
   const hours = rangeToHours(timeRange);
   const costPerBatch =
-    batchCount > 0 ? ((cloudCost + proverCost) / HOURS_IN_MONTH) * hours / batchCount : 0;
+    batchCount > 0
+      ? (((cloudCost + proverCost) / HOURS_IN_MONTH) * hours) / batchCount
+      : 0;
 
   const calcProfit = (wei: number) => (wei / 1e18) * ethPrice - costPerBatch;
 
   const profits = batchData.map((b) => ({
     batch: b.batch,
+    block: b.block,
     profit: b.priority + b.base - (b.l1Cost ?? 0),
   }));
-  const topBatches = [...profits].sort((a, b) => b.profit - a.profit).slice(0, 5);
-  const bottomBatches = [...profits].sort((a, b) => a.profit - b.profit).slice(0, 5);
+  const topBatches = [...profits]
+    .sort((a, b) => b.profit - a.profit)
+    .slice(0, 5);
+  const bottomBatches = [...profits]
+    .sort((a, b) => a.profit - b.profit)
+    .slice(0, 5);
 
-  const renderTable = (title: string, items: { batch: number; profit: number }[] | null) => (
+  const renderTable = (
+    title: string,
+    items: { batch: number; block: number; profit: number }[] | null,
+  ) => (
     <div>
       <h3 className="text-lg font-semibold mb-2">{title}</h3>
       <div className="overflow-x-auto">
@@ -59,9 +72,14 @@ export const BlockProfitTables: React.FC<BlockProfitTablesProps> = ({
           </thead>
           <tbody>
             {items?.map((b) => (
-              <tr key={b.batch} className="border-t border-gray-200 dark:border-gray-700">
-                <td className="px-2 py-1">{blockLink(b.batch)}</td>
-                <td className="px-2 py-1">${formatUsd(calcProfit(b.profit))}</td>
+              <tr
+                key={b.batch}
+                className="border-t border-gray-200 dark:border-gray-700"
+              >
+                <td className="px-2 py-1">{blockLink(b.block)}</td>
+                <td className="px-2 py-1">
+                  ${formatUsd(calcProfit(b.profit))}
+                </td>
               </tr>
             ))}
           </tbody>

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -178,10 +178,10 @@ export const fetchL2ReorgEvents = async (
   return {
     data: res.data?.events
       ? res.data.events.map((e) => ({
-        l2_block_number: e.l2_block_number,
-        depth: e.depth,
-        timestamp: Date.parse(e.inserted_at),
-      }))
+          l2_block_number: e.l2_block_number,
+          depth: e.depth,
+          timestamp: Date.parse(e.inserted_at),
+        }))
       : null,
     badRequest: res.badRequest,
     error: res.error,
@@ -320,10 +320,10 @@ export const fetchProveTimes = async (
   return {
     data: res.data
       ? res.data.batches.map((b) => ({
-        name: b.batch_id.toString(),
-        value: b.seconds_to_prove,
-        timestamp: 0,
-      }))
+          name: b.batch_id.toString(),
+          value: b.seconds_to_prove,
+          timestamp: 0,
+        }))
       : null,
     badRequest: res.badRequest,
     error: res.error,
@@ -353,10 +353,10 @@ export const fetchVerifyTimes = async (
   return {
     data: res.data
       ? res.data.batches.map((b) => ({
-        name: b.batch_id.toString(),
-        value: b.seconds_to_verify,
-        timestamp: 0,
-      }))
+          name: b.batch_id.toString(),
+          value: b.seconds_to_verify,
+          timestamp: 0,
+        }))
       : null,
     badRequest: res.badRequest,
     error: res.error,
@@ -525,10 +525,10 @@ export const fetchL2GasUsed = async (
   return {
     data: res.data
       ? res.data.blocks.map((b) => ({
-        value: b.l2_block_number,
-        timestamp: b.gas_used,
-        blockTime: new Date(b.block_time).getTime(),
-      }))
+          value: b.l2_block_number,
+          timestamp: b.gas_used,
+          blockTime: new Date(b.block_time).getTime(),
+        }))
       : null,
     badRequest: res.badRequest,
     error: res.error,
@@ -548,10 +548,10 @@ export const fetchL2GasUsedAggregated = async (
   return {
     data: res.data
       ? res.data.blocks.map((b) => ({
-        value: b.l2_block_number,
-        timestamp: b.gas_used,
-        blockTime: new Date(b.block_time).getTime(),
-      }))
+          value: b.l2_block_number,
+          timestamp: b.gas_used,
+          blockTime: new Date(b.block_time).getTime(),
+        }))
       : null,
     badRequest: res.badRequest,
     error: res.error,
@@ -568,11 +568,11 @@ export const fetchSequencerDistribution = async (
   return {
     data: res.data
       ? res.data.sequencers.map((s) => ({
-        name: getSequencerName(s.address),
-        address: s.address,
-        value: s.blocks,
-        tps: s.tps,
-      }))
+          name: getSequencerName(s.address),
+          address: s.address,
+          value: s.blocks,
+          tps: s.tps,
+        }))
       : null,
     badRequest: res.badRequest,
     error: res.error,
@@ -639,11 +639,11 @@ export const fetchBlockTransactions = async (
   return {
     data: res.data?.blocks
       ? res.data.blocks.map((b) => ({
-        block: b.block,
-        txs: b.txs,
-        sequencer: getSequencerName(b.sequencer),
-        blockTime: new Date(b.block_time).getTime(),
-      }))
+          block: b.block,
+          txs: b.txs,
+          sequencer: getSequencerName(b.sequencer),
+          blockTime: new Date(b.block_time).getTime(),
+        }))
       : null,
     badRequest: res.badRequest,
     error: res.error,
@@ -684,11 +684,11 @@ export const fetchBlockTransactionsAggregated = async (
   return {
     data: res.data?.blocks
       ? res.data.blocks.map((b) => ({
-        block: b.block,
-        txs: b.txs,
-        sequencer: getSequencerName(b.sequencer),
-        blockTime: new Date(b.block_time).getTime(),
-      }))
+          block: b.block,
+          txs: b.txs,
+          sequencer: getSequencerName(b.sequencer),
+          blockTime: new Date(b.block_time).getTime(),
+        }))
       : null,
     badRequest: res.badRequest,
     error: res.error,
@@ -728,10 +728,10 @@ export const fetchBatchBlobCounts = async (
   return {
     data: res.data
       ? res.data.batches.map((b) => ({
-        block: b.l1_block_number ?? b.batch_id, // Fallback to batch_id for backward compatibility
-        batch: b.batch_id,
-        blobs: b.blob_count,
-      }))
+          block: b.l1_block_number ?? b.batch_id, // Fallback to batch_id for backward compatibility
+          batch: b.batch_id,
+          blobs: b.blob_count,
+        }))
       : null,
     badRequest: res.badRequest,
     error: res.error,
@@ -803,6 +803,7 @@ export interface FeeComponent {
 
 export interface BatchFeeComponent {
   batch: number;
+  block: number;
   priority: number;
   base: number;
   l1Cost: number | null;
@@ -826,11 +827,11 @@ export const fetchFeeComponents = async (
   return {
     data: res.data
       ? res.data.blocks.map((b) => ({
-        block: b.l2_block_number,
-        priority: b.priority_fee,
-        base: b.base_fee,
-        l1Cost: b.l1_data_cost ?? null,
-      }))
+          block: b.l2_block_number,
+          priority: b.priority_fee,
+          base: b.base_fee,
+          l1Cost: b.l1_data_cost ?? null,
+        }))
       : null,
     badRequest: res.badRequest,
     error: res.error,
@@ -847,6 +848,7 @@ export const fetchBatchFeeComponents = async (
   const res = await fetchJson<{
     batches: {
       batch_id: number;
+      first_l2_block_number: number;
       priority_fee: number;
       base_fee: number;
       l1_data_cost: number | null;
@@ -856,6 +858,7 @@ export const fetchBatchFeeComponents = async (
     data: res.data
       ? res.data.batches.map((b) => ({
           batch: b.batch_id,
+          block: b.first_l2_block_number,
           priority: b.priority_fee,
           base: b.base_fee,
           l1Cost: b.l1_data_cost ?? null,
@@ -951,9 +954,13 @@ export const fetchBlockProfits = async (
   const url =
     `${API_BASE}/block-profits?${timeRangeToQuery(range)}&order=${order}&limit=${limit}` +
     (address ? `&address=${address}` : '');
-  const res = await fetchJson<{ blocks: { block: number; profit: number }[] }>(url);
+  const res = await fetchJson<{ blocks: { block: number; profit: number }[] }>(
+    url,
+  );
   return {
-    data: res.data ? res.data.blocks.map((b) => ({ block: b.block, profit: b.profit })) : null,
+    data: res.data
+      ? res.data.blocks.map((b) => ({ block: b.block, profit: b.profit }))
+      : null,
     badRequest: res.badRequest,
     error: res.error,
   };

--- a/dashboard/types.ts
+++ b/dashboard/types.ts
@@ -59,6 +59,7 @@ export interface FeeComponent {
 
 export interface BatchFeeComponent {
   batch: number;
+  block: number;
   priority: number;
   base: number;
   l1Cost: number | null;


### PR DESCRIPTION
## Summary
- link batch numbers in economics BlockProfitTables to the block explorer

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685ab70844ec83288fcb20cb1e418100