### PR TITLE
Handle prove/verify costs in charts

### DIFF
--- a/dashboard/components/ProfitRankingTable.tsx
+++ b/dashboard/components/ProfitRankingTable.tsx
@@ -16,6 +16,8 @@ interface ProfitRankingTableProps {
   timeRange: TimeRange;
   cloudCost: number;
   proverCost: number;
+  proveCost?: number;
+  verifyCost?: number;
 }
 
 const formatUsd = (value: number): string => {
@@ -33,6 +35,8 @@ export const ProfitRankingTable: React.FC<ProfitRankingTableProps> = ({
   timeRange,
   cloudCost,
   proverCost,
+  proveCost = 0,
+  verifyCost = 0,
 }) => {
   const { data: distRes } = useSWR(['profitRankingSeq', timeRange], () =>
     fetchSequencerDistribution(timeRange),
@@ -85,12 +89,14 @@ export const ProfitRankingTable: React.FC<ProfitRankingTableProps> = ({
 
   const hours = rangeToHours(timeRange);
   const MONTH_HOURS = 30 * 24;
-  const costPerSeqUsd = ((cloudCost + proverCost) / MONTH_HOURS) * hours;
-  const costPerSeqEth = ethPrice ? costPerSeqUsd / ethPrice : 0;
+  const baseSeqCostUsd = ((cloudCost + proverCost) / MONTH_HOURS) * hours;
 
   const rows = sequencers.map((seq) => {
     const addr = seq.address || getSequencerAddress(seq.name) || '';
     const batchCount = batchCounts?.get(addr.toLowerCase()) ?? null;
+    const costPerSeqUsd =
+      baseSeqCostUsd + (proveCost + verifyCost) * (batchCount ?? 0);
+    const costPerSeqEth = ethPrice ? costPerSeqUsd / ethPrice : 0;
     const fees = feeDataMap.get(addr.toLowerCase());
     if (!fees) {
       return {

--- a/dashboard/components/views/DashboardView.tsx
+++ b/dashboard/components/views/DashboardView.tsx
@@ -10,6 +10,7 @@ import { ChartCard } from '../ChartCard';
 import { TAIKO_PINK } from '../../theme';
 import { TimeRange, MetricData } from '../../types';
 import { useNavigate, useSearchParams } from 'react-router-dom';
+import { parseEthValue } from '../../utils';
 
 const SequencerPieChart = lazy(() =>
   import('../SequencerPieChart').then((m) => ({
@@ -85,6 +86,14 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
   // Default monthly costs in USD
   const [cloudCost, setCloudCost] = useState(1000);
   const [proverCost, setProverCost] = useState(1000);
+  const proveCost = React.useMemo(() => {
+    const metric = metricsData.metrics.find((m) => m.title === 'Prove Cost');
+    return metric ? parseEthValue(metric.value) : 0;
+  }, [metricsData.metrics]);
+  const verifyCost = React.useMemo(() => {
+    const metric = metricsData.metrics.find((m) => m.title === 'Verify Cost');
+    return metric ? parseEthValue(metric.value) : 0;
+  }, [metricsData.metrics]);
 
   const visibleMetrics = React.useMemo(
     () =>
@@ -320,6 +329,8 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
                 timeRange={timeRange}
                 cloudCost={cloudCost}
                 proverCost={proverCost}
+                proveCost={proveCost}
+                verifyCost={verifyCost}
                 address={selectedSequencer || undefined}
               />
             </div>
@@ -327,11 +338,15 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
               timeRange={timeRange}
               cloudCost={cloudCost}
               proverCost={proverCost}
+              proveCost={proveCost}
+              verifyCost={verifyCost}
             />
             <BlockProfitTables
               timeRange={timeRange}
               cloudCost={cloudCost}
               proverCost={proverCost}
+              proveCost={proveCost}
+              verifyCost={verifyCost}
               address={selectedSequencer || undefined}
             />
           </>

--- a/dashboard/tests/profitRankingTable.test.ts
+++ b/dashboard/tests/profitRankingTable.test.ts
@@ -88,6 +88,8 @@ describe('ProfitRankingTable', () => {
         timeRange: '1h',
         cloudCost: 0,
         proverCost: 0,
+        proveCost: 0,
+        verifyCost: 0,
       }),
     );
     expect(html.includes('Sequencer Profit Ranking')).toBe(true);
@@ -161,8 +163,10 @@ describe('ProfitRankingTable', () => {
         timeRange: '1h',
         cloudCost: 0,
         proverCost: 0,
+        proveCost: 1,
+        verifyCost: 2,
       }),
     );
-    expect(html.includes('title="$50.00"')).toBe(true);
+    expect(html.includes('title="$53.00"')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- compute proveCost and verifyCost from metrics in `DashboardView`
- forward those costs to charts and tables
- include extra costs when ranking sequencer profitability
- update profit ranking table tests

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685c06bf97788328be92f37f4cb3751b