### PR TITLE
Fix subsidy node color

### DIFF
--- a/dashboard/components/FeeFlowChart.tsx
+++ b/dashboard/components/FeeFlowChart.tsx
@@ -29,7 +29,8 @@ const SankeyNode = ({ x, y, width, height, payload }: any) => {
     payload.name === 'Cloud Cost' ||
     payload.name === 'Prover Cost' ||
     payload.name === 'L1 Data Cost' ||
-    payload.name === 'Subsidy';
+    payload.name === 'Subsidy' ||
+    (typeof payload.name === 'string' && payload.name.includes('Subsidy'));
   const isProfitNode = payload.name === 'Profit' || payload.profitNode;
   const isPinkNode =
     payload.name === 'Taiko DAO' ||
@@ -86,7 +87,9 @@ const SankeyLink = ({
     payload.target.name === 'Cloud Cost' ||
     payload.target.name === 'Prover Cost' ||
     payload.target.name === 'L1 Data Cost' ||
-    payload.target.name === 'Subsidy';
+    payload.target.name === 'Subsidy' ||
+    (typeof payload.target.name === 'string' &&
+      payload.target.name.includes('Subsidy'));
   const isProfit =
     payload.target.name === 'Profit' || payload.target.profitNode;
 


### PR DESCRIPTION
## Summary
- color 'Subsidy' nodes red when their labels include sequencer addresses

## Testing
- `npm run check`
- `npm run test`
- `npm run lint:whitespace`
- `just ci` *(fails: `cargo +nightly` not available)*

------
https://chatgpt.com/codex/tasks/task_b_685bb749c2d88328b7407db92070a23d