### PR TITLE
Fix economics view hooks

### DIFF
--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -10,6 +10,7 @@ export default defineConfig(() => {
       alias: {
         '@': path.resolve(__dirname, '.'),
       },
+      dedupe: ['react', 'react-dom'],
     },
     build: {
       chunkSizeWarningLimit: 1000,


### PR DESCRIPTION
## Summary
- dedupe react packages in dashboard build

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685beefeba8c83289a88059cda4e5da2