### PR TITLE
Add USD tooltip to economics metrics

### DIFF
--- a/dashboard/components/MetricCard.tsx
+++ b/dashboard/components/MetricCard.tsx
@@ -9,6 +9,7 @@ interface MetricCardProps {
   description?: React.ReactNode;
   className?: string;
   onMore?: () => void;
+  tooltip?: string;
 }
 
 export const MetricCard: React.FC<MetricCardProps> = ({
@@ -18,6 +19,7 @@ export const MetricCard: React.FC<MetricCardProps> = ({
   description,
   className,
   onMore,
+  tooltip,
 }) => {
   // Check if value looks like an Ethereum address (0x followed by 40 hex characters)
   const isAddress = /^0x[a-fA-F0-9]{40}$/.test(value);
@@ -43,6 +45,7 @@ export const MetricCard: React.FC<MetricCardProps> = ({
       </div>
       <p
         className={`mt-1 font-semibold text-gray-900 dark:text-gray-100 ${isAddress ? 'text-base break-all' : `text-2xl${isShortValue ? '' : ' whitespace-nowrap overflow-hidden text-ellipsis'}`}`}
+        title={tooltip}
       >
         {link ? (
           <a

--- a/dashboard/components/layout/MetricsGrid.tsx
+++ b/dashboard/components/layout/MetricsGrid.tsx
@@ -3,6 +3,8 @@ import { MetricCard } from '../MetricCard';
 import { MetricCardSkeleton } from '../MetricCardSkeleton';
 import { MetricData, TimeRange } from '../../types';
 import { formatTimeRangeDisplay } from '../../utils/timeRange';
+import { parseEthValue, formatUsd } from '../../utils';
+import { useEthPrice } from '../../services/priceService';
 
 interface MetricsGridProps {
   isLoading: boolean;
@@ -30,6 +32,7 @@ export const MetricsGrid: React.FC<MetricsGridProps> = ({
   timeRange,
 }) => {
   const displayedGroupOrder = groupOrder;
+  const { data: ethPrice = 0 } = useEthPrice();
   const regularGrid =
     'grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 gap-4 md:gap-6';
   const economicsGrid =
@@ -78,19 +81,26 @@ export const MetricsGrid: React.FC<MetricsGridProps> = ({
                 </h2>
               )}
               <div className={economicsView ? economicsGrid : regularGrid}>
-                {groupedMetrics[group].map((m, idx) => (
-                  <MetricCard
-                    key={`${group}-${idx}`}
-                    title={m.title}
-                    value={m.value}
-                    link={m.link}
-                    onMore={
-                      typeof m.title === 'string'
-                        ? onMetricAction(m.title)
-                        : undefined
-                    }
-                  />
-                ))}
+                {groupedMetrics[group].map((m, idx) => {
+                  const tooltip =
+                    economicsView && /ETH/i.test(m.value)
+                      ? `$${formatUsd(parseEthValue(m.value) * ethPrice)}`
+                      : undefined;
+                  return (
+                    <MetricCard
+                      key={`${group}-${idx}`}
+                      title={m.title}
+                      value={m.value}
+                      link={m.link}
+                      onMore={
+                        typeof m.title === 'string'
+                          ? onMetricAction(m.title)
+                          : undefined
+                      }
+                      tooltip={tooltip}
+                    />
+                  );
+                })}
               </div>
               {groupedCharts?.[group] && groupedCharts[group].length > 0 && (
                 <div className={chartsGrid}>{groupedCharts[group].map((c, i) => (

--- a/dashboard/utils.ts
+++ b/dashboard/utils.ts
@@ -115,6 +115,17 @@ export const parseEthValue = (value: string): number => {
   return /gwei/i.test(value) ? amount / 1e9 : amount;
 };
 
+export const formatUsd = (value: number): string => {
+  const abs = Math.abs(value);
+  if (abs >= 1000) {
+    return Math.trunc(value).toLocaleString();
+  }
+  return value.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+};
+
 export const formatTime = (ms: number): string =>
   new Date(ms).toLocaleTimeString([], {
     hour: '2-digit',


### PR DESCRIPTION
## Summary
- show tooltip for metrics on Economics page
- compute USD equivalent for ETH values using `parseEthValue` and `formatUsd`
- expose `formatUsd` util and new tooltip prop on `MetricCard`

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685ac223a6148328b4de4f40edb23432