### PR TITLE
Fix metric title truncation

### DIFF
--- a/dashboard/components/MetricCard.tsx
+++ b/dashboard/components/MetricCard.tsx
@@ -30,7 +30,7 @@ export const MetricCard: React.FC<MetricCardProps> = ({
       className={`bg-white dark:bg-gray-800 p-4 rounded-lg border border-gray-200 dark:border-gray-700 transition-shadow duration-200 ${isAddress ? 'min-w-0 w-full col-span-2 sm:col-span-2 md:col-span-2 lg:col-span-2 xl:col-span-2 2xl:col-span-2' : ''} ${className ?? ''}`.trim()}
     >
       <div className="relative">
-        <h3 className="text-xs sm:text-sm font-medium text-gray-500 dark:text-gray-400 truncate pr-8">
+        <h3 className="text-xs sm:text-sm font-medium text-gray-500 dark:text-gray-400 truncate md:overflow-visible md:whitespace-normal md:text-clip pr-8">
           {title}
         </h3>
         {onMore && (


### PR DESCRIPTION
## Summary
- tweak MetricCard title styling so it's not truncated on medium screens

## Testing
- `npm run lint:whitespace`
- `npm run check`
- `npm run test` *(fails: DashboardHeader > renders time range and refresh controls)*
- `just ci` *(fails: DashboardHeader test)*

------
https://chatgpt.com/codex/tasks/task_b_685bf85d6c80832887bba12763d6dc50