### PR TITLE
Improve profit ranking accuracy

### DIFF
--- a/crates/api-types/src/lib.rs
+++ b/crates/api-types/src/lib.rs
@@ -361,6 +361,22 @@ pub struct BlockProfitsResponse {
     pub blocks: Vec<BlockProfitItem>,
 }
 
+/// Aggregated cost attributed to a proposer.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ProposerCostItem {
+    /// Proposer address.
+    pub address: String,
+    /// Total cost in wei.
+    pub cost: u128,
+}
+
+/// Aggregated cost results grouped by proposer.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ProposerCostsResponse {
+    /// Cost entries for each proposer.
+    pub proposers: Vec<ProposerCostItem>,
+}
+
 /// Aggregated L2 fees for a sequencer.
 #[derive(Debug, Serialize, ToSchema)]
 pub struct SequencerFeeRow {

--- a/crates/api/src/routes/mod.rs
+++ b/crates/api/src/routes/mod.rs
@@ -50,6 +50,8 @@ pub fn router(state: ApiState) -> Router {
         .route("/batch-fee-components/aggregated", get(batch_fee_components_aggregated))
         .route("/dashboard-data", get(dashboard_data))
         .route("/l1-data-cost", get(l1_data_cost))
+        .route("/prove-costs", get(prove_costs))
+        .route("/verify-costs", get(verify_costs))
         .route("/prove-cost", get(prove_cost))
         .route("/verify-cost", get(verify_cost))
         .route("/block-profits", get(block_profits))

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -887,6 +887,11 @@ export interface VerifyCostItem {
   cost: number;
 }
 
+export interface SequencerCostItem {
+  address: string;
+  cost: number;
+}
+
 export const fetchL1DataCost = async (
   range: TimeRange,
   limit = 50,
@@ -969,6 +974,30 @@ export const fetchVerifyCost = async (
     data: res.data
       ? res.data.batches.map((b) => ({ batch: b.batch_id, cost: b.cost }))
       : null,
+    badRequest: res.badRequest,
+    error: res.error,
+  };
+};
+
+export const fetchProveCostsByProposer = async (
+  range: TimeRange,
+): Promise<RequestResult<SequencerCostItem[]>> => {
+  const url = `${API_BASE}/prove-costs?${timeRangeToQuery(range)}`;
+  const res = await fetchJson<{ proposers: SequencerCostItem[] }>(url);
+  return {
+    data: res.data?.proposers ?? null,
+    badRequest: res.badRequest,
+    error: res.error,
+  };
+};
+
+export const fetchVerifyCostsByProposer = async (
+  range: TimeRange,
+): Promise<RequestResult<SequencerCostItem[]>> => {
+  const url = `${API_BASE}/verify-costs?${timeRangeToQuery(range)}`;
+  const res = await fetchJson<{ proposers: SequencerCostItem[] }>(url);
+  return {
+    data: res.data?.proposers ?? null,
     badRequest: res.badRequest,
     error: res.error,
   };

--- a/dashboard/tests/profitRankingTable.test.ts
+++ b/dashboard/tests/profitRankingTable.test.ts
@@ -23,6 +23,8 @@ describe('ProfitRankingTable', () => {
           ],
         } as RequestResult<SequencerDistributionDataItem[]>,
       } as unknown as ReturnType<typeof swr.default>)
+      .mockReturnValueOnce({ data: new Map() } as unknown as ReturnType<typeof swr.default>)
+      .mockReturnValueOnce({ data: new Map() } as unknown as ReturnType<typeof swr.default>)
       .mockReturnValueOnce({
         data: {
           data: {
@@ -84,6 +86,16 @@ describe('ProfitRankingTable', () => {
       badRequest: false,
       error: null,
     } as RequestResult<L2FeesResponse>);
+    vi.spyOn(api, 'fetchProveCostsByProposer').mockResolvedValue({
+      data: [],
+      badRequest: false,
+      error: null,
+    } as RequestResult<api.SequencerCostItem[]>);
+    vi.spyOn(api, 'fetchVerifyCostsByProposer').mockResolvedValue({
+      data: [],
+      badRequest: false,
+      error: null,
+    } as RequestResult<api.SequencerCostItem[]>);
     vi.spyOn(priceService, 'useEthPrice').mockReturnValue({
       data: 1000,
     } as unknown as ReturnType<typeof priceService.useEthPrice>);
@@ -115,6 +127,12 @@ describe('ProfitRankingTable', () => {
         data: {
           data: [{ name: 'SeqA', address: '0xseqA', value: 1, tps: null }],
         } as RequestResult<SequencerDistributionDataItem[]>,
+      } as unknown as ReturnType<typeof swr.default>)
+      .mockReturnValueOnce({
+        data: new Map([['0xseqa', 1e16]]),
+      } as unknown as ReturnType<typeof swr.default>)
+      .mockReturnValueOnce({
+        data: new Map([['0xseqa', 2e16]]),
       } as unknown as ReturnType<typeof swr.default>)
       .mockReturnValueOnce({
         data: {
@@ -159,6 +177,16 @@ describe('ProfitRankingTable', () => {
       badRequest: false,
       error: null,
     } as RequestResult<L2FeesResponse>);
+    vi.spyOn(api, 'fetchProveCostsByProposer').mockResolvedValue({
+      data: [{ address: '0xseqA', cost: 1e16 }],
+      badRequest: false,
+      error: null,
+    } as RequestResult<api.SequencerCostItem[]>);
+    vi.spyOn(api, 'fetchVerifyCostsByProposer').mockResolvedValue({
+      data: [{ address: '0xseqA', cost: 2e16 }],
+      badRequest: false,
+      error: null,
+    } as RequestResult<api.SequencerCostItem[]>);
     vi.spyOn(priceService, 'useEthPrice').mockReturnValue({
       data: 100,
     } as unknown as ReturnType<typeof priceService.useEthPrice>);


### PR DESCRIPTION
## Summary
- expose aggregated prover and verifier cost APIs
- support prover and verifier cost lookups in dashboard services
- account for per-sequencer prove/verify costs in the profit ranking table
- test profit ranking with new cost inputs

## Testing
- `just lint`
- `just lint-dashboard`
- `just test`
- `just check-dashboard`
- `just test-dashboard`
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685d25cb060083289e06e5a0373d8033