### PR TITLE
Revert Dockerfile cache mounts

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -17,13 +17,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     cmake \
     && rm -rf /var/lib/apt/lists/*
 
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/local/cargo/git \
-    cargo install --locked sccache cargo-chef && \
+RUN cargo install --locked sccache cargo-chef && \
     rm -rf /usr/local/cargo/registry /usr/local/cargo/git
 
-ENV RUSTC_WRAPPER=sccache SCCACHE_DIR=/sccache \
-    CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
+ENV RUSTC_WRAPPER=sccache SCCACHE_DIR=/sccache
 
 FROM base AS planner
 
@@ -32,8 +29,6 @@ WORKDIR /app
 COPY . .
 
 RUN --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
-    --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/local/cargo/git \
     cargo chef prepare --recipe-path recipe.json
 
 FROM base AS builder
@@ -45,13 +40,9 @@ COPY --from=planner /app/recipe.json recipe.json
 ARG TARGETARCH
 
 RUN --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
-    --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/local/cargo/git \
     cargo chef cook --release --recipe-path recipe.json
 COPY . .
 RUN --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
-    --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/local/cargo/git \
     if [ "$TARGETARCH" = "arm64" ]; then \
     echo "Building for arm64 with JEMALLOC_SYS_WITH_LG_PAGE=16"; \
     JEMALLOC_SYS_WITH_LG_PAGE=16 cargo build --profile release --bin api-server; \
@@ -59,7 +50,6 @@ RUN --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
     echo "Building for $TARGETARCH"; \
     cargo build --profile release --bin api-server; \
     fi
-RUN strip target/release/api-server
 
 FROM debian:bookworm-slim AS runtime
 
@@ -74,9 +64,6 @@ COPY --from=builder /app/target/release/api-server api-server
 RUN chmod +x api-server && \
     groupadd -r taikoscope && \
     useradd -r -g taikoscope taikoscope
-
-# Expose the HTTP port
-EXPOSE 3000
 
 USER taikoscope
 


### PR DESCRIPTION
## Summary
- remove the cargo registry and git cache mounts
- drop `CARGO_REGISTRIES_CRATES_IO_PROTOCOL` and `strip` lines
- remove exposing port 3000 in runtime images

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685be960bb3883289be8f804485ebb7f