### PR TITLE
Add NATS config options

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -27,7 +27,7 @@ pub struct ClickhouseOpts {
 pub struct NatsOpts {
     /// Nats server URL
     #[clap(long = "nats-url", env = "NATS_URL")]
-    pub nats_url: Url,
+    pub nats_url: Option<Url>,
     /// Nats username
     #[clap(id = "nats_username", long = "nats-username", env = "NATS_USERNAME")]
     pub username: Option<String>,

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -22,6 +22,20 @@ pub struct ClickhouseOpts {
     pub password: String,
 }
 
+/// Nats client configuration options
+#[derive(Debug, Clone, Parser)]
+pub struct NatsOpts {
+    /// Nats server URL
+    #[clap(long = "nats-url", env = "NATS_URL")]
+    pub nats_url: Url,
+    /// Nats username
+    #[clap(id = "nats_username", long = "nats-username", env = "NATS_USERNAME")]
+    pub username: Option<String>,
+    /// Nats password
+    #[clap(id = "nats_password", long = "nats-password", env = "NATS_PASSWORD")]
+    pub password: Option<String>,
+}
+
 /// RPC endpoint configuration options
 #[derive(Debug, Clone, Parser)]
 pub struct RpcOpts {
@@ -142,6 +156,10 @@ pub struct Opts {
     #[clap(flatten)]
     pub clickhouse: ClickhouseOpts,
 
+    /// Nats client configuration
+    #[clap(flatten)]
+    pub nats: NatsOpts,
+
     /// RPC endpoint configuration
     #[clap(flatten)]
     pub rpc: RpcOpts,
@@ -187,6 +205,12 @@ mod tests {
             "user",
             "--password",
             "pass",
+            "--nats-url",
+            "nats://localhost:4222",
+            "--nats-username",
+            "natsuser",
+            "--nats-password",
+            "natspass",
             "--l1-url",
             "http://l1",
             "--l2-url",

--- a/crates/driver/src/lib.rs
+++ b/crates/driver/src/lib.rs
@@ -620,7 +620,9 @@ mod tests {
         ProvedBatchRow, VerifiedBatchRow,
     };
     use clickhouse_rs::test::{Mock, handlers};
-    use config::{ApiOpts, ClickhouseOpts, InstatusOpts, Opts, RpcOpts, TaikoAddressOpts};
+    use config::{
+        ApiOpts, ClickhouseOpts, InstatusOpts, NatsOpts, Opts, RpcOpts, TaikoAddressOpts,
+    };
 
     use alloy_primitives::{Address, B256};
     use futures::future;
@@ -641,13 +643,18 @@ mod tests {
         (url, handle)
     }
 
-    fn make_opts(url: Url, l1_url: Url, l2_url: Url) -> Opts {
+    fn make_opts(url: Url, nats_url: Url, l1_url: Url, l2_url: Url) -> Opts {
         Opts {
             clickhouse: ClickhouseOpts {
                 url,
                 db: "test".into(),
                 username: "user".into(),
                 password: "pass".into(),
+            },
+            nats: NatsOpts {
+                nats_url,
+                username: Some("natsuser".into()),
+                password: Some("natspass".into()),
             },
             rpc: RpcOpts { l1_url, l2_url, public_url: None },
             api: ApiOpts {
@@ -687,7 +694,8 @@ mod tests {
         let url = Url::parse(mock.url()).unwrap();
         let (l1_url, l1_handle) = start_ws_server().await;
         let (l2_url, l2_handle) = start_ws_server().await;
-        let opts = make_opts(url, l1_url.clone(), l2_url.clone());
+        let nats_url = Url::parse("nats://localhost:4222").unwrap();
+        let opts = make_opts(url, nats_url, l1_url.clone(), l2_url.clone());
 
         let driver = Driver::new_with_migrations(opts.clone(), false).await.unwrap();
         l1_handle.abort();
@@ -705,10 +713,13 @@ mod tests {
         let url = Url::parse(mock.url()).unwrap();
         let (l1_url, l1_handle) = start_ws_server().await;
         let (l2_url, l2_handle) = start_ws_server().await;
-        let mut driver =
-            Driver::new_with_migrations(make_opts(url, l1_url.clone(), l2_url.clone()), false)
-                .await
-                .unwrap();
+        let nats_url = Url::parse("nats://localhost:4222").unwrap();
+        let mut driver = Driver::new_with_migrations(
+            make_opts(url, nats_url, l1_url.clone(), l2_url.clone()),
+            false,
+        )
+        .await
+        .unwrap();
         l1_handle.abort();
         l2_handle.abort();
 
@@ -754,10 +765,13 @@ mod tests {
         let url = Url::parse(mock.url()).unwrap();
         let (l1_url, l1_handle) = start_ws_server().await;
         let (l2_url, l2_handle) = start_ws_server().await;
-        let driver =
-            Driver::new_with_migrations(make_opts(url, l1_url.clone(), l2_url.clone()), false)
-                .await
-                .unwrap();
+        let nats_url = Url::parse("nats://localhost:4222").unwrap();
+        let driver = Driver::new_with_migrations(
+            make_opts(url, nats_url, l1_url.clone(), l2_url.clone()),
+            false,
+        )
+        .await
+        .unwrap();
         l1_handle.abort();
         l2_handle.abort();
 
@@ -787,10 +801,13 @@ mod tests {
         let url = Url::parse(mock.url()).unwrap();
         let (l1_url, l1_handle) = start_ws_server().await;
         let (l2_url, l2_handle) = start_ws_server().await;
-        let driver =
-            Driver::new_with_migrations(make_opts(url, l1_url.clone(), l2_url.clone()), false)
-                .await
-                .unwrap();
+        let nats_url = Url::parse("nats://localhost:4222").unwrap();
+        let driver = Driver::new_with_migrations(
+            make_opts(url, nats_url, l1_url.clone(), l2_url.clone()),
+            false,
+        )
+        .await
+        .unwrap();
         l1_handle.abort();
         l2_handle.abort();
 
@@ -829,10 +846,13 @@ mod tests {
         let url = Url::parse(mock.url()).unwrap();
         let (l1_url, l1_handle) = start_ws_server().await;
         let (l2_url, l2_handle) = start_ws_server().await;
-        let driver =
-            Driver::new_with_migrations(make_opts(url, l1_url.clone(), l2_url.clone()), false)
-                .await
-                .unwrap();
+        let nats_url = Url::parse("nats://localhost:4222").unwrap();
+        let driver = Driver::new_with_migrations(
+            make_opts(url, nats_url, l1_url.clone(), l2_url.clone()),
+            false,
+        )
+        .await
+        .unwrap();
         l1_handle.abort();
         l2_handle.abort();
 

--- a/crates/driver/src/lib.rs
+++ b/crates/driver/src/lib.rs
@@ -652,7 +652,7 @@ mod tests {
                 password: "pass".into(),
             },
             nats: NatsOpts {
-                nats_url,
+                nats_url: Some(nats_url),
                 username: Some("natsuser".into()),
                 password: Some("natspass".into()),
             },


### PR DESCRIPTION
## Summary
- add `NatsOpts` with URL and optional credentials
- expose `nats` config in `Opts`
- adjust unit tests and driver tests for the new field

## Testing
- `just lint`
- `just test`


------
https://chatgpt.com/codex/tasks/task_b_685bc7aebea88328ae7b302b3402a59c