### PR TITLE
Fix TPS calculation precision

### DIFF
--- a/crates/clickhouse/src/reader.rs
+++ b/crates/clickhouse/src/reader.rs
@@ -922,7 +922,8 @@ impl ClickhouseReader {
 
         let mut query = format!(
             "SELECT h.l2_block_number, sum_tx, \
-                    toUInt64OrNull(toString((h.block_ts - lagInFrame(h.block_ts) OVER (ORDER BY h.l2_block_number)) * 1000)) AS ms_since_prev_block \
+                    toUInt64OrNull(toString((toUnixTimestamp64Milli(h.inserted_at) - \
+                        lagInFrame(toUnixTimestamp64Milli(h.inserted_at)) OVER (ORDER BY h.l2_block_number)))) AS ms_since_prev_block \
              FROM {db}.l2_head_events h \
              WHERE h.block_ts >= {since} \
                AND {filter}",
@@ -1889,7 +1890,8 @@ impl ClickhouseReader {
 
         let mut query = format!(
             "SELECT h.l2_block_number, sum_tx, \
-                    toUInt64OrNull(toString((h.block_ts - lagInFrame(h.block_ts) OVER (ORDER BY h.l2_block_number)) * 1000)) \
+                    toUInt64OrNull(toString((toUnixTimestamp64Milli(h.inserted_at) - \
+                        lagInFrame(toUnixTimestamp64Milli(h.inserted_at)) OVER (ORDER BY h.l2_block_number)))) \
                         AS ms_since_prev_block \
              FROM {db}.l2_head_events h \
              WHERE h.block_ts >= toUnixTimestamp(now64() - INTERVAL {interval}) \
@@ -1935,7 +1937,8 @@ impl ClickhouseReader {
 
         let mut query = format!(
             "SELECT h.l2_block_number, sum_tx, \
-                    toUInt64OrNull(toString((h.block_ts - lagInFrame(h.block_ts) OVER (ORDER BY h.l2_block_number)) * 1000)) \
+                    toUInt64OrNull(toString((toUnixTimestamp64Milli(h.inserted_at) - \
+                        lagInFrame(toUnixTimestamp64Milli(h.inserted_at)) OVER (ORDER BY h.l2_block_number)))) \
                         AS ms_since_prev_block \
              FROM {db}.l2_head_events h \
              WHERE {filter}",


### PR DESCRIPTION
## Summary
- calculate `ms_since_prev_block` using `inserted_at` timestamps when querying TPS metrics

## Testing
- `cargo +nightly fmt --all` *(failed: could not download `channel-rust-nightly.toml.sha256`)*
- `cargo clippy --examples --tests --benches --all-features --locked` *(failed: `clippy` component not installed)*
- `cargo nextest run --workspace --all-targets` *(failed: `nextest` not installed)*

------
https://chatgpt.com/codex/tasks/task_b_685bebfcd3b48328b86e5a943523d7e4