### PR TITLE
Fix prove/verify costs in block profitability tables

### DIFF
--- a/dashboard/components/views/DashboardView.tsx
+++ b/dashboard/components/views/DashboardView.tsx
@@ -10,6 +10,8 @@ import { ChartCard } from '../ChartCard';
 import { TAIKO_PINK } from '../../theme';
 import { TimeRange, MetricData } from '../../types';
 import { useNavigate, useSearchParams } from 'react-router-dom';
+import { parseEthValue, findMetricValue } from '../../utils';
+import { useEthPrice } from '../../services/priceService';
 
 const SequencerPieChart = lazy(() =>
   import('../SequencerPieChart').then((m) => ({
@@ -85,6 +87,15 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
   // Default monthly costs in USD
   const [cloudCost, setCloudCost] = useState(1000);
   const [proverCost, setProverCost] = useState(1000);
+  const { data: ethPrice = 0 } = useEthPrice();
+  const proveCostUsd = React.useMemo(() => {
+    const eth = parseEthValue(findMetricValue(metricsData.metrics, 'Prove Cost'));
+    return eth * ethPrice;
+  }, [metricsData.metrics, ethPrice]);
+  const verifyCostUsd = React.useMemo(() => {
+    const eth = parseEthValue(findMetricValue(metricsData.metrics, 'Verify Cost'));
+    return eth * ethPrice;
+  }, [metricsData.metrics, ethPrice]);
 
   const visibleMetrics = React.useMemo(
     () =>
@@ -332,6 +343,8 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
               timeRange={timeRange}
               cloudCost={cloudCost}
               proverCost={proverCost}
+              proveCost={proveCostUsd}
+              verifyCost={verifyCostUsd}
               address={selectedSequencer || undefined}
             />
           </>

--- a/dashboard/tests/profitabilityChart.test.ts
+++ b/dashboard/tests/profitabilityChart.test.ts
@@ -28,4 +28,21 @@ describe('ProfitabilityChart', () => {
 
     expect(html).toContain('recharts-responsive-container');
   });
+
+  it('renders with non-zero prove and verify cost', () => {
+    vi.mocked(swr.default).mockReturnValue({ data: { data: feeData } } as any);
+    vi.spyOn(priceService, 'useEthPrice').mockReturnValue({ data: 1 } as any);
+
+    const html = renderToStaticMarkup(
+      React.createElement(ProfitabilityChart, {
+        timeRange: '1h',
+        cloudCost: 1000,
+        proverCost: 1000,
+        proveCost: 5,
+        verifyCost: 2,
+      })
+    );
+
+    expect(html).toContain('recharts-responsive-container');
+  });
 });


### PR DESCRIPTION
## Summary
- derive prover/verifier USD costs in DashboardView
- forward these to BlockProfitTables component
- cover non-zero cost case in ProfitabilityChart tests

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685c06c19ae08328aee03ca6706cb95f