### PR TITLE
Fix sequencer name display

### DIFF
--- a/dashboard/components/FeeFlowChart.tsx
+++ b/dashboard/components/FeeFlowChart.tsx
@@ -6,6 +6,7 @@ import { TAIKO_PINK } from '../theme';
 const NODE_GREEN = '#22c55e';
 import useSWR from 'swr';
 import { fetchL2Fees } from '../services/apiService';
+import { getSequencerName } from '../sequencerConfig';
 import { useEthPrice } from '../services/priceService';
 import { TimeRange } from '../types';
 import { rangeToHours } from '../utils/timeRange';
@@ -173,7 +174,11 @@ export const FeeFlowChart: React.FC<FeeFlowChartProps> = ({
     const actualL1CostWei = ethPrice
       ? (actualL1Cost / ethPrice) * WEI_TO_ETH
       : 0;
-    const shortAddress = f.address.slice(0, 7);
+    const name = getSequencerName(f.address);
+    const shortAddress =
+      name.toLowerCase() === f.address.toLowerCase()
+        ? f.address.slice(0, 7)
+        : name;
     return {
       address: f.address,
       shortAddress,

--- a/dashboard/components/ProfitRankingTable.tsx
+++ b/dashboard/components/ProfitRankingTable.tsx
@@ -262,7 +262,7 @@ export const ProfitRankingTable: React.FC<ProfitRankingTableProps> = ({
                 key={row.address}
                 className="border-t border-gray-200 dark:border-gray-700"
               >
-                <td className="px-2 py-1">{addressLink(row.address)}</td>
+                <td className="px-2 py-1">{addressLink(row.address, row.name)}</td>
                 <td className="px-2 py-1">{row.blocks.toLocaleString()}</td>
                 <td className="px-2 py-1">
                   {row.batches != null ? row.batches.toLocaleString() : 'N/A'}


### PR DESCRIPTION
## Summary
- show sequencer names rather than addresses in profit ranking table
- use sequencer name for short address labels in the fee flow chart

## Testing
- `npm run check`
- `npm run lint:whitespace`
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_685ac2d736f88328a12ccc9dd5b099f3