### PR TITLE
fix dashboard eth price error handling

### DIFF
--- a/dashboard/tests/priceService.test.ts
+++ b/dashboard/tests/priceService.test.ts
@@ -45,9 +45,8 @@ describe('getEthPrice', () => {
   it('handles fetch failure', async () => {
     globalThis.fetch = mockFetch(0, false);
     const spy = vi.spyOn(toast, 'showToast').mockImplementation(() => {});
-    await expect(getEthPrice()).rejects.toThrow(
-      'Failed to fetch ETH price: 500',
-    );
+    const price = await getEthPrice();
+    expect(price).toBe(0);
     expect(spy).toHaveBeenCalled();
     spy.mockRestore();
   });
@@ -63,8 +62,7 @@ describe('getEthPrice', () => {
 
   it('handles invalid response format', async () => {
     globalThis.fetch = mockFetchWithInvalidResponse();
-    await expect(getEthPrice()).rejects.toThrow(
-      'Invalid ETH price response format',
-    );
+    const price = await getEthPrice();
+    expect(price).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- handle eth price fetch failures by returning 0 instead of throwing
- avoid caching failed ETH price fetch results
- update price service tests

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685bcf9f44888328a50a05217bcc53d4