### PR TITLE
Update Prove Cost metric

### DIFF
--- a/dashboard/components/BlockProfitTables.tsx
+++ b/dashboard/components/BlockProfitTables.tsx
@@ -11,7 +11,6 @@ interface BlockProfitTablesProps {
   cloudCost: number;
   proverCost: number;
   proveCost?: number;
-  verifyCost?: number;
   address?: string;
 }
 
@@ -29,7 +28,6 @@ export const BlockProfitTables: React.FC<BlockProfitTablesProps> = ({
   cloudCost,
   proverCost,
   proveCost = 0,
-  verifyCost = 0,
   address,
 }) => {
   const { data: ethPrice = 0 } = useEthPrice();
@@ -45,8 +43,7 @@ export const BlockProfitTables: React.FC<BlockProfitTablesProps> = ({
     batchCount > 0
       ?
       ((cloudCost + proverCost) / HOURS_IN_MONTH) * (hours / batchCount) +
-      proveCost +
-      verifyCost
+      proveCost
       : 0;
   const costPerBatchEth = ethPrice ? costPerBatchUsd / ethPrice : 0;
 

--- a/dashboard/components/EconomicsChart.tsx
+++ b/dashboard/components/EconomicsChart.tsx
@@ -20,7 +20,6 @@ interface EconomicsChartProps {
   cloudCost: number;
   proverCost: number;
   proveCost?: number;
-  verifyCost?: number;
   address?: string;
 }
 
@@ -29,7 +28,6 @@ export const EconomicsChart: React.FC<EconomicsChartProps> = ({
   cloudCost,
   proverCost,
   proveCost = 0,
-  verifyCost = 0,
   address,
 }) => {
   const { data: feeRes } = useSWR(
@@ -50,7 +48,7 @@ export const EconomicsChart: React.FC<EconomicsChartProps> = ({
   const hours = rangeToHours(timeRange);
   const HOURS_IN_MONTH = 30 * 24;
   const baseCostUsd = ((cloudCost + proverCost) / HOURS_IN_MONTH) * hours;
-  const baseCostPerBatchUsd = baseCostUsd / feeData.length + proveCost + verifyCost;
+  const baseCostPerBatchUsd = baseCostUsd / feeData.length + proveCost;
   const baseCostPerBatchEth = ethPrice ? baseCostPerBatchUsd / ethPrice : 0;
 
   const data = feeData.map((b) => {

--- a/dashboard/components/ProfitRankingTable.tsx
+++ b/dashboard/components/ProfitRankingTable.tsx
@@ -17,7 +17,6 @@ interface ProfitRankingTableProps {
   cloudCost: number;
   proverCost: number;
   proveCost?: number;
-  verifyCost?: number;
 }
 
 const formatUsd = (value: number): string => {
@@ -36,7 +35,6 @@ export const ProfitRankingTable: React.FC<ProfitRankingTableProps> = ({
   cloudCost,
   proverCost,
   proveCost = 0,
-  verifyCost = 0,
 }) => {
   const { data: distRes } = useSWR(['profitRankingSeq', timeRange], () =>
     fetchSequencerDistribution(timeRange),
@@ -97,7 +95,7 @@ export const ProfitRankingTable: React.FC<ProfitRankingTableProps> = ({
     const batchCount = batchCounts?.get(addr.toLowerCase()) ?? null;
     const fees = feeDataMap.get(addr.toLowerCase());
     if (!fees) {
-      const extraUsd = batchCount ? (proveCost + verifyCost) * batchCount : 0;
+      const extraUsd = batchCount ? proveCost * batchCount : 0;
       const extraEth = ethPrice ? extraUsd / ethPrice : 0;
       return {
         name: seq.name,
@@ -118,7 +116,7 @@ export const ProfitRankingTable: React.FC<ProfitRankingTableProps> = ({
     const l1CostEth = (fees.l1_data_cost ?? 0) / 1e18;
     const revenueUsd = revenueEth * ethPrice;
     const l1CostUsd = l1CostEth * ethPrice;
-    const extraUsd = batchCount ? (proveCost + verifyCost) * batchCount : 0;
+    const extraUsd = batchCount ? proveCost * batchCount : 0;
     const extraEth = ethPrice ? extraUsd / ethPrice : 0;
     const costEth = costPerSeqEth + l1CostEth + extraEth;
     const costUsd = costPerSeqUsd + l1CostUsd + extraUsd;

--- a/dashboard/components/ProfitabilityChart.tsx
+++ b/dashboard/components/ProfitabilityChart.tsx
@@ -20,7 +20,6 @@ interface ProfitabilityChartProps {
   cloudCost: number;
   proverCost: number;
   proveCost?: number;
-  verifyCost?: number;
   address?: string;
 }
 
@@ -29,7 +28,6 @@ export const ProfitabilityChart: React.FC<ProfitabilityChartProps> = ({
   cloudCost,
   proverCost,
   proveCost = 0,
-  verifyCost = 0,
   address,
 }) => {
   const { data: feeRes } = useSWR(
@@ -51,8 +49,7 @@ export const ProfitabilityChart: React.FC<ProfitabilityChartProps> = ({
   const HOURS_IN_MONTH = 30 * 24;
   const costPerBatchUsd =
     ((cloudCost + proverCost) / HOURS_IN_MONTH) * (hours / feeData.length) +
-    proveCost +
-    verifyCost;
+    proveCost;
   const costPerBatchEth = ethPrice ? costPerBatchUsd / ethPrice : 0;
 
   const data = feeData.map((b) => {

--- a/dashboard/components/views/DashboardView.tsx
+++ b/dashboard/components/views/DashboardView.tsx
@@ -88,12 +88,8 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
   const [cloudCost, setCloudCost] = useState(1000);
   const [proverCost, setProverCost] = useState(1000);
   const { data: ethPrice = 0 } = useEthPrice();
-  const proveCostUsd = React.useMemo(() => {
-    const eth = parseEthValue(findMetricValue(metricsData.metrics, 'Prove Cost'));
-    return eth * ethPrice;
-  }, [metricsData.metrics, ethPrice]);
-  const verifyCostUsd = React.useMemo(() => {
-    const eth = parseEthValue(findMetricValue(metricsData.metrics, 'Verify Cost'));
+  const l1ProveCostUsd = React.useMemo(() => {
+    const eth = parseEthValue(findMetricValue(metricsData.metrics, 'L1 Prove Cost'));
     return eth * ethPrice;
   }, [metricsData.metrics, ethPrice]);
 
@@ -165,8 +161,7 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
         'Avg. Prove Time': () => onOpenTable('prove-time', timeRange),
         'Avg. Verify Time': () => onOpenTable('verify-time', timeRange),
         'L1 Data Cost': () => onOpenTable('l1-data-cost', timeRange),
-        'Prove Cost': () => onOpenTable('prove-cost', timeRange),
-        'Verify Cost': () => onOpenTable('verify-cost', timeRange),
+        'L1 Prove Cost': () => onOpenTable('prove-cost', timeRange),
       };
       return actions[title];
     },
@@ -331,8 +326,7 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
                 timeRange={timeRange}
                 cloudCost={cloudCost}
                 proverCost={proverCost}
-                proveCost={proveCostUsd}
-                verifyCost={verifyCostUsd}
+                proveCost={l1ProveCostUsd}
                 address={selectedSequencer || undefined}
               />
             </div>
@@ -340,15 +334,13 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
               timeRange={timeRange}
               cloudCost={cloudCost}
               proverCost={proverCost}
-              proveCost={proveCostUsd}
-              verifyCost={verifyCostUsd}
+              proveCost={l1ProveCostUsd}
             />
             <BlockProfitTables
               timeRange={timeRange}
               cloudCost={cloudCost}
               proverCost={proverCost}
-              proveCost={proveCostUsd}
-              verifyCost={verifyCostUsd}
+              proveCost={l1ProveCostUsd}
               address={selectedSequencer || undefined}
             />
           </>

--- a/dashboard/config/tableConfig.ts
+++ b/dashboard/config/tableConfig.ts
@@ -348,7 +348,7 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
   },
 
   'prove-cost': {
-    title: 'Prove Cost',
+    title: 'L1 Prove Cost',
     description: 'Cost to prove each batch.',
     fetcher: fetchProveCost,
     columns: [

--- a/dashboard/hooks/useDataFetcher.ts
+++ b/dashboard/hooks/useDataFetcher.ts
@@ -75,8 +75,10 @@ export const useDataFetcher = ({
         priorityFee: data.priorityFee,
         baseFee: data.baseFee,
         l1DataCost: data.l1DataCost,
-        proveCost: data.proveCost,
-        verifyCost: data.verifyCost,
+        proveCost:
+          data.proveCost != null && data.verifyCost != null
+            ? data.proveCost + data.verifyCost
+            : null,
         profit:
           data.priorityFee != null &&
           data.baseFee != null &&
@@ -128,8 +130,10 @@ export const useDataFetcher = ({
       forcedInclusions: data.forcedInclusions,
       priorityFee: data.priorityFee,
       baseFee: data.baseFee,
-      proveCost: data.proveCost,
-      verifyCost: data.verifyCost,
+      proveCost:
+        data.proveCost != null && data.verifyCost != null
+          ? data.proveCost + data.verifyCost
+          : null,
       l1DataCost: null,
       profit: null,
       l2Block: data.l2Block,

--- a/dashboard/tests/blockProfitTables.test.ts
+++ b/dashboard/tests/blockProfitTables.test.ts
@@ -21,7 +21,6 @@ describe('BlockProfitTables', () => {
         cloudCost: 100,
         proverCost: 100,
         proveCost: 5,
-        verifyCost: 2,
       }),
     );
 

--- a/dashboard/tests/economicsChart.test.ts
+++ b/dashboard/tests/economicsChart.test.ts
@@ -19,7 +19,6 @@ describe('EconomicsChart', () => {
         cloudCost: 100,
         proverCost: 100,
         proveCost: 5,
-        verifyCost: 2,
       }),
     );
 

--- a/dashboard/tests/helpers.test.ts
+++ b/dashboard/tests/helpers.test.ts
@@ -17,8 +17,7 @@ const metrics = createMetrics({
   l1Block: 50,
   priorityFee: 41e18,
   baseFee: 1e18,
-  proveCost: 9e18,
-  verifyCost: 11e18,
+  proveCost: 20e18,
   l1DataCost: 2e18,
   profit: 40e18,
 });
@@ -45,7 +44,6 @@ const metricsAllNull = createMetrics({
   priorityFee: null,
   baseFee: null,
   proveCost: null,
-  verifyCost: null,
   l1DataCost: null,
   profit: null,
 });
@@ -82,16 +80,14 @@ describe('helpers', () => {
     expect(metrics[13].group).toBe('Network Economics');
     expect(metrics[14].value).toBe('2.00 ETH');
     expect(metrics[14].group).toBe('Network Economics');
-    expect(metrics[15].value).toBe('9.00 ETH');
+    expect(metrics[15].value).toBe('20.0 ETH');
     expect(metrics[15].group).toBe('Network Economics');
-    expect(metrics[16].value).toBe('11.0 ETH');
-    expect(metrics[16].group).toBe('Network Economics');
-    expect(metrics[17].value).toBe('100');
-    expect(metrics[17].link).toContain('/block/100');
+    expect(metrics[16].value).toBe('100');
+    expect(metrics[16].link).toContain('/block/100');
+    expect(metrics[16].group).toBe('Block Information');
+    expect(metrics[17].value).toBe('50');
+    expect(metrics[17].link).toContain('/block/50');
     expect(metrics[17].group).toBe('Block Information');
-    expect(metrics[18].value).toBe('50');
-    expect(metrics[18].link).toContain('/block/50');
-    expect(metrics[18].group).toBe('Block Information');
   });
 
   it('detects bad requests', () => {
@@ -121,9 +117,8 @@ describe('helpers', () => {
     expect(metricsAllNull[13].group).toBe('Network Economics');
     expect(metricsAllNull[14].group).toBe('Network Economics');
     expect(metricsAllNull[15].group).toBe('Network Economics');
-    expect(metricsAllNull[16].group).toBe('Network Economics');
+    expect(metricsAllNull[16].group).toBe('Block Information');
     expect(metricsAllNull[17].group).toBe('Block Information');
-    expect(metricsAllNull[18].group).toBe('Block Information');
   });
 
   it('handles all successful requests', () => {

--- a/dashboard/tests/metricsCreator.test.ts
+++ b/dashboard/tests/metricsCreator.test.ts
@@ -20,15 +20,14 @@ describe('metricsCreator', () => {
       forcedInclusions: 3,
       priorityFee: 40e18,
       baseFee: 2e18,
-      proveCost: 5e18,
-      verifyCost: 6e18,
+      proveCost: 11e18,
       l1DataCost: 3e18,
       profit: 39e18,
       l2Block: 100,
       l1Block: 50,
     });
 
-    expect(metrics).toHaveLength(19);
+    expect(metrics).toHaveLength(18);
     expect(metrics[0].value).toBe('1.23');
 
     const proveMetric = metrics.find((m) => m.title === 'Avg. Prove Time');
@@ -36,10 +35,8 @@ describe('metricsCreator', () => {
     expect(proveMetric?.value).toBe('2.00s');
     expect(verifyMetric?.value).toBe('3.00s');
 
-    const proveCostMetric = metrics.find((m) => m.title === 'Prove Cost');
-    const verifyCostMetric = metrics.find((m) => m.title === 'Verify Cost');
-    expect(proveCostMetric?.value).toBe('5.00 ETH');
-    expect(verifyCostMetric?.value).toBe('6.00 ETH');
+    const proveCostMetric = metrics.find((m) => m.title === 'L1 Prove Cost');
+    expect(proveCostMetric?.value).toBe('11.0 ETH');
 
     const profitMetric = metrics.find((m) => m.title === 'Profit');
     expect(profitMetric?.value).toBe('39.0 ETH');
@@ -73,7 +70,6 @@ describe('metricsCreator', () => {
       priorityFee: null,
       baseFee: null,
       proveCost: null,
-      verifyCost: null,
       l1DataCost: null,
       profit: null,
       l2Block: null,

--- a/dashboard/tests/profitRankingTable.test.ts
+++ b/dashboard/tests/profitRankingTable.test.ts
@@ -162,9 +162,8 @@ describe('ProfitRankingTable', () => {
         cloudCost: 0,
         proverCost: 0,
         proveCost: 1,
-        verifyCost: 2,
       }),
     );
-    expect(html.includes('title="$53.00"')).toBe(true);
+    expect(html.includes('title="$51.00"')).toBe(true);
   });
 });

--- a/dashboard/tests/profitabilityChart.test.ts
+++ b/dashboard/tests/profitabilityChart.test.ts
@@ -22,7 +22,6 @@ describe('ProfitabilityChart', () => {
         cloudCost: 1000,
         proverCost: 1000,
         proveCost: 0,
-        verifyCost: 0,
       })
     );
 
@@ -39,7 +38,6 @@ describe('ProfitabilityChart', () => {
         cloudCost: 1000,
         proverCost: 1000,
         proveCost: 5,
-        verifyCost: 2,
       })
     );
 

--- a/dashboard/utils/metricsCreator.ts
+++ b/dashboard/utils/metricsCreator.ts
@@ -27,7 +27,6 @@ export interface MetricInputData {
   l1DataCost?: number | null;
   profit?: number | null;
   proveCost?: number | null;
-  verifyCost?: number | null;
 }
 
 export const createMetrics = (data: MetricInputData): MetricData[] => [
@@ -135,13 +134,8 @@ export const createMetrics = (data: MetricInputData): MetricData[] => [
     group: 'Network Economics',
   },
   {
-    title: 'Prove Cost',
+    title: 'L1 Prove Cost',
     value: data.proveCost != null ? formatEth(data.proveCost) : 'N/A',
-    group: 'Network Economics',
-  },
-  {
-    title: 'Verify Cost',
-    value: data.verifyCost != null ? formatEth(data.verifyCost) : 'N/A',
     group: 'Network Economics',
   },
   {


### PR DESCRIPTION
## Summary
- combine Prove Cost and Verify Cost metrics into a single **L1 Prove Cost** metric
- pass the new cost to dashboard charts/tables
- adjust tests to match

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685d18919db48328b2c999d2559dd48d