### PR TITLE
Fix negative zero formatting in dashboard

### DIFF
--- a/dashboard/tests/utils.test.ts
+++ b/dashboard/tests/utils.test.ts
@@ -135,6 +135,9 @@ describe('utils', () => {
     expect(formatEth(1422636.1e9)).toBe('1,422,636 Gwei');
     expect(formatEth(1422636.1e18)).toBe('1,422,636 ETH');
     expect(formatEth(187788.9e9)).toBe('187,788 Gwei');
+    expect(formatEth(-1e8)).toBe('-100,000,000 wei');
+    expect(formatEth(-345678.9e9)).toBe('-345,678 Gwei');
+    expect(formatEth(-1.2345e18)).toBe('-1.23 ETH');
   });
 
   it('parses ETH and Gwei values', () => {

--- a/dashboard/utils.ts
+++ b/dashboard/utils.ts
@@ -61,7 +61,8 @@ export const addressLink = (
 
 export const formatDecimal = (value: number): string => {
   const decimals = Math.abs(value) >= 10 ? 1 : 2;
-  return value.toFixed(decimals);
+  const fixed = value.toFixed(decimals);
+  return Number(fixed).toFixed(decimals);
 };
 
 export const formatSeconds = (seconds: number): string => {


### PR DESCRIPTION
## Summary
- avoid `-0.00 ETH` in UI by normalising near-zero values
- ensure negative ETH amounts format to wei or gwei

## Testing
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_685bbc716c7083288cf54fe7214bc8f7