### PR TITLE
Add L1 Prove Cost to FeeFlowChart

### DIFF
--- a/dashboard/components/views/DashboardView.tsx
+++ b/dashboard/components/views/DashboardView.tsx
@@ -96,6 +96,10 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
     const eth = parseEthValue(findMetricValue(metricsData.metrics, 'Verify Cost'));
     return eth * ethPrice;
   }, [metricsData.metrics, ethPrice]);
+  const l1ProveCostUsd = React.useMemo(
+    () => proveCostUsd + verifyCostUsd,
+    [proveCostUsd, verifyCostUsd],
+  );
 
   const visibleMetrics = React.useMemo(
     () =>
@@ -317,6 +321,7 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
               timeRange={timeRange}
               cloudCost={cloudCost}
               proverCost={proverCost}
+              l1ProveCost={l1ProveCostUsd}
               address={selectedSequencer || undefined}
             />
             <ProfitCalculator


### PR DESCRIPTION
## Summary
- show L1 Prove Cost on the fee flow chart
- compute new value in `DashboardView` and pass to the chart

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685d18919db48328b2c999d2559dd48d