### PR TITLE
Fix batch block mapping

### DIFF
--- a/crates/clickhouse/src/writer.rs
+++ b/crates/clickhouse/src/writer.rs
@@ -377,7 +377,7 @@ impl ClickhouseWriter {
         insert.end().await?;
 
         // Insert batch-block mappings
-        let l2_block_numbers = batch_row.l2_block_numbers();
+        let l2_block_numbers = batch.block_numbers_proposed();
         self.insert_batch_blocks(batch_row.batch_id, l2_block_numbers).await?;
 
         Ok(())


### PR DESCRIPTION
## Summary
- use actual block_numbers from `BatchProposed` when inserting batch to ClickHouse

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685bdd1e2fb083289e701761bc719fdf