### PR TITLE
Add BlockPaginatedQuery

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -53,6 +53,7 @@ use utoipa::OpenApi;
         schemas(
             validation::CommonQuery,
             validation::PaginatedQuery,
+            validation::BlockPaginatedQuery,
             validation::TimeRangeParams,
             validation::BlockRangeParams,
             L2HeadResponse,


### PR DESCRIPTION
## Summary
- add `BlockPaginatedQuery` type to combine block ranges with pagination
- include the new type in the OpenAPI spec
- extend validation tests for block range edge cases

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685bd04000f4832896d2101885204f06