### PR TITLE
Add block range validation

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -53,6 +53,7 @@ use utoipa::OpenApi;
             validation::CommonQuery,
             validation::PaginatedQuery,
             validation::TimeRangeParams,
+            validation::BlockRangeParams,
             L2HeadResponse,
             L1HeadResponse,
             L2HeadBlockResponse,


### PR DESCRIPTION
## Summary
- support block-based range filters in API
- expose `BlockRangeParams` in OpenAPI
- test new validation logic

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685bc9635c208328884df7b332e461d7