### PR TITLE
Include prove/verify cost in charts

### DIFF
--- a/dashboard/components/BlockProfitTables.tsx
+++ b/dashboard/components/BlockProfitTables.tsx
@@ -10,6 +10,8 @@ interface BlockProfitTablesProps {
   timeRange: TimeRange;
   cloudCost: number;
   proverCost: number;
+  proveCost?: number;
+  verifyCost?: number;
   address?: string;
 }
 
@@ -26,6 +28,8 @@ export const BlockProfitTables: React.FC<BlockProfitTablesProps> = ({
   timeRange,
   cloudCost,
   proverCost,
+  proveCost = 0,
+  verifyCost = 0,
   address,
 }) => {
   const { data: ethPrice = 0 } = useEthPrice();
@@ -39,7 +43,10 @@ export const BlockProfitTables: React.FC<BlockProfitTablesProps> = ({
   const hours = rangeToHours(timeRange);
   const costPerBatchUsd =
     batchCount > 0
-      ? (((cloudCost + proverCost) / HOURS_IN_MONTH) * hours) / batchCount
+      ?
+          ((cloudCost + proverCost) / HOURS_IN_MONTH) * (hours / batchCount) +
+        proveCost +
+        verifyCost
       : 0;
   const costPerBatchEth = ethPrice ? costPerBatchUsd / ethPrice : 0;
 

--- a/dashboard/components/EconomicsChart.tsx
+++ b/dashboard/components/EconomicsChart.tsx
@@ -19,6 +19,8 @@ interface EconomicsChartProps {
   timeRange: TimeRange;
   cloudCost: number;
   proverCost: number;
+  proveCost?: number;
+  verifyCost?: number;
   address?: string;
 }
 
@@ -26,6 +28,8 @@ export const EconomicsChart: React.FC<EconomicsChartProps> = ({
   timeRange,
   cloudCost,
   proverCost,
+  proveCost = 0,
+  verifyCost = 0,
   address,
 }) => {
   const { data: feeRes } = useSWR(
@@ -46,8 +50,8 @@ export const EconomicsChart: React.FC<EconomicsChartProps> = ({
   const hours = rangeToHours(timeRange);
   const HOURS_IN_MONTH = 30 * 24;
   const baseCostUsd = ((cloudCost + proverCost) / HOURS_IN_MONTH) * hours;
-  const baseCostEth = ethPrice ? baseCostUsd / ethPrice : 0;
-  const baseCostPerBatchEth = baseCostEth / feeData.length;
+  const baseCostPerBatchUsd = baseCostUsd / feeData.length + proveCost + verifyCost;
+  const baseCostPerBatchEth = ethPrice ? baseCostPerBatchUsd / ethPrice : 0;
 
   const data = feeData.map((b) => {
     const incomeEth = (b.priority + b.base) / 1e18;

--- a/dashboard/components/ProfitabilityChart.tsx
+++ b/dashboard/components/ProfitabilityChart.tsx
@@ -19,6 +19,8 @@ interface ProfitabilityChartProps {
   timeRange: TimeRange;
   cloudCost: number;
   proverCost: number;
+  proveCost?: number;
+  verifyCost?: number;
   address?: string;
 }
 
@@ -26,6 +28,8 @@ export const ProfitabilityChart: React.FC<ProfitabilityChartProps> = ({
   timeRange,
   cloudCost,
   proverCost,
+  proveCost = 0,
+  verifyCost = 0,
   address,
 }) => {
   const { data: feeRes } = useSWR(
@@ -45,9 +49,11 @@ export const ProfitabilityChart: React.FC<ProfitabilityChartProps> = ({
 
   const hours = rangeToHours(timeRange);
   const HOURS_IN_MONTH = 30 * 24;
-  const totalCostUsd = ((cloudCost + proverCost) / HOURS_IN_MONTH) * hours;
-  const totalCostEth = ethPrice ? totalCostUsd / ethPrice : 0;
-  const costPerBatchEth = totalCostEth / feeData.length;
+  const costPerBatchUsd =
+    ((cloudCost + proverCost) / HOURS_IN_MONTH) * (hours / feeData.length) +
+    proveCost +
+    verifyCost;
+  const costPerBatchEth = ethPrice ? costPerBatchUsd / ethPrice : 0;
 
   const data = feeData.map((b) => {
     const revenueEth = (b.priority + b.base - (b.l1Cost ?? 0)) / 1e18;

--- a/dashboard/tests/economicsChart.test.ts
+++ b/dashboard/tests/economicsChart.test.ts
@@ -18,6 +18,8 @@ describe('EconomicsChart', () => {
         timeRange: '1h',
         cloudCost: 100,
         proverCost: 100,
+        proveCost: 0,
+        verifyCost: 0,
       }),
     );
 

--- a/dashboard/tests/profitabilityChart.test.ts
+++ b/dashboard/tests/profitabilityChart.test.ts
@@ -21,6 +21,8 @@ describe('ProfitabilityChart', () => {
         timeRange: '1h',
         cloudCost: 1000,
         proverCost: 1000,
+        proveCost: 0,
+        verifyCost: 0,
       })
     );
 


### PR DESCRIPTION
## Summary
- extend chart components to accept `proveCost` and `verifyCost`
- factor these costs into per-batch calculations
- update unit tests for new props

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685bff3ba3648328a711a26adcaf79c6