### PR TITLE
Ensure block range for paginated tables

### DIFF
--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -307,7 +307,7 @@ export const fetchProveTimes = async (
   if (startingAfter === undefined && endingBefore === undefined) {
     url += `${timeRangeToQuery(range)}&limit=${limit}`;
   } else {
-    url += `limit=${limit}`;
+    url += `${rangeToQuery(range)}&limit=${limit}`;
   }
   if (startingAfter !== undefined) {
     url += `&starting_after=${startingAfter}`;
@@ -340,7 +340,7 @@ export const fetchVerifyTimes = async (
   if (startingAfter === undefined && endingBefore === undefined) {
     url += `${timeRangeToQuery(range)}&limit=${limit}`;
   } else {
-    url += `limit=${limit}`;
+    url += `${rangeToQuery(range)}&limit=${limit}`;
   }
   if (startingAfter !== undefined) {
     url += `&starting_after=${startingAfter}`;
@@ -407,7 +407,7 @@ export const fetchL2BlockTimes = async (
   if (startingAfter === undefined && endingBefore === undefined) {
     url += `${timeRangeToQuery(range)}&limit=${limit}`;
   } else {
-    url += `limit=${limit}`;
+    url += `${rangeToQuery(range)}&limit=${limit}`;
   }
   if (startingAfter !== undefined) {
     url += `&starting_after=${startingAfter}`;
@@ -476,7 +476,7 @@ export const fetchBatchPostingTimes = async (
   if (startingAfter === undefined && endingBefore === undefined) {
     url += `${timeRangeToQuery(range)}&limit=${limit}`;
   } else {
-    url += `limit=${limit}`;
+    url += `${rangeToQuery(range)}&limit=${limit}`;
   }
   if (startingAfter !== undefined) {
     url += `&starting_after=${startingAfter}`;
@@ -509,7 +509,7 @@ export const fetchL2GasUsed = async (
   if (startingAfter === undefined && endingBefore === undefined) {
     url += `${timeRangeToQuery(range)}&limit=${limit}`;
   } else {
-    url += `limit=${limit}`;
+    url += `${rangeToQuery(range)}&limit=${limit}`;
   }
   if (startingAfter !== undefined) {
     url += `&starting_after=${startingAfter}`;
@@ -613,7 +613,7 @@ export const fetchBlockTransactions = async (
   if (startingAfter === undefined && endingBefore === undefined) {
     url += `${timeRangeToQuery(range)}&limit=${limit}`;
   } else {
-    url += `limit=${limit}`;
+    url += `${rangeToQuery(range)}&limit=${limit}`;
   }
 
   // For unlimited fetching, we ignore pagination parameters to get all data
@@ -711,7 +711,7 @@ export const fetchBatchBlobCounts = async (
   if (startingAfter === undefined && endingBefore === undefined) {
     url += `${timeRangeToQuery(range)}&limit=${limit}`;
   } else {
-    url += `limit=${limit}`;
+    url += `${rangeToQuery(range)}&limit=${limit}`;
   }
   if (startingAfter !== undefined) {
     url += `&starting_after=${startingAfter}`;
@@ -885,7 +885,7 @@ export const fetchL1DataCost = async (
   if (startingAfter === undefined && endingBefore === undefined) {
     url += `${timeRangeToQuery(range)}&limit=${limit}`;
   } else {
-    url += `limit=${limit}`;
+    url += `${rangeToQuery(range)}&limit=${limit}`;
   }
   if (startingAfter !== undefined) {
     url += `&starting_after=${startingAfter}`;
@@ -915,7 +915,7 @@ export const fetchL2Tps = async (
   if (startingAfter === undefined && endingBefore === undefined) {
     url += `${timeRangeToQuery(range)}&limit=${limit}`;
   } else {
-    url += `limit=${limit}`;
+    url += `${rangeToQuery(range)}&limit=${limit}`;
   }
   if (startingAfter !== undefined) {
     url += `&starting_after=${startingAfter}`;


### PR DESCRIPTION
## Summary
- query tables with pagination using block ranges
- keep chart queries using time ranges

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685be37839cc8328b517cb8d8d061236