### PR TITLE
Show sequencer filter in economics view

### DIFF
--- a/dashboard/components/DashboardHeader.tsx
+++ b/dashboard/components/DashboardHeader.tsx
@@ -58,7 +58,6 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({
   const { navigateToDashboard, updateSearchParams } = useRouterNavigation();
   const { errorMessage } = useErrorHandler();
   const [searchParams] = useSearchParams();
-  const isEconomicsView = searchParams.get('view') === 'economics';
   React.useEffect(() => {
     if (errorMessage) {
       showToast(errorMessage);
@@ -117,13 +116,11 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({
           lastRefresh={lastRefresh}
           onRefresh={onManualRefresh}
         />
-        {!isEconomicsView && (
-          <SequencerSelector
-            sequencers={sequencers}
-            value={selectedSequencer}
-            onChange={onSequencerChange}
-          />
-        )}
+        <SequencerSelector
+          sequencers={sequencers}
+          value={selectedSequencer}
+          onChange={onSequencerChange}
+        />
         <ThemeToggle />
         {/* Export button removed as per request */}
       </div>

--- a/dashboard/hooks/useDashboardController.ts
+++ b/dashboard/hooks/useDashboardController.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback } from 'react';
 import { useMetricsData } from './useMetricsData';
 import { useChartsData } from './useChartsData';
 import { useBlockData } from './useBlockData';
@@ -27,11 +27,6 @@ export const useDashboardController = () => {
   const { selectedSequencer, setSelectedSequencer, sequencerList } =
     useSequencerHandler({ blockData, metricsData });
 
-  useEffect(() => {
-    if (metricsData.isEconomicsView && selectedSequencer) {
-      setSelectedSequencer(null);
-    }
-  }, [metricsData.isEconomicsView, selectedSequencer, setSelectedSequencer]);
 
   // Table actions
   const {

--- a/dashboard/hooks/useDataFetcher.ts
+++ b/dashboard/hooks/useDataFetcher.ts
@@ -46,11 +46,10 @@ export const useDataFetcher = ({
     [tableView, viewParam, isTableRoute],
   );
 
-  const selectedSequencerForFetch = isEconomicsView ? null : selectedSequencer;
+  const selectedSequencerForFetch = selectedSequencer;
 
-  const fetchKey = isTableView
-    ? null
-    : ['metrics', timeRange, selectedSequencerForFetch, isEconomicsView];
+  const fetchKey =
+    isTableView ? null : ['metrics', timeRange, selectedSequencerForFetch, isEconomicsView];
 
   const fetcher = async () => {
     if (isEconomicsView) {

--- a/dashboard/tests/dashboardHeader.test.ts
+++ b/dashboard/tests/dashboardHeader.test.ts
@@ -38,11 +38,11 @@ describe('DashboardHeader', () => {
     expect(html.includes('Refresh')).toBe(true);
     expect(html.includes('Status')).toBe(true);
     expect(html.includes('All Sequencers')).toBe(true);
-    expect(html.includes('Economics')).toBe(false);
+    expect(html.includes('Economics')).toBe(true);
     expect(html.includes('Dark Mode')).toBe(true);
   });
 
-  it('hides sequencer selector in economics view', () => {
+  it('shows sequencer selector in economics view', () => {
     const html = renderToStaticMarkup(
       React.createElement(
         ThemeProvider,
@@ -68,7 +68,7 @@ describe('DashboardHeader', () => {
         ),
       ),
     );
-    expect(html.includes('All Sequencers')).toBe(false);
+    expect(html.includes('All Sequencers')).toBe(true);
     expect(html.includes('Dark Mode')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- display the sequencer dropdown for the economics view
- remove state reset of selected sequencer when switching views
- allow economics data fetcher to use the selected sequencer
- update header tests

## Testing
- `just check-dashboard`
- `just test-dashboard`
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_685bff5ff580832886ea82f68df5b0e6