### PR TITLE
Add prove/verify cost endpoints

### DIFF
--- a/crates/api-types/src/lib.rs
+++ b/crates/api-types/src/lib.rs
@@ -7,7 +7,8 @@
 use clickhouse_lib::{
     BatchBlobCountRow, BatchPostingTimeRow, BatchProveTimeRow, BatchVerifyTimeRow,
     BlockFeeComponentRow, ForcedInclusionProcessedRow, L1BlockTimeRow, L1DataCostRow,
-    L2BlockTimeRow, L2GasUsedRow, L2ReorgRow, L2TpsRow, SlashingEventRow,
+    L2BlockTimeRow, L2GasUsedRow, L2ReorgRow, L2TpsRow, ProveCostRow, SlashingEventRow,
+    VerifyCostRow,
 };
 
 use axum::{Json, http::StatusCode, response::IntoResponse};
@@ -238,6 +239,20 @@ pub struct L1DataCostResponse {
     pub blocks: Vec<L1DataCostRow>,
 }
 
+/// Prover cost per batch.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ProveCostResponse {
+    /// Cost information for each proved batch.
+    pub batches: Vec<ProveCostRow>,
+}
+
+/// Verifier cost per batch.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct VerifyCostResponse {
+    /// Cost information for each verified batch.
+    pub batches: Vec<VerifyCostRow>,
+}
+
 /// Fee components for each L2 block
 #[derive(Debug, Serialize, ToSchema)]
 pub struct FeeComponentsResponse {
@@ -439,6 +454,10 @@ pub struct DashboardDataResponse {
     pub priority_fee: Option<u128>,
     /// Sum of base fees for the range.
     pub base_fee: Option<u128>,
+    /// Total prover cost for the range.
+    pub prove_cost: Option<u128>,
+    /// Total verifier cost for the range.
+    pub verify_cost: Option<u128>,
     /// Estimated infrastructure cost in USD for the requested range.
     pub cloud_cost: Option<f64>,
 }

--- a/crates/api/src/routes/aggregated.rs
+++ b/crates/api/src/routes/aggregated.rs
@@ -599,6 +599,8 @@ pub async fn dashboard_data(
         l1_head_block,
         priority_fee,
         base_fee,
+        prove_cost,
+        verify_cost,
     ) = tokio::try_join!(
         state.client.get_l2_block_cadence(address, time_range),
         state.client.get_batch_posting_cadence(time_range),
@@ -612,7 +614,9 @@ pub async fn dashboard_data(
         state.client.get_last_l2_block_number(),
         state.client.get_last_l1_block_number(),
         state.client.get_l2_priority_fee(address, time_range),
-        state.client.get_l2_base_fee(address, time_range)
+        state.client.get_l2_base_fee(address, time_range),
+        state.client.get_total_prove_cost(address, time_range),
+        state.client.get_total_verify_cost(address, time_range)
     )
     .map_err(|e| {
         tracing::error!(error = %e, "Failed to get dashboard data");
@@ -652,6 +656,8 @@ pub async fn dashboard_data(
         l1_head_block,
         priority_fee,
         base_fee,
+        prove_cost,
+        verify_cost,
         cloud_cost: Some(cost),
     }))
 }

--- a/crates/api/src/routes/core.rs
+++ b/crates/api/src/routes/core.rs
@@ -13,8 +13,9 @@ use api_types::{
     ActiveGatewaysResponse, AvgBlobsPerBatchResponse, BatchPostingTimesResponse, BlockProfitItem,
     BlockProfitsResponse, ErrorResponse, EthPriceResponse, L1BlockTimesResponse,
     L1DataCostResponse, L1HeadBlockResponse, L1HeadResponse, L2HeadBlockResponse, L2HeadResponse,
-    ProveTimesResponse, SequencerBlocksItem, SequencerBlocksResponse, SequencerDistributionItem,
-    SequencerDistributionResponse, VerifyTimesResponse,
+    ProveCostResponse, ProveTimesResponse, SequencerBlocksItem, SequencerBlocksResponse,
+    SequencerDistributionItem, SequencerDistributionResponse, VerifyCostResponse,
+    VerifyTimesResponse,
 };
 use axum::{
     Json,
@@ -506,6 +507,94 @@ pub async fn l1_data_cost(
     };
     tracing::info!(count = rows.len(), "Returning L1 data cost");
     Ok(Json(L1DataCostResponse { blocks: rows }))
+}
+
+#[utoipa::path(
+    get,
+    path = "/prove-cost",
+    params(
+        PaginatedQuery
+    ),
+    responses(
+        (status = 200, description = "Prover cost", body = ProveCostResponse),
+        (status = 500, description = "Database error", body = ErrorResponse)
+    ),
+    tag = "taikoscope"
+)]
+/// Get prover cost information for the specified time range
+pub async fn prove_cost(
+    Query(params): Query<PaginatedQuery>,
+    State(state): State<ApiState>,
+) -> Result<Json<ProveCostResponse>, ErrorResponse> {
+    validate_time_range(&params.common.time_range)?;
+    let limit = validate_pagination(
+        params.starting_after.as_ref(),
+        params.ending_before.as_ref(),
+        params.limit.as_ref(),
+        MAX_TABLE_LIMIT,
+    )?;
+    let has_time_range = has_time_range_params(&params.common.time_range);
+    let has_slot_range = params.starting_after.is_some() || params.ending_before.is_some();
+    validate_range_exclusivity(has_time_range, has_slot_range)?;
+
+    let since = resolve_time_range_since(&params.common.range, &params.common.time_range);
+    let rows = match state
+        .client
+        .get_prove_costs_paginated(since, limit, params.starting_after, params.ending_before)
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::error!("Failed to get prove cost: {}", e);
+            return Err(ErrorResponse::database_error());
+        }
+    };
+    tracing::info!(count = rows.len(), "Returning prove cost");
+    Ok(Json(ProveCostResponse { batches: rows }))
+}
+
+#[utoipa::path(
+    get,
+    path = "/verify-cost",
+    params(
+        PaginatedQuery
+    ),
+    responses(
+        (status = 200, description = "Verifier cost", body = VerifyCostResponse),
+        (status = 500, description = "Database error", body = ErrorResponse)
+    ),
+    tag = "taikoscope"
+)]
+/// Get verifier cost information for the specified time range
+pub async fn verify_cost(
+    Query(params): Query<PaginatedQuery>,
+    State(state): State<ApiState>,
+) -> Result<Json<VerifyCostResponse>, ErrorResponse> {
+    validate_time_range(&params.common.time_range)?;
+    let limit = validate_pagination(
+        params.starting_after.as_ref(),
+        params.ending_before.as_ref(),
+        params.limit.as_ref(),
+        MAX_TABLE_LIMIT,
+    )?;
+    let has_time_range = has_time_range_params(&params.common.time_range);
+    let has_slot_range = params.starting_after.is_some() || params.ending_before.is_some();
+    validate_range_exclusivity(has_time_range, has_slot_range)?;
+
+    let since = resolve_time_range_since(&params.common.range, &params.common.time_range);
+    let rows = match state
+        .client
+        .get_verify_costs_paginated(since, limit, params.starting_after, params.ending_before)
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::error!("Failed to get verify cost: {}", e);
+            return Err(ErrorResponse::database_error());
+        }
+    };
+    tracing::info!(count = rows.len(), "Returning verify cost");
+    Ok(Json(VerifyCostResponse { batches: rows }))
 }
 
 #[utoipa::path(

--- a/crates/api/src/routes/mod.rs
+++ b/crates/api/src/routes/mod.rs
@@ -50,6 +50,8 @@ pub fn router(state: ApiState) -> Router {
         .route("/batch-fee-components/aggregated", get(batch_fee_components_aggregated))
         .route("/dashboard-data", get(dashboard_data))
         .route("/l1-data-cost", get(l1_data_cost))
+        .route("/prove-cost", get(prove_cost))
+        .route("/verify-cost", get(verify_cost))
         .route("/block-profits", get(block_profits))
         .route("/eth-price", get(eth_price));
 

--- a/crates/clickhouse/src/reader.rs
+++ b/crates/clickhouse/src/reader.rs
@@ -16,8 +16,8 @@ use crate::{
         BatchBlobCountRow, BatchFeeComponentRow, BatchPostingTimeRow, BatchProveTimeRow,
         BatchVerifyTimeRow, BlockFeeComponentRow, BlockTransactionRow, ForcedInclusionProcessedRow,
         L1BlockTimeRow, L1DataCostRow, L2BlockTimeRow, L2GasUsedRow, L2ReorgRow, L2TpsRow,
-        PreconfData, SequencerBlockRow, SequencerDistributionRow, SequencerFeeRow,
-        SlashingEventRow,
+        PreconfData, ProveCostRow, SequencerBlockRow, SequencerDistributionRow, SequencerFeeRow,
+        SlashingEventRow, VerifyCostRow,
     },
     types::AddressBytes,
 };
@@ -1872,6 +1872,136 @@ impl ClickhouseReader {
                 l1_data_cost: r.l1_data_cost,
             })
             .collect())
+    }
+
+    /// Get prover cost since the given cutoff time with cursor-based pagination
+    /// Results are returned in descending order by batch id
+    pub async fn get_prove_costs_paginated(
+        &self,
+        since: DateTime<Utc>,
+        limit: u64,
+        starting_after: Option<u64>,
+        ending_before: Option<u64>,
+    ) -> Result<Vec<ProveCostRow>> {
+        let mut query = format!(
+            "SELECT pc.l1_block_number, pc.batch_id, pc.cost \
+             FROM {db}.prove_costs pc \
+             INNER JOIN {db}.l1_head_events h \
+               ON pc.l1_block_number = h.l1_block_number \
+             WHERE h.block_ts >= {since}",
+            since = since.timestamp(),
+            db = self.db_name,
+        );
+        if let Some(start) = starting_after {
+            query.push_str(&format!(" AND pc.batch_id < {}", start));
+        }
+        if let Some(end) = ending_before {
+            query.push_str(&format!(" AND pc.batch_id > {}", end));
+        }
+        query.push_str(" ORDER BY pc.batch_id DESC");
+        query.push_str(&format!(" LIMIT {}", limit));
+
+        let rows = self.execute::<ProveCostRow>(&query).await?;
+        Ok(rows)
+    }
+
+    /// Get verifier cost since the given cutoff time with cursor-based pagination
+    /// Results are returned in descending order by batch id
+    pub async fn get_verify_costs_paginated(
+        &self,
+        since: DateTime<Utc>,
+        limit: u64,
+        starting_after: Option<u64>,
+        ending_before: Option<u64>,
+    ) -> Result<Vec<VerifyCostRow>> {
+        let mut query = format!(
+            "SELECT vc.l1_block_number, vc.batch_id, vc.cost \
+             FROM {db}.verify_costs vc \
+             INNER JOIN {db}.l1_head_events h \
+               ON vc.l1_block_number = h.l1_block_number \
+             WHERE h.block_ts >= {since}",
+            since = since.timestamp(),
+            db = self.db_name,
+        );
+        if let Some(start) = starting_after {
+            query.push_str(&format!(" AND vc.batch_id < {}", start));
+        }
+        if let Some(end) = ending_before {
+            query.push_str(&format!(" AND vc.batch_id > {}", end));
+        }
+        query.push_str(" ORDER BY vc.batch_id DESC");
+        query.push_str(&format!(" LIMIT {}", limit));
+
+        let rows = self.execute::<VerifyCostRow>(&query).await?;
+        Ok(rows)
+    }
+
+    /// Get the total prover cost for the given range
+    pub async fn get_total_prove_cost(
+        &self,
+        sequencer: Option<AddressBytes>,
+        range: TimeRange,
+    ) -> Result<Option<u128>> {
+        #[derive(Row, Deserialize)]
+        struct SumRow {
+            total: u128,
+        }
+
+        let mut query = format!(
+            "SELECT sum(pc.cost) AS total \
+             FROM {db}.prove_costs pc \
+             INNER JOIN {db}.batch_blocks bb ON pc.batch_id = bb.batch_id \
+             INNER JOIN {db}.l2_head_events h ON bb.l2_block_number = h.l2_block_number \
+             WHERE h.block_ts >= toUnixTimestamp(now64() - INTERVAL {interval}) \
+               AND {filter}",
+            interval = range.interval(),
+            filter = self.reorg_filter("h"),
+            db = self.db_name,
+        );
+        if let Some(addr) = sequencer {
+            query.push_str(&format!(" AND h.sequencer = unhex('{}')", encode(addr)));
+        }
+
+        let rows = self.execute::<SumRow>(&query).await?;
+        let row = match rows.into_iter().next() {
+            Some(r) => r,
+            None => return Ok(None),
+        };
+        Ok(Some(row.total))
+    }
+
+    /// Get the total verifier cost for the given range
+    pub async fn get_total_verify_cost(
+        &self,
+        sequencer: Option<AddressBytes>,
+        range: TimeRange,
+    ) -> Result<Option<u128>> {
+        #[derive(Row, Deserialize)]
+        struct SumRow {
+            total: u128,
+        }
+
+        let mut query = format!(
+            "SELECT sum(vc.cost) AS total \
+             FROM {db}.verify_costs vc \
+             INNER JOIN {db}.batch_blocks bb ON vc.batch_id = bb.batch_id \
+             INNER JOIN {db}.l2_head_events h ON bb.l2_block_number = h.l2_block_number \
+             WHERE h.block_ts >= toUnixTimestamp(now64() - INTERVAL {interval}) \
+               AND {filter}",
+            interval = range.interval(),
+            filter = self.reorg_filter("h"),
+            db = self.db_name,
+        );
+        if let Some(addr) = sequencer {
+            query.push_str(&format!(" AND h.sequencer = unhex('{}')", encode(addr)));
+        }
+
+        let rows = self.execute::<SumRow>(&query).await?;
+        let row = match rows.into_iter().next() {
+            Some(r) => r,
+            None => return Ok(None),
+        };
+        Ok(Some(row.total))
     }
 
     /// Get the transactions per second for each L2 block within the given range

--- a/docs/api.md
+++ b/docs/api.md
@@ -28,3 +28,11 @@ All time range parameters are in milliseconds. Time range parameters cannot be u
 ### `/l2-fees`
 
 Returns total priority fee, base fee and optional L1 data cost for the selected address (or all sequencers). The response also includes a `sequencers` array with the fee breakdown for each sequencer.
+
+### `/prove-cost`
+
+Returns the prover cost for each batch within the selected time range. Supports cursor-based pagination using `starting_after`, `ending_before` and `limit`.
+
+### `/verify-cost`
+
+Returns the verifier cost for each batch within the selected time range. The pagination parameters are the same as for `/prove-cost`.


### PR DESCRIPTION
## Summary
- add ProveCostResponse and VerifyCostResponse
- expose total prove/verify cost in dashboard data
- implement `/prove-cost` and `/verify-cost` endpoints
- register new routes
- document new API endpoints

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685be9dad3288328862fc509e205bff0