### PR TITLE
Add sequencer column to top 5 tables

### DIFF
--- a/crates/api-types/src/lib.rs
+++ b/crates/api-types/src/lib.rs
@@ -5,9 +5,9 @@
 //! depend on them without pulling in the rest of the server implementation.
 
 use clickhouse_lib::{
-    BatchBlobCountRow, BatchFeeComponentRow, BatchPostingTimeRow, BatchProveTimeRow,
-    BatchVerifyTimeRow, BlockFeeComponentRow, ForcedInclusionProcessedRow, L1BlockTimeRow,
-    L1DataCostRow, L2BlockTimeRow, L2GasUsedRow, L2ReorgRow, L2TpsRow, SlashingEventRow,
+    BatchBlobCountRow, BatchPostingTimeRow, BatchProveTimeRow, BatchVerifyTimeRow,
+    BlockFeeComponentRow, ForcedInclusionProcessedRow, L1BlockTimeRow, L1DataCostRow,
+    L2BlockTimeRow, L2GasUsedRow, L2ReorgRow, L2TpsRow, SlashingEventRow,
 };
 
 use axum::{Json, http::StatusCode, response::IntoResponse};
@@ -243,6 +243,23 @@ pub struct L1DataCostResponse {
 pub struct FeeComponentsResponse {
     /// Fee components per block
     pub blocks: Vec<BlockFeeComponentRow>,
+}
+
+/// Fee components for a batch
+#[derive(Debug, Serialize, ToSchema)]
+pub struct BatchFeeComponentRow {
+    /// Batch ID
+    pub batch_id: u64,
+    /// L1 block number that included the batch
+    pub l1_block_number: u64,
+    /// Sequencer address that proposed the batch
+    pub sequencer: String,
+    /// Total priority fee for the batch
+    pub priority_fee: u128,
+    /// Total base fee for the batch
+    pub base_fee: u128,
+    /// L1 data posting cost associated with the batch, if available
+    pub l1_data_cost: Option<u128>,
 }
 
 /// Fee components for each batch

--- a/crates/api/src/helpers/aggregation.rs
+++ b/crates/api/src/helpers/aggregation.rs
@@ -2,9 +2,8 @@
 
 use api_types::BlockTransactionsItem;
 
-use clickhouse_lib::{
-    BatchFeeComponentRow, BlockFeeComponentRow, L2BlockTimeRow, L2GasUsedRow, TimeRange,
-};
+use api_types::BatchFeeComponentRow;
+use clickhouse_lib::{BlockFeeComponentRow, L2BlockTimeRow, L2GasUsedRow, TimeRange};
 use std::collections::BTreeMap;
 
 /// Determine bucket size based on time range
@@ -119,9 +118,11 @@ pub fn aggregate_batch_fee_components(
                 (s + r.l1_data_cost.unwrap_or(0), a || r.l1_data_cost.is_some())
             });
             let last_l1 = rs.last().map(|r| r.l1_block_number).unwrap_or_default();
+            let last_seq = rs.last().map(|r| r.sequencer.clone()).unwrap_or_default();
             BatchFeeComponentRow {
                 batch_id: g * bucket,
                 l1_block_number: last_l1,
+                sequencer: last_seq,
                 priority_fee: sum_priority,
                 base_fee: sum_base,
                 l1_data_cost: any.then_some(sum_l1),

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -94,7 +94,6 @@ use utoipa::OpenApi;
             FeeComponentsResponse,
             BatchFeeComponentsResponse,
             SequencerFeeRow,
-            clickhouse_lib::BatchFeeComponentRow,
             DashboardDataResponse,
             EthPriceResponse,
             api_types::ErrorResponse,

--- a/crates/api/src/routes/aggregated.rs
+++ b/crates/api/src/routes/aggregated.rs
@@ -470,11 +470,22 @@ pub async fn batch_fee_components(
         None
     };
 
-    let batches =
-        state.client.get_batch_fee_components(address, time_range).await.map_err(|e| {
-            tracing::error!(error = %e, "Failed to get batch fee components");
-            ErrorResponse::database_error()
-        })?;
+    let rows = state.client.get_batch_fee_components(address, time_range).await.map_err(|e| {
+        tracing::error!(error = %e, "Failed to get batch fee components");
+        ErrorResponse::database_error()
+    })?;
+
+    let batches: Vec<BatchFeeComponentRow> = rows
+        .into_iter()
+        .map(|r| BatchFeeComponentRow {
+            batch_id: r.batch_id,
+            l1_block_number: r.l1_block_number,
+            sequencer: format!("0x{}", encode(r.sequencer)),
+            priority_fee: r.priority_fee,
+            base_fee: r.base_fee,
+            l1_data_cost: r.l1_data_cost,
+        })
+        .collect();
 
     Ok(Json(BatchFeeComponentsResponse { batches }))
 }
@@ -519,11 +530,22 @@ pub async fn batch_fee_components_aggregated(
         None
     };
 
-    let batches =
-        state.client.get_batch_fee_components(address, time_range).await.map_err(|e| {
-            tracing::error!(error = %e, "Failed to get batch fee components");
-            ErrorResponse::database_error()
-        })?;
+    let rows = state.client.get_batch_fee_components(address, time_range).await.map_err(|e| {
+        tracing::error!(error = %e, "Failed to get batch fee components");
+        ErrorResponse::database_error()
+    })?;
+
+    let batches: Vec<BatchFeeComponentRow> = rows
+        .into_iter()
+        .map(|r| BatchFeeComponentRow {
+            batch_id: r.batch_id,
+            l1_block_number: r.l1_block_number,
+            sequencer: format!("0x{}", encode(r.sequencer)),
+            priority_fee: r.priority_fee,
+            base_fee: r.base_fee,
+            l1_data_cost: r.l1_data_cost,
+        })
+        .collect();
 
     let bucket = bucket_size_from_range(&time_range);
     let batches = aggregate_batch_fee_components(batches, bucket);

--- a/crates/clickhouse/src/models.rs
+++ b/crates/clickhouse/src/models.rs
@@ -315,6 +315,8 @@ pub struct BatchFeeComponentRow {
     pub batch_id: u64,
     /// L1 block number that included the batch
     pub l1_block_number: u64,
+    /// Sequencer address that proposed the batch
+    pub sequencer: AddressBytes,
     /// Total priority fee for the batch
     pub priority_fee: u128,
     /// Total base fee for the batch

--- a/crates/clickhouse/src/reader.rs
+++ b/crates/clickhouse/src/reader.rs
@@ -1744,6 +1744,7 @@ impl ClickhouseReader {
         struct RawRow {
             batch_id: u64,
             l1_block_number: u64,
+            proposer: AddressBytes,
             priority_fee: u128,
             base_fee: u128,
             l1_data_cost: Option<u128>,
@@ -1753,6 +1754,7 @@ impl ClickhouseReader {
         let mut query = format!(
             "SELECT bb.batch_id, \
                     b.l1_block_number AS l1_block_number, \
+                    b.proposer_addr AS proposer, \
                     sum(h.sum_priority_fee) AS priority_fee, \
                     sum(h.sum_base_fee) AS base_fee, \
                     toNullable(sum(dc.cost)) AS l1_data_cost \
@@ -1782,6 +1784,7 @@ impl ClickhouseReader {
             .map(|r| BatchFeeComponentRow {
                 batch_id: r.batch_id,
                 l1_block_number: r.l1_block_number,
+                sequencer: r.proposer,
                 priority_fee: r.priority_fee,
                 base_fee: r.base_fee,
                 l1_data_cost: r.l1_data_cost,
@@ -2306,6 +2309,7 @@ mod tests {
     struct BatchFeeRow {
         batch_id: u64,
         l1_block_number: u64,
+        proposer: AddressBytes,
         priority_fee: u128,
         base_fee: u128,
         l1_data_cost: Option<u128>,
@@ -2317,6 +2321,7 @@ mod tests {
         mock.add(handlers::provide(vec![BatchFeeRow {
             batch_id: 1,
             l1_block_number: 10,
+            proposer: AddressBytes([1u8; 20]),
             priority_fee: 10,
             base_fee: 20,
             l1_data_cost: Some(5),
@@ -2333,6 +2338,7 @@ mod tests {
             vec![BatchFeeComponentRow {
                 batch_id: 1,
                 l1_block_number: 10,
+                sequencer: AddressBytes([1u8; 20]),
                 priority_fee: 10,
                 base_fee: 20,
                 l1_data_cost: Some(5),
@@ -2347,6 +2353,7 @@ mod tests {
             mock.add(handlers::provide(vec![BatchFeeRow {
                 batch_id: 1,
                 l1_block_number: 10,
+                proposer: AddressBytes([1u8; 20]),
                 priority_fee: 10,
                 base_fee: 20,
                 l1_data_cost: Some(5),

--- a/crates/messages/src/models.rs
+++ b/crates/messages/src/models.rs
@@ -306,6 +306,8 @@ pub struct SequencerFeeRow {
 pub struct BatchFeeComponentRow {
     /// Batch ID
     pub batch_id: u64,
+    /// Sequencer address that proposed the batch
+    pub sequencer: AddressBytes,
     /// Total priority fee for the batch
     pub priority_fee: u128,
     /// Total base fee for the batch

--- a/dashboard/components/BlockProfitTables.tsx
+++ b/dashboard/components/BlockProfitTables.tsx
@@ -48,6 +48,7 @@ export const BlockProfitTables: React.FC<BlockProfitTablesProps> = ({
   const profits = batchData.map((b) => ({
     batch: b.batch,
     l1Block: b.l1Block,
+    sequencer: b.sequencer,
     profit: b.priority + b.base - (b.l1Cost ?? 0),
   }));
   const topBatches = [...profits]
@@ -59,7 +60,9 @@ export const BlockProfitTables: React.FC<BlockProfitTablesProps> = ({
 
   const renderTable = (
     title: string,
-    items: { batch: number; l1Block: number; profit: number }[] | null,
+    items:
+      | { batch: number; l1Block: number; sequencer: string; profit: number }[]
+      | null,
   ) => (
     <div>
       <h3 className="text-lg font-semibold mb-2">{title}</h3>
@@ -68,6 +71,7 @@ export const BlockProfitTables: React.FC<BlockProfitTablesProps> = ({
           <thead>
             <tr>
               <th className="px-2 py-1 text-left">Batch</th>
+              <th className="px-2 py-1 text-left">Sequencer</th>
               <th className="px-2 py-1 text-left">Profit (ETH)</th>
             </tr>
           </thead>
@@ -80,6 +84,7 @@ export const BlockProfitTables: React.FC<BlockProfitTablesProps> = ({
                 <td className="px-2 py-1">
                   {l1BlockLink(b.l1Block ?? 0, b.batch.toLocaleString())}
                 </td>
+                <td className="px-2 py-1">{b.sequencer}</td>
                 <td
                   className="px-2 py-1"
                   title={`$${formatUsd(calcProfitEth(b.profit) * ethPrice)}`}

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -178,10 +178,10 @@ export const fetchL2ReorgEvents = async (
   return {
     data: res.data?.events
       ? res.data.events.map((e) => ({
-        l2_block_number: e.l2_block_number,
-        depth: e.depth,
-        timestamp: Date.parse(e.inserted_at),
-      }))
+          l2_block_number: e.l2_block_number,
+          depth: e.depth,
+          timestamp: Date.parse(e.inserted_at),
+        }))
       : null,
     badRequest: res.badRequest,
     error: res.error,
@@ -320,10 +320,10 @@ export const fetchProveTimes = async (
   return {
     data: res.data
       ? res.data.batches.map((b) => ({
-        name: b.batch_id.toString(),
-        value: b.seconds_to_prove,
-        timestamp: 0,
-      }))
+          name: b.batch_id.toString(),
+          value: b.seconds_to_prove,
+          timestamp: 0,
+        }))
       : null,
     badRequest: res.badRequest,
     error: res.error,
@@ -353,10 +353,10 @@ export const fetchVerifyTimes = async (
   return {
     data: res.data
       ? res.data.batches.map((b) => ({
-        name: b.batch_id.toString(),
-        value: b.seconds_to_verify,
-        timestamp: 0,
-      }))
+          name: b.batch_id.toString(),
+          value: b.seconds_to_verify,
+          timestamp: 0,
+        }))
       : null,
     badRequest: res.badRequest,
     error: res.error,
@@ -525,10 +525,10 @@ export const fetchL2GasUsed = async (
   return {
     data: res.data
       ? res.data.blocks.map((b) => ({
-        value: b.l2_block_number,
-        timestamp: b.gas_used,
-        blockTime: new Date(b.block_time).getTime(),
-      }))
+          value: b.l2_block_number,
+          timestamp: b.gas_used,
+          blockTime: new Date(b.block_time).getTime(),
+        }))
       : null,
     badRequest: res.badRequest,
     error: res.error,
@@ -548,10 +548,10 @@ export const fetchL2GasUsedAggregated = async (
   return {
     data: res.data
       ? res.data.blocks.map((b) => ({
-        value: b.l2_block_number,
-        timestamp: b.gas_used,
-        blockTime: new Date(b.block_time).getTime(),
-      }))
+          value: b.l2_block_number,
+          timestamp: b.gas_used,
+          blockTime: new Date(b.block_time).getTime(),
+        }))
       : null,
     badRequest: res.badRequest,
     error: res.error,
@@ -568,11 +568,11 @@ export const fetchSequencerDistribution = async (
   return {
     data: res.data
       ? res.data.sequencers.map((s) => ({
-        name: getSequencerName(s.address),
-        address: s.address,
-        value: s.blocks,
-        tps: s.tps,
-      }))
+          name: getSequencerName(s.address),
+          address: s.address,
+          value: s.blocks,
+          tps: s.tps,
+        }))
       : null,
     badRequest: res.badRequest,
     error: res.error,
@@ -639,11 +639,11 @@ export const fetchBlockTransactions = async (
   return {
     data: res.data?.blocks
       ? res.data.blocks.map((b) => ({
-        block: b.block,
-        txs: b.txs,
-        sequencer: getSequencerName(b.sequencer),
-        blockTime: new Date(b.block_time).getTime(),
-      }))
+          block: b.block,
+          txs: b.txs,
+          sequencer: getSequencerName(b.sequencer),
+          blockTime: new Date(b.block_time).getTime(),
+        }))
       : null,
     badRequest: res.badRequest,
     error: res.error,
@@ -684,11 +684,11 @@ export const fetchBlockTransactionsAggregated = async (
   return {
     data: res.data?.blocks
       ? res.data.blocks.map((b) => ({
-        block: b.block,
-        txs: b.txs,
-        sequencer: getSequencerName(b.sequencer),
-        blockTime: new Date(b.block_time).getTime(),
-      }))
+          block: b.block,
+          txs: b.txs,
+          sequencer: getSequencerName(b.sequencer),
+          blockTime: new Date(b.block_time).getTime(),
+        }))
       : null,
     badRequest: res.badRequest,
     error: res.error,
@@ -728,16 +728,15 @@ export const fetchBatchBlobCounts = async (
   return {
     data: res.data
       ? res.data.batches.map((b) => ({
-        block: b.l1_block_number ?? b.batch_id, // Fallback to batch_id for backward compatibility
-        batch: b.batch_id,
-        blobs: b.blob_count,
-      }))
+          block: b.l1_block_number ?? b.batch_id, // Fallback to batch_id for backward compatibility
+          batch: b.batch_id,
+          blobs: b.blob_count,
+        }))
       : null,
     badRequest: res.badRequest,
     error: res.error,
   };
 };
-
 
 export const fetchAvgBlobsPerBatch = async (
   range: TimeRange,
@@ -805,6 +804,7 @@ export interface FeeComponent {
 export interface BatchFeeComponent {
   batch: number;
   l1Block: number;
+  sequencer: string;
   priority: number;
   base: number;
   l1Cost: number | null;
@@ -828,11 +828,11 @@ export const fetchFeeComponents = async (
   return {
     data: res.data
       ? res.data.blocks.map((b) => ({
-        block: b.l2_block_number,
-        priority: b.priority_fee,
-        base: b.base_fee,
-        l1Cost: b.l1_data_cost ?? null,
-      }))
+          block: b.l2_block_number,
+          priority: b.priority_fee,
+          base: b.base_fee,
+          l1Cost: b.l1_data_cost ?? null,
+        }))
       : null,
     badRequest: res.badRequest,
     error: res.error,
@@ -850,6 +850,7 @@ export const fetchBatchFeeComponents = async (
     batches: {
       batch_id: number;
       l1_block_number: number;
+      sequencer: string;
       priority_fee: number;
       base_fee: number;
       l1_data_cost: number | null;
@@ -860,6 +861,7 @@ export const fetchBatchFeeComponents = async (
       ? res.data.batches.map((b) => ({
           batch: b.batch_id,
           l1Block: b.l1_block_number,
+          sequencer: getSequencerName(b.sequencer),
           priority: b.priority_fee,
           base: b.base_fee,
           l1Cost: b.l1_data_cost ?? null,
@@ -955,9 +957,13 @@ export const fetchBlockProfits = async (
   const url =
     `${API_BASE}/block-profits?${timeRangeToQuery(range)}&order=${order}&limit=${limit}` +
     (address ? `&address=${address}` : '');
-  const res = await fetchJson<{ blocks: { block: number; profit: number }[] }>(url);
+  const res = await fetchJson<{ blocks: { block: number; profit: number }[] }>(
+    url,
+  );
   return {
-    data: res.data ? res.data.blocks.map((b) => ({ block: b.block, profit: b.profit })) : null,
+    data: res.data
+      ? res.data.blocks.map((b) => ({ block: b.block, profit: b.profit }))
+      : null,
     badRequest: res.badRequest,
     error: res.error,
   };

--- a/dashboard/types.ts
+++ b/dashboard/types.ts
@@ -60,6 +60,7 @@ export interface FeeComponent {
 export interface BatchFeeComponent {
   batch: number;
   l1Block: number;
+  sequencer: string;
   priority: number;
   base: number;
   l1Cost: number | null;


### PR DESCRIPTION
## Summary
- include sequencer address in batch fee data models
- convert sequencer to string in API responses
- show sequencer column in top/bottom profit tables on dashboard

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685be201ae408328ba02c46d234604f2