### PR TITLE
Add typed hook interfaces

### DIFF
--- a/dashboard/hooks/useBlockData.ts
+++ b/dashboard/hooks/useBlockData.ts
@@ -1,9 +1,9 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { fetchDashboardData } from '../services/apiService';
-import { MetricData } from '../types';
+import { MetricData, BlockDataState } from '../types';
 import { TAIKOSCAN_BASE } from '../utils';
 
-export const useBlockData = () => {
+export const useBlockData = (): BlockDataState => {
   const [l2HeadBlock, setL2HeadBlock] = useState<string>('0');
   const [l1HeadBlock, setL1HeadBlock] = useState<string>('0');
   const [candidates, setCandidates] = useState<string[]>([]);

--- a/dashboard/hooks/useChartsData.ts
+++ b/dashboard/hooks/useChartsData.ts
@@ -1,8 +1,13 @@
 import { useState, useCallback, useMemo } from 'react';
-import { TimeSeriesData, PieChartDataItem } from '../types';
+import {
+  TimeSeriesData,
+  PieChartDataItem,
+  ChartsData,
+  ChartsDataUpdate,
+} from '../types';
 import type { BlockTransaction, BatchBlobCount } from '../services/apiService';
 
-export const useChartsData = () => {
+export const useChartsData = (): ChartsData => {
   const [secondsToProveData, setSecondsToProveData] = useState<
     TimeSeriesData[]
   >([]);
@@ -16,17 +21,6 @@ export const useChartsData = () => {
   const [sequencerDistribution, setSequencerDistribution] = useState<
     PieChartDataItem[]
   >([]);
-
-  interface ChartsDataUpdate {
-    proveTimes?: TimeSeriesData[];
-    verifyTimes?: TimeSeriesData[];
-    l2Times?: TimeSeriesData[];
-    l2Gas?: TimeSeriesData[];
-    txPerBlock?: BlockTransaction[];
-    blobsPerBatch?: BatchBlobCount[];
-    sequencerDist?: PieChartDataItem[];
-  }
-
   const updateChartsData = useCallback(
     (data: ChartsDataUpdate) => {
       if (data.proveTimes) setSecondsToProveData([...data.proveTimes]);

--- a/dashboard/hooks/useMetricsData.ts
+++ b/dashboard/hooks/useMetricsData.ts
@@ -1,9 +1,9 @@
 import { useState, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { useErrorHandler } from './useErrorHandler';
-import type { MetricData } from '../types';
+import type { MetricData, MetricsDataState } from '../types';
 
-export const useMetricsData = () => {
+export const useMetricsData = (): MetricsDataState => {
   const [metrics, setMetrics] = useState<MetricData[]>([]);
   const [loadingMetrics, setLoadingMetrics] = useState(true);
   const { errorMessage, setErrorMessage } = useErrorHandler();

--- a/dashboard/hooks/useRefreshTimer.ts
+++ b/dashboard/hooks/useRefreshTimer.ts
@@ -1,7 +1,8 @@
 import { useState, useEffect, useCallback } from 'react';
 import { loadRefreshRate, saveRefreshRate, isValidRefreshRate } from '../utils';
+import type { RefreshTimerState } from '../types';
 
-export const useRefreshTimer = () => {
+export const useRefreshTimer = (): RefreshTimerState => {
   const [refreshRate, setRefreshRateState] = useState<number>(() =>
     loadRefreshRate(),
   );

--- a/dashboard/tests/smartCache.test.ts
+++ b/dashboard/tests/smartCache.test.ts
@@ -27,12 +27,12 @@ describe('SmartCache', () => {
   it('evicts least recently used item', async () => {
     const cache = new SmartCache<number>(2, 1000);
     cache.set('a', 1);
-    await wait(1);
+    await wait(5);
     cache.set('b', 2);
-    await wait(1);
+    await wait(5);
     // Access 'a' so 'b' becomes least recently used
     cache.get('a');
-    await wait(1);
+    await wait(5);
     cache.set('c', 3);
     expect(cache.has('b')).toBe(false);
     expect(cache.has('a')).toBe(true);

--- a/dashboard/types.ts
+++ b/dashboard/types.ts
@@ -14,6 +14,7 @@ export interface PieChartDataItem {
 }
 
 import type { ReactNode } from 'react';
+import type { BlockTransaction, BatchBlobCount } from './services/apiService';
 
 export interface MetricData {
   title: ReactNode;
@@ -69,4 +70,50 @@ export interface BatchFeeComponent {
 export interface BlockProfit {
   block: number;
   profit: number;
+}
+
+export interface ChartsDataUpdate {
+  proveTimes?: TimeSeriesData[];
+  verifyTimes?: TimeSeriesData[];
+  l2Times?: TimeSeriesData[];
+  l2Gas?: TimeSeriesData[];
+  txPerBlock?: BlockTransaction[];
+  blobsPerBatch?: BatchBlobCount[];
+  sequencerDist?: PieChartDataItem[];
+}
+
+export interface ChartsData {
+  secondsToProveData: TimeSeriesData[];
+  secondsToVerifyData: TimeSeriesData[];
+  l2BlockTimeData: TimeSeriesData[];
+  l2GasUsedData: TimeSeriesData[];
+  blockTxData: BlockTransaction[];
+  batchBlobCounts: BatchBlobCount[];
+  sequencerDistribution: PieChartDataItem[];
+  updateChartsData: (data: ChartsDataUpdate) => void;
+}
+
+export interface MetricsDataState {
+  metrics: MetricData[];
+  setMetrics: (metrics: MetricData[]) => void;
+  loadingMetrics: boolean;
+  setLoadingMetrics: (v: boolean) => void;
+  errorMessage: string;
+  setErrorMessage: (msg: string) => void;
+  isEconomicsView: boolean;
+}
+
+export interface BlockDataState {
+  l2HeadBlock: string;
+  l1HeadBlock: string;
+  candidates: string[];
+  updateBlockHeads: () => Promise<void>;
+  updateMetricsWithBlockHeads: (metrics: MetricData[]) => MetricData[];
+}
+
+export interface RefreshTimerState {
+  refreshRate: number;
+  setRefreshRate: (rate: number) => void;
+  lastRefresh: number;
+  updateLastRefresh: () => void;
 }


### PR DESCRIPTION
## Summary
- describe shape of dashboard hooks data in `types.ts`
- type `useChartsData`, `useMetricsData`, `useBlockData`, and `useRefreshTimer` using the new interfaces
- stabilize SmartCache test timings

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685d111d09a88328b670cfc8d7a3489a