### PR TITLE
Update block number field names

### DIFF
--- a/crates/clickhouse/src/models.rs
+++ b/crates/clickhouse/src/models.rs
@@ -237,7 +237,7 @@ pub struct L1BlockTimeRow {
     /// Minute timestamp (unix seconds)
     pub minute: u64,
     /// Highest L1 block number within that minute
-    pub block_number: u64,
+    pub l1_block_number: u64,
 }
 
 /// Row representing the time between consecutive L2 blocks

--- a/crates/clickhouse/src/reader.rs
+++ b/crates/clickhouse/src/reader.rs
@@ -1301,11 +1301,11 @@ impl ClickhouseReader {
     pub async fn get_l1_block_times(&self, range: TimeRange) -> Result<Vec<L1BlockTimeRow>> {
         let query = format!(
             "SELECT toUInt64(toStartOfMinute(fromUnixTimestamp64Milli(block_ts * 1000))) AS minute, \
-                    max(l1_block_number) AS block_number \
+                    max(l1_block_number) AS l1_block_number \
              FROM {db}.l1_head_events \
-             WHERE block_ts >= toUnixTimestamp(now64() - INTERVAL {interval}) \
-             GROUP BY minute \
-             ORDER BY minute",
+              WHERE block_ts >= toUnixTimestamp(now64() - INTERVAL {interval}) \
+              GROUP BY minute \
+              ORDER BY minute",
             interval = range.interval(),
             db = self.db_name,
         );

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -252,10 +252,10 @@ export const fetchL1HeadBlock = async (
   range: TimeRange,
 ): Promise<RequestResult<number>> => {
   const url = `${API_BASE}/l1-block-times?${timeRangeToQuery(range)}`;
-  const res = await fetchJson<{ blocks: { block_number: number }[] }>(url);
+  const res = await fetchJson<{ blocks: { l1_block_number: number }[] }>(url);
   const value =
     res.data && res.data.blocks.length > 0
-      ? res.data.blocks[res.data.blocks.length - 1].block_number
+      ? res.data.blocks[res.data.blocks.length - 1].l1_block_number
       : null;
   return { data: value, badRequest: res.badRequest, error: res.error };
 };
@@ -368,7 +368,7 @@ export const fetchL1BlockTimes = async (
 ): Promise<RequestResult<TimeSeriesData[]>> => {
   const url = `${API_BASE}/l1-block-times?${timeRangeToQuery(range)}`;
   const res = await fetchJson<{
-    blocks: { minute: number; block_number: number }[];
+    blocks: { minute: number; l1_block_number: number }[];
   }>(url);
   if (!res.data) {
     return { data: null, badRequest: res.badRequest, error: res.error };
@@ -376,7 +376,7 @@ export const fetchL1BlockTimes = async (
 
   const blocks = res.data.blocks.map((b) => ({
     ts: b.minute * 1000,
-    block: b.block_number,
+    block: b.l1_block_number,
   }));
 
   const data = blocks

--- a/dashboard/tests/app.integration.test.ts
+++ b/dashboard/tests/app.integration.test.ts
@@ -102,14 +102,14 @@ const responses: Record<string, Record<string, unknown>> = {
   },
   [`/v1/l1-block-times?${q1h}`]: {
     blocks: [
-      { block_number: 50, minute: 1 },
-      { block_number: 52, minute: 2 },
+      { l1_block_number: 50, minute: 1 },
+      { l1_block_number: 52, minute: 2 },
     ],
   },
   [`/v1/l1-block-times?${q15m}`]: {
     blocks: [
-      { block_number: 50, minute: 1 },
-      { block_number: 52, minute: 2 },
+      { l1_block_number: 50, minute: 1 },
+      { l1_block_number: 52, minute: 2 },
     ],
   },
   [`/v1/prove-times?${q1h}&limit=50`]: {

--- a/tests/api_integration.rs
+++ b/tests/api_integration.rs
@@ -107,7 +107,7 @@ struct BlockNumRow {
 #[derive(Serialize, Row)]
 struct BlockTimeRow {
     minute: u64,
-    block_number: u64,
+    l1_block_number: u64,
 }
 
 #[derive(Serialize, Row)]
@@ -253,7 +253,7 @@ async fn l1_head_block_integration() {
 #[tokio::test]
 async fn l1_block_times_success_and_invalid() {
     let mock = Mock::new();
-    mock.add(handlers::provide(vec![BlockTimeRow { minute: 1, block_number: 2 }]));
+    mock.add(handlers::provide(vec![BlockTimeRow { minute: 1, l1_block_number: 2 }]));
 
     let url = Url::parse(mock.url()).unwrap();
     let client =
@@ -269,7 +269,7 @@ async fn l1_block_times_success_and_invalid() {
     .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
     let body: serde_json::Value = resp.json().await.unwrap();
-    assert_eq!(body, serde_json::json!({ "blocks": [ { "minute": 1, "block_number": 2 } ] }));
+    assert_eq!(body, serde_json::json!({ "blocks": [ { "minute": 1, "l1_block_number": 2 } ] }));
 
     let resp = reqwest::get(
         format!("http://{addr}/{API_VERSION}/l1-block-times?created[gte]=10&created[lte]=5"),


### PR DESCRIPTION
## Summary
- rename `block_number` fields to `l1_block_number`
- propagate rename in queries, API service, and tests

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685bc6b8c4dc8328827032026271d2c3