### PR TITLE
Fix dashboard hook types

### DIFF
--- a/dashboard/hooks/useDataFetcher.ts
+++ b/dashboard/hooks/useDataFetcher.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo } from 'react';
 import useSWR from 'swr';
 import { useSearchParams, useLocation } from 'react-router-dom';
-import { TimeRange, MetricData } from '../types';
+import { TimeRange, MetricData, ChartsDataUpdate } from '../types';
 import { TableViewState } from './useTableActions';
 import {
   fetchMainDashboardData,
@@ -14,7 +14,7 @@ interface UseDataFetcherProps {
   timeRange: TimeRange;
   selectedSequencer: string | null;
   tableView: TableViewState | null;
-  updateChartsData: (data: any) => void;
+  updateChartsData: (data: ChartsDataUpdate) => void;
   setMetrics: (metrics: MetricData[]) => void;
   setLoadingMetrics: (v: boolean) => void;
   setErrorMessage: (msg: string) => void;

--- a/dashboard/hooks/useSequencerHandler.ts
+++ b/dashboard/hooks/useSequencerHandler.ts
@@ -1,17 +1,18 @@
 import { useState, useEffect, useMemo, useRef } from 'react';
 import { getSequencerName } from '../sequencerConfig';
 import { useSearchParams } from 'react-router-dom';
+import type { MetricData } from '../types';
 
 interface UseSequencerHandlerProps {
   blockData: {
     l1HeadBlock: string;
     l2HeadBlock: string;
     candidates: string[];
-    updateMetricsWithBlockHeads: (metrics: any[]) => any[];
+    updateMetricsWithBlockHeads: (metrics: MetricData[]) => MetricData[];
   };
   metricsData: {
-    metrics: any[];
-    setMetrics: (metrics: any[]) => void;
+    metrics: MetricData[];
+    setMetrics: (metrics: MetricData[]) => void;
   };
 }
 


### PR DESCRIPTION
## Summary
- use `ChartsDataUpdate` when updating charts
- use `MetricData[]` when updating metrics

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685d14126588832891072c8976d0a6d3