### PR TITLE
Add ROI column to profit ranking table

### DIFF
--- a/dashboard/tests/profitRankingTable.test.ts
+++ b/dashboard/tests/profitRankingTable.test.ts
@@ -41,7 +41,12 @@ describe('ProfitRankingTable', () => {
           },
         },
       } as any)
-      .mockReturnValueOnce({ data: new Map([['0xseqa', 1], ['0xseqb', 1]]) } as any);
+      .mockReturnValueOnce({
+        data: new Map([
+          ['0xseqa', 1],
+          ['0xseqb', 1],
+        ]),
+      } as any);
 
     vi.spyOn(api, 'fetchSequencerDistribution').mockResolvedValue({
       data: [
@@ -95,6 +100,7 @@ describe('ProfitRankingTable', () => {
     expect(html.includes('Batches')).toBe(true);
     expect(html.includes('Cost (ETH)')).toBe(true);
     expect(html.includes('Profit (ETH)')).toBe(true);
+    expect(html.includes('Income/Cost')).toBe(true);
     expect(html.includes('↓')).toBe(true);
   });
 
@@ -102,9 +108,7 @@ describe('ProfitRankingTable', () => {
     vi.mocked(swr.default)
       .mockReturnValueOnce({
         data: {
-          data: [
-            { name: 'SeqA', address: '0xseqA', value: 1, tps: null },
-          ],
+          data: [{ name: 'SeqA', address: '0xseqA', value: 1, tps: null }],
         },
       } as any)
       .mockReturnValueOnce({


### PR DESCRIPTION
## Summary
- show ratio of income to cost in sequencer profit ranking table
- test presence of new column

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685bb90d3b248328b9c5b91f602b1768