### PR TITLE
Default sort by income ratio

### DIFF
--- a/dashboard/components/ProfitRankingTable.tsx
+++ b/dashboard/components/ProfitRankingTable.tsx
@@ -78,7 +78,7 @@ export const ProfitRankingTable: React.FC<ProfitRankingTableProps> = ({
 
   const [sortBy, setSortBy] = React.useState<
     'name' | 'blocks' | 'batches' | 'revenue' | 'cost' | 'profit' | 'ratio'
-  >('profit');
+  >('ratio');
   const [sortDirection, setSortDirection] = React.useState<'asc' | 'desc'>(
     'desc',
   );


### PR DESCRIPTION
## Summary
- default the Sequencer Profit Ranking sort to income/cost ratio

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685d08e700548328ab494ab508386b1e