### PR TITLE
Combine economics charts

### DIFF
--- a/dashboard/components/EconomicsChart.tsx
+++ b/dashboard/components/EconomicsChart.tsx
@@ -1,0 +1,159 @@
+import React from 'react';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import useSWR from 'swr';
+import { useEthPrice } from '../services/priceService';
+import { fetchBatchFeeComponents } from '../services/apiService';
+import { TimeRange, BatchFeeComponent } from '../types';
+import { rangeToHours } from '../utils/timeRange';
+import { formatEth } from '../utils';
+
+interface EconomicsChartProps {
+  timeRange: TimeRange;
+  cloudCost: number;
+  proverCost: number;
+  address?: string;
+}
+
+export const EconomicsChart: React.FC<EconomicsChartProps> = ({
+  timeRange,
+  cloudCost,
+  proverCost,
+  address,
+}) => {
+  const { data: feeRes } = useSWR(
+    ['batchFeeComponents', timeRange, address],
+    () => fetchBatchFeeComponents(timeRange, address),
+  );
+  const feeData: BatchFeeComponent[] | null = feeRes?.data ?? null;
+  const { data: ethPrice = 0, error: ethPriceError } = useEthPrice();
+
+  if (!feeData || feeData.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-full text-gray-500">
+        No data available
+      </div>
+    );
+  }
+
+  const hours = rangeToHours(timeRange);
+  const HOURS_IN_MONTH = 30 * 24;
+  const baseCostUsd = ((cloudCost + proverCost) / HOURS_IN_MONTH) * hours;
+  const baseCostEth = ethPrice ? baseCostUsd / ethPrice : 0;
+  const baseCostPerBatchEth = baseCostEth / feeData.length;
+
+  const data = feeData.map((b) => {
+    const incomeEth = (b.priority + b.base) / 1e18;
+    const costEth = baseCostPerBatchEth + (b.l1Cost ?? 0) / 1e18;
+    const profitEth = incomeEth - costEth;
+    const incomeUsd = incomeEth * ethPrice;
+    const costUsd = costEth * ethPrice;
+    const profitUsd = profitEth * ethPrice;
+    return {
+      batch: b.batch,
+      incomeEth,
+      costEth,
+      profitEth,
+      incomeUsd,
+      costUsd,
+      profitUsd,
+    };
+  });
+
+  return (
+    <>
+      {ethPriceError && (
+        <div className="text-red-500 text-xs mb-1">ETH price unavailable</div>
+      )}
+      <ResponsiveContainer width="100%" height={240}>
+        <LineChart
+          data={data}
+          margin={{ top: 5, right: 20, left: 20, bottom: 40 }}
+        >
+          <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
+          <XAxis
+            dataKey="batch"
+            stroke="#666666"
+            fontSize={12}
+            label={{
+              value: 'Batch',
+              position: 'insideBottom',
+              offset: -10,
+              fontSize: 10,
+              fill: '#666666',
+            }}
+          />
+          <YAxis
+            stroke="#666666"
+            fontSize={12}
+            domain={['auto', 'auto']}
+            tickFormatter={(v: number) => formatEth(v * 1e18)}
+            label={{
+              value: 'ETH',
+              angle: -90,
+              position: 'insideLeft',
+              offset: -16,
+              fontSize: 10,
+              fill: '#666666',
+            }}
+          />
+          <Tooltip
+            labelFormatter={(v: number) => `Batch ${v}`}
+            formatter={(value: number, name: string, { payload }: any) => {
+              if (name === 'Income')
+                return [
+                  `${formatEth(value * 1e18)} ($${payload.incomeUsd.toFixed(2)})`,
+                  name,
+                ];
+              if (name === 'Cost')
+                return [
+                  `${formatEth(value * 1e18)} ($${payload.costUsd.toFixed(2)})`,
+                  name,
+                ];
+              return [
+                `${formatEth(value * 1e18)} ($${payload.profitUsd.toFixed(2)})`,
+                name,
+              ];
+            }}
+            contentStyle={{
+              backgroundColor: 'rgba(255,255,255,0.8)',
+              borderColor: '#8884d8',
+            }}
+            labelStyle={{ color: '#333' }}
+          />
+          <Line
+            type="monotone"
+            dataKey="incomeEth"
+            stroke="#4E79A7"
+            strokeWidth={2}
+            dot={false}
+            name="Income"
+          />
+          <Line
+            type="monotone"
+            dataKey="costEth"
+            stroke="#E573B5"
+            strokeWidth={2}
+            dot={false}
+            name="Cost"
+          />
+          <Line
+            type="monotone"
+            dataKey="profitEth"
+            stroke="#8884d8"
+            strokeWidth={2}
+            dot={false}
+            name="Profit"
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </>
+  );
+};

--- a/dashboard/components/views/DashboardView.tsx
+++ b/dashboard/components/views/DashboardView.tsx
@@ -2,9 +2,7 @@ import React, { useCallback, lazy, useState } from 'react';
 import { ErrorDisplay } from '../layout/ErrorDisplay';
 import { MetricsGrid } from '../layout/MetricsGrid';
 import { ProfitCalculator } from '../ProfitCalculator';
-import { IncomeChart } from '../IncomeChart';
-import { CostChart } from '../CostChart';
-import { ProfitabilityChart } from '../ProfitabilityChart';
+import { EconomicsChart } from '../EconomicsChart';
 import { ProfitRankingTable } from '../ProfitRankingTable';
 import { BlockProfitTables } from '../BlockProfitTables';
 import { FeeFlowChart } from '../FeeFlowChart';
@@ -116,10 +114,10 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
   const skeletonGroupCounts: Record<string, number> = isEconomicsView
     ? { 'Network Economics': 3 }
     : {
-      'Network Performance': 3,
-      'Network Health': 5,
-      Sequencers: 3,
-    };
+        'Network Performance': 3,
+        'Network Health': 5,
+        Sequencers: 3,
+      };
 
   const displayGroupName = useCallback(
     (group: string): string => {
@@ -315,29 +313,13 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
               onCloudCostChange={setCloudCost}
               onProverCostChange={setProverCost}
             />
-            <div className="mt-6 grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6">
-              <div>
-                <IncomeChart
-                  timeRange={timeRange}
-                  address={selectedSequencer || undefined}
-                />
-              </div>
-              <div>
-                <CostChart
-                  timeRange={timeRange}
-                  cloudCost={cloudCost}
-                  proverCost={proverCost}
-                  address={selectedSequencer || undefined}
-                />
-              </div>
-              <div>
-                <ProfitabilityChart
-                  timeRange={timeRange}
-                  cloudCost={cloudCost}
-                  proverCost={proverCost}
-                  address={selectedSequencer || undefined}
-                />
-              </div>
+            <div className="mt-6">
+              <EconomicsChart
+                timeRange={timeRange}
+                cloudCost={cloudCost}
+                proverCost={proverCost}
+                address={selectedSequencer || undefined}
+              />
             </div>
             <ProfitRankingTable
               timeRange={timeRange}

--- a/dashboard/tests/economicsChart.test.ts
+++ b/dashboard/tests/economicsChart.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import * as swr from 'swr';
+vi.mock('swr', () => ({ default: vi.fn() }));
+import * as priceService from '../services/priceService';
+import { EconomicsChart } from '../components/EconomicsChart';
+
+const feeData = [{ batch: 1, priority: 1, base: 1, l1Cost: 0 }];
+
+describe('EconomicsChart', () => {
+  it('renders with economics data', () => {
+    vi.mocked(swr.default).mockReturnValue({ data: { data: feeData } } as any);
+    vi.spyOn(priceService, 'useEthPrice').mockReturnValue({ data: 1 } as any);
+
+    const html = renderToStaticMarkup(
+      React.createElement(EconomicsChart, {
+        timeRange: '1h',
+        cloudCost: 100,
+        proverCost: 100,
+      }),
+    );
+
+    expect(html).toContain('recharts-responsive-container');
+  });
+});


### PR DESCRIPTION
## Summary
- add EconomicsChart with stacked income/cost/profit
- show EconomicsChart in economics view
- test EconomicsChart component

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685bdc46fbf48328b1c46c1ee0e51975