### PR TITLE
feat(dashboard): show prove and verify costs

### DIFF
--- a/dashboard/hooks/useDataFetcher.ts
+++ b/dashboard/hooks/useDataFetcher.ts
@@ -48,12 +48,16 @@ export const useDataFetcher = ({
 
   const selectedSequencerForFetch = selectedSequencer;
 
-  const fetchKey =
-    isTableView ? null : ['metrics', timeRange, selectedSequencerForFetch, isEconomicsView];
+  const fetchKey = isTableView
+    ? null
+    : ['metrics', timeRange, selectedSequencerForFetch, isEconomicsView];
 
   const fetcher = async () => {
     if (isEconomicsView) {
-      const data = await fetchEconomicsData(timeRange, selectedSequencerForFetch);
+      const data = await fetchEconomicsData(
+        timeRange,
+        selectedSequencerForFetch,
+      );
       const anyBadRequest = hasBadRequest(data.badRequestResults);
 
       const metricsInput: MetricInputData = {
@@ -71,14 +75,20 @@ export const useDataFetcher = ({
         priorityFee: data.priorityFee,
         baseFee: data.baseFee,
         l1DataCost: data.l1DataCost,
+        proveCost: data.proveCost,
+        verifyCost: data.verifyCost,
         profit:
           data.priorityFee != null &&
           data.baseFee != null &&
-          data.l1DataCost != null
-            ? data.priorityFee + data.baseFee - data.l1DataCost
+          data.l1DataCost != null &&
+          data.proveCost != null &&
+          data.verifyCost != null
+            ? data.priorityFee +
+              data.baseFee -
+              data.l1DataCost -
+              data.proveCost -
+              data.verifyCost
             : null,
-        proveCost: null,
-        verifyCost: null,
         l2Block: data.l2Block,
         l1Block: data.l1Block,
       };
@@ -92,7 +102,10 @@ export const useDataFetcher = ({
       };
     }
 
-    const data = await fetchMainDashboardData(timeRange, selectedSequencerForFetch);
+    const data = await fetchMainDashboardData(
+      timeRange,
+      selectedSequencerForFetch,
+    );
 
     const anyBadRequest = hasBadRequest(data.badRequestResults);
     const activeGateways = data.preconfData

--- a/dashboard/tests/dataFetcher.test.ts
+++ b/dashboard/tests/dataFetcher.test.ts
@@ -47,8 +47,12 @@ describe('dataFetcher', () => {
       fetchVerifyTimes: ok([{ name: '2', value: 2, timestamp: 0 }]),
       fetchL2BlockTimesAggregated: ok([{ value: 2, timestamp: 0 }]),
       fetchL2GasUsedAggregated: ok([{ value: 3, timestamp: 0 }]),
-      fetchSequencerDistribution: ok([{ name: 'foo', address: '0xfoo', value: 1 }]),
-      fetchBlockTransactionsAggregated: ok([{ block: 1, txs: 2, sequencer: 'bar' }]),
+      fetchSequencerDistribution: ok([
+        { name: 'foo', address: '0xfoo', value: 1 },
+      ]),
+      fetchBlockTransactionsAggregated: ok([
+        { block: 1, txs: 2, sequencer: 'bar' },
+      ]),
       fetchBatchBlobCounts: ok([{ block: 10, batch: 1, blobs: 2 }]),
     });
 
@@ -82,10 +86,17 @@ describe('dataFetcher', () => {
 
   it('fetches economics data', async () => {
     setAll({
-      fetchL2Fees: ok({ priority_fee: 1, base_fee: 2, l1_data_cost: 4, sequencers: [] }),
+      fetchL2Fees: ok({
+        priority_fee: 1,
+        base_fee: 2,
+        l1_data_cost: 4,
+        sequencers: [],
+      }),
       fetchL2HeadBlock: ok(2),
       fetchL1HeadBlock: ok(3),
-      fetchSequencerDistribution: ok([{ name: 'foo', address: '0xfoo', value: 1, tps: null }]),
+      fetchSequencerDistribution: ok([
+        { name: 'foo', address: '0xfoo', value: 1, tps: null },
+      ]),
       fetchDashboardData: ok({ prove_cost: 5, verify_cost: 6 }),
     });
 
@@ -98,6 +109,29 @@ describe('dataFetcher', () => {
     expect(res.proveCost).toBe(5);
     expect(res.verifyCost).toBe(6);
     expect(res.sequencerDist[0].name).toBe('foo');
+    expect(res.badRequestResults).toHaveLength(5);
+  });
+
+  it('defaults economics costs to null when missing', async () => {
+    setAll({
+      fetchL2Fees: ok({
+        priority_fee: null,
+        base_fee: null,
+        l1_data_cost: null,
+        sequencers: [],
+      }),
+      fetchL2HeadBlock: ok(null),
+      fetchL1HeadBlock: ok(null),
+      fetchSequencerDistribution: ok(null),
+      fetchDashboardData: ok({}),
+    });
+
+    const res = await fetchEconomicsData('1h', null);
+    expect(res.priorityFee).toBeNull();
+    expect(res.baseFee).toBeNull();
+    expect(res.l1DataCost).toBeNull();
+    expect(res.proveCost).toBeNull();
+    expect(res.verifyCost).toBeNull();
     expect(res.badRequestResults).toHaveLength(5);
   });
 

--- a/dashboard/tests/metricsCreator.test.ts
+++ b/dashboard/tests/metricsCreator.test.ts
@@ -41,6 +41,9 @@ describe('metricsCreator', () => {
     expect(proveCostMetric?.value).toBe('5.00 ETH');
     expect(verifyCostMetric?.value).toBe('6.00 ETH');
 
+    const profitMetric = metrics.find((m) => m.title === 'Profit');
+    expect(profitMetric?.value).toBe('39.0 ETH');
+
     const current = metrics.find((m) => m.title === 'Current Sequencer');
     const next = metrics.find((m) => m.title === 'Next Sequencer');
     expect(current?.value).toBe('Chainbound A');


### PR DESCRIPTION
## Summary
- expose proveCost/verifyCost in economics view
- include prove and verify costs when computing profit
- cover new fields in metricsCreator and dataFetcher tests

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685c06bcddcc8328941d8a156630d98f