### PR TITLE
Add prove and verify cost tables

### DIFF
--- a/dashboard/components/views/DashboardView.tsx
+++ b/dashboard/components/views/DashboardView.tsx
@@ -154,6 +154,8 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
         'Avg. Prove Time': () => onOpenTable('prove-time', timeRange),
         'Avg. Verify Time': () => onOpenTable('verify-time', timeRange),
         'L1 Data Cost': () => onOpenTable('l1-data-cost', timeRange),
+        'Prove Cost': () => onOpenTable('prove-cost', timeRange),
+        'Verify Cost': () => onOpenTable('verify-cost', timeRange),
       };
       return actions[title];
     },

--- a/dashboard/config/tableConfig.ts
+++ b/dashboard/config/tableConfig.ts
@@ -21,11 +21,19 @@ import {
   fetchL2GasUsed,
   fetchL2GasUsedAggregated,
   fetchL1DataCost,
+  fetchProveCost,
+  fetchVerifyCost,
   fetchSequencerDistribution,
   fetchL2Tps,
 } from '../services/apiService';
 import { getSequencerName } from '../sequencerConfig';
-import { bytesToHex, blockLink, addressLink, formatDateTime, formatEth } from '../utils';
+import {
+  bytesToHex,
+  blockLink,
+  addressLink,
+  formatDateTime,
+  formatEth,
+} from '../utils';
 import { TAIKO_PINK } from '../theme';
 import React from 'react';
 
@@ -336,6 +344,40 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
         cost: formatEth(d.cost),
       })),
     urlKey: 'l1-data-cost',
+    supportsPagination: true,
+  },
+
+  'prove-cost': {
+    title: 'Prove Cost',
+    description: 'Cost to prove each batch.',
+    fetcher: fetchProveCost,
+    columns: [
+      { key: 'batch', label: 'Batch' },
+      { key: 'cost', label: 'Cost' },
+    ],
+    mapData: (data) =>
+      (data as { batch: number; cost: number }[]).map((d) => ({
+        batch: d.batch.toLocaleString(),
+        cost: formatEth(d.cost),
+      })),
+    urlKey: 'prove-cost',
+    supportsPagination: true,
+  },
+
+  'verify-cost': {
+    title: 'Verify Cost',
+    description: 'Cost to verify each batch.',
+    fetcher: fetchVerifyCost,
+    columns: [
+      { key: 'batch', label: 'Batch' },
+      { key: 'cost', label: 'Cost' },
+    ],
+    mapData: (data) =>
+      (data as { batch: number; cost: number }[]).map((d) => ({
+        batch: d.batch.toLocaleString(),
+        cost: formatEth(d.cost),
+      })),
+    urlKey: 'verify-cost',
     supportsPagination: true,
   },
 

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -877,6 +877,16 @@ export interface L1DataCostItem {
   cost: number;
 }
 
+export interface ProveCostItem {
+  batch: number;
+  cost: number;
+}
+
+export interface VerifyCostItem {
+  batch: number;
+  cost: number;
+}
+
 export const fetchL1DataCost = async (
   range: TimeRange,
   limit = 50,
@@ -900,6 +910,64 @@ export const fetchL1DataCost = async (
   return {
     data: res.data
       ? res.data.blocks.map((b) => ({ block: b.l1_block_number, cost: b.cost }))
+      : null,
+    badRequest: res.badRequest,
+    error: res.error,
+  };
+};
+
+export const fetchProveCost = async (
+  range: TimeRange,
+  limit = 50,
+  startingAfter?: number,
+  endingBefore?: number,
+): Promise<RequestResult<ProveCostItem[]>> => {
+  let url = `${API_BASE}/prove-cost?`;
+  if (startingAfter === undefined && endingBefore === undefined) {
+    url += `${timeRangeToQuery(range)}&limit=${limit}`;
+  } else {
+    url += `${rangeToQuery(range)}&limit=${limit}`;
+  }
+  if (startingAfter !== undefined) {
+    url += `&starting_after=${startingAfter}`;
+  } else if (endingBefore !== undefined) {
+    url += `&ending_before=${endingBefore}`;
+  }
+  const res = await fetchJson<{
+    batches: { batch_id: number; cost: number }[];
+  }>(url);
+  return {
+    data: res.data
+      ? res.data.batches.map((b) => ({ batch: b.batch_id, cost: b.cost }))
+      : null,
+    badRequest: res.badRequest,
+    error: res.error,
+  };
+};
+
+export const fetchVerifyCost = async (
+  range: TimeRange,
+  limit = 50,
+  startingAfter?: number,
+  endingBefore?: number,
+): Promise<RequestResult<VerifyCostItem[]>> => {
+  let url = `${API_BASE}/verify-cost?`;
+  if (startingAfter === undefined && endingBefore === undefined) {
+    url += `${timeRangeToQuery(range)}&limit=${limit}`;
+  } else {
+    url += `${rangeToQuery(range)}&limit=${limit}`;
+  }
+  if (startingAfter !== undefined) {
+    url += `&starting_after=${startingAfter}`;
+  } else if (endingBefore !== undefined) {
+    url += `&ending_before=${endingBefore}`;
+  }
+  const res = await fetchJson<{
+    batches: { batch_id: number; cost: number }[];
+  }>(url);
+  return {
+    data: res.data
+      ? res.data.batches.map((b) => ({ batch: b.batch_id, cost: b.cost }))
       : null,
     badRequest: res.badRequest,
     error: res.error,

--- a/dashboard/tests/proveCostMap.test.ts
+++ b/dashboard/tests/proveCostMap.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { TABLE_CONFIGS } from '../config/tableConfig';
+
+describe('prove-cost mapData', () => {
+  const mapData = TABLE_CONFIGS['prove-cost'].mapData!;
+
+  it('formats batch number and cost correctly', () => {
+    const rows = mapData([{ batch: 1000, cost: 42e18 }]);
+    expect(rows[0].batch).toBe('1,000');
+    expect(rows[0].cost).toBe('42.0 ETH');
+  });
+});

--- a/dashboard/tests/verifyCostMap.test.ts
+++ b/dashboard/tests/verifyCostMap.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { TABLE_CONFIGS } from '../config/tableConfig';
+
+describe('verify-cost mapData', () => {
+  const mapData = TABLE_CONFIGS['verify-cost'].mapData!;
+
+  it('formats batch number and cost correctly', () => {
+    const rows = mapData([{ batch: 2000, cost: 21e18 }]);
+    expect(rows[0].batch).toBe('2,000');
+    expect(rows[0].cost).toBe('21.0 ETH');
+  });
+});


### PR DESCRIPTION
## Summary
- add interfaces and API calls for prove/verify cost
- configure prove/verify cost tables with ETH formatting
- hook new metrics to open tables
- test prove/verify cost table mapping

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685bff3acb588328853cc4580ae9d882