### PR TITLE
Split prove cost node

### DIFF
--- a/dashboard/components/views/DashboardView.tsx
+++ b/dashboard/components/views/DashboardView.tsx
@@ -96,10 +96,6 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
     const eth = parseEthValue(findMetricValue(metricsData.metrics, 'Verify Cost'));
     return eth * ethPrice;
   }, [metricsData.metrics, ethPrice]);
-  const l1ProveCostUsd = React.useMemo(
-    () => proveCostUsd + verifyCostUsd,
-    [proveCostUsd, verifyCostUsd],
-  );
 
   const visibleMetrics = React.useMemo(
     () =>
@@ -321,7 +317,8 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
               timeRange={timeRange}
               cloudCost={cloudCost}
               proverCost={proverCost}
-              l1ProveCost={l1ProveCostUsd}
+              l1ProveCost={proveCostUsd}
+              l1VerifyCost={verifyCostUsd}
               address={selectedSequencer || undefined}
             />
             <ProfitCalculator


### PR DESCRIPTION
## Summary
- expand FeeFlowChart props for separate L1 costs
- insert L1 Prove/Verify Cost nodes in flow chart
- pass new prove/verify costs from DashboardView

## Testing
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_685d3bda854083288e80bbc3627cddcf