### PR TITLE
Improve Docker build efficiency

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -17,10 +17,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     cmake \
     && rm -rf /var/lib/apt/lists/*
 
-RUN cargo install --locked sccache cargo-chef && \
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    cargo install --locked sccache cargo-chef && \
     rm -rf /usr/local/cargo/registry /usr/local/cargo/git
 
-ENV RUSTC_WRAPPER=sccache SCCACHE_DIR=/sccache
+ENV RUSTC_WRAPPER=sccache SCCACHE_DIR=/sccache \
+    CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 
 FROM base AS planner
 
@@ -29,6 +32,8 @@ WORKDIR /app
 COPY . .
 
 RUN --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
     cargo chef prepare --recipe-path recipe.json
 
 FROM base AS builder
@@ -40,9 +45,13 @@ COPY --from=planner /app/recipe.json recipe.json
 ARG TARGETARCH
 
 RUN --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
     cargo chef cook --release --recipe-path recipe.json
 COPY . .
 RUN --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
     if [ "$TARGETARCH" = "arm64" ]; then \
     echo "Building for arm64 with JEMALLOC_SYS_WITH_LG_PAGE=16"; \
     JEMALLOC_SYS_WITH_LG_PAGE=16 cargo build --profile release --bin api-server; \
@@ -50,6 +59,7 @@ RUN --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
     echo "Building for $TARGETARCH"; \
     cargo build --profile release --bin api-server; \
     fi
+RUN strip target/release/api-server
 
 FROM debian:bookworm-slim AS runtime
 
@@ -64,6 +74,9 @@ COPY --from=builder /app/target/release/api-server api-server
 RUN chmod +x api-server && \
     groupadd -r taikoscope && \
     useradd -r -g taikoscope taikoscope
+
+# Expose the HTTP port
+EXPOSE 3000
 
 USER taikoscope
 


### PR DESCRIPTION
## Summary
- optimize Dockerfiles using `--mount` cache for cargo
- enable sparse protocol for crates.io
- strip binaries to slim runtime
- expose service ports

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685bd0255938832881d171cc88fd0e9d