### PR TITLE
Add prove and verify cost to L2 fees endpoint

### DIFF
--- a/crates/api-types/src/lib.rs
+++ b/crates/api-types/src/lib.rs
@@ -186,6 +186,10 @@ pub struct L2FeesResponse {
     pub base_fee: Option<u128>,
     /// Total L1 data posting cost for the range.
     pub l1_data_cost: Option<u128>,
+    /// Total proving cost for the range.
+    pub prove_cost: Option<u128>,
+    /// Total verifying cost for the range.
+    pub verify_cost: Option<u128>,
     /// Fee breakdown for each sequencer.
     pub sequencers: Vec<SequencerFeeRow>,
 }

--- a/crates/api/src/routes/aggregated.rs
+++ b/crates/api/src/routes/aggregated.rs
@@ -235,10 +235,12 @@ pub async fn l2_fees(
         None
     };
 
-    let (priority_fee, base_fee, l1_data_cost, rows) = tokio::try_join!(
+    let (priority_fee, base_fee, l1_data_cost, prove_cost, verify_cost, rows) = tokio::try_join!(
         state.client.get_l2_priority_fee(address, time_range),
         state.client.get_l2_base_fee(address, time_range),
         state.client.get_l1_total_data_cost(address, time_range),
+        state.client.get_total_prove_cost(address, time_range),
+        state.client.get_total_verify_cost(address, time_range),
         state.client.get_l2_fees_by_sequencer(time_range)
     )
     .map_err(|e| {
@@ -262,7 +264,14 @@ pub async fn l2_fees(
         .collect();
 
     tracing::info!(count = sequencers.len(), "Returning L2 fees and breakdown");
-    Ok(Json(L2FeesResponse { priority_fee, base_fee, l1_data_cost, sequencers }))
+    Ok(Json(L2FeesResponse {
+        priority_fee,
+        base_fee,
+        l1_data_cost,
+        prove_cost,
+        verify_cost,
+        sequencers,
+    }))
 }
 
 #[utoipa::path(
@@ -328,7 +337,14 @@ pub async fn batch_fees(
         .collect();
 
     tracing::info!(count = sequencers.len(), "Returning batch fees and breakdown");
-    Ok(Json(L2FeesResponse { priority_fee, base_fee, l1_data_cost, sequencers }))
+    Ok(Json(L2FeesResponse {
+        priority_fee,
+        base_fee,
+        l1_data_cost,
+        prove_cost: None,
+        verify_cost: None,
+        sequencers,
+    }))
 }
 
 #[utoipa::path(

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -776,6 +776,8 @@ export interface L2FeesResponse {
   priority_fee: number | null;
   base_fee: number | null;
   l1_data_cost: number | null;
+  prove_cost: number | null;
+  verify_cost: number | null;
   sequencers: SequencerFee[];
 }
 

--- a/dashboard/tests/app.integration.test.ts
+++ b/dashboard/tests/app.integration.test.ts
@@ -140,12 +140,16 @@ const responses: Record<string, Record<string, unknown>> = {
     priority_fee: 600,
     base_fee: 400,
     l1_data_cost: null,
+    prove_cost: 5,
+    verify_cost: 6,
     sequencers: [],
   },
   [`/v1/l2-fees?${q15m}`]: {
     priority_fee: 600,
     base_fee: 400,
     l1_data_cost: null,
+    prove_cost: 5,
+    verify_cost: 6,
     sequencers: [],
   },
   [`/v1/sequencer-distribution?${q1h}`]: {
@@ -160,6 +164,8 @@ const responses: Record<string, Record<string, unknown>> = {
     priority_fee: 1200,
     base_fee: 800,
     l1_data_cost: null,
+    prove_cost: 10,
+    verify_cost: 12,
     sequencers: [],
   },
 };

--- a/dashboard/tests/dataFetcher.test.ts
+++ b/dashboard/tests/dataFetcher.test.ts
@@ -90,6 +90,8 @@ describe('dataFetcher', () => {
         priority_fee: 1,
         base_fee: 2,
         l1_data_cost: 4,
+        prove_cost: 5,
+        verify_cost: 6,
         sequencers: [],
       }),
       fetchL2HeadBlock: ok(2),
@@ -97,7 +99,7 @@ describe('dataFetcher', () => {
       fetchSequencerDistribution: ok([
         { name: 'foo', address: '0xfoo', value: 1, tps: null },
       ]),
-      fetchDashboardData: ok({ prove_cost: 5, verify_cost: 6 }),
+      fetchDashboardData: ok({}),
     });
 
     const res = await fetchEconomicsData('1h', null);
@@ -118,6 +120,8 @@ describe('dataFetcher', () => {
         priority_fee: null,
         base_fee: null,
         l1_data_cost: null,
+        prove_cost: null,
+        verify_cost: null,
         sequencers: [],
       }),
       fetchL2HeadBlock: ok(null),

--- a/dashboard/tests/profitRankingTable.test.ts
+++ b/dashboard/tests/profitRankingTable.test.ts
@@ -31,6 +31,8 @@ describe('ProfitRankingTable', () => {
             priority_fee: 3e18,
             base_fee: 1.5e18,
             l1_data_cost: 0,
+            prove_cost: 0,
+            verify_cost: 0,
             sequencers: [
               {
                 address: '0xseqA',
@@ -68,6 +70,8 @@ describe('ProfitRankingTable', () => {
         priority_fee: 3e18,
         base_fee: 1.5e18,
         l1_data_cost: 0,
+        prove_cost: 0,
+        verify_cost: 0,
         sequencers: [
           {
             address: '0xseqA',
@@ -140,6 +144,8 @@ describe('ProfitRankingTable', () => {
             priority_fee: 1e18,
             base_fee: 0,
             l1_data_cost: 5e17,
+            prove_cost: 0,
+            verify_cost: 0,
             sequencers: [
               {
                 address: '0xseqA',
@@ -165,6 +171,8 @@ describe('ProfitRankingTable', () => {
         priority_fee: 1e18,
         base_fee: 0,
         l1_data_cost: 5e17,
+        prove_cost: 0,
+        verify_cost: 0,
         sequencers: [
           {
             address: '0xseqA',

--- a/dashboard/utils/dataFetcher.ts
+++ b/dashboard/utils/dataFetcher.ts
@@ -147,8 +147,10 @@ export const fetchEconomicsData = async (
     priorityFee: l2FeesRes.data?.priority_fee ?? null,
     baseFee: l2FeesRes.data?.base_fee ?? null,
     l1DataCost: l2FeesRes.data?.l1_data_cost ?? null,
-    proveCost: dashboardRes.data?.prove_cost ?? null,
-    verifyCost: dashboardRes.data?.verify_cost ?? null,
+    proveCost:
+      l2FeesRes.data?.prove_cost ?? dashboardRes.data?.prove_cost ?? null,
+    verifyCost:
+      l2FeesRes.data?.verify_cost ?? dashboardRes.data?.verify_cost ?? null,
     l2Block: l2BlockRes.data,
     l1Block: l1BlockRes.data,
     sequencerDist: sequencerDistRes.data || [],

--- a/docs/api.md
+++ b/docs/api.md
@@ -27,7 +27,7 @@ All time range parameters are in milliseconds. Time range parameters cannot be u
 
 ### `/l2-fees`
 
-Returns total priority fee, base fee and optional L1 data cost for the selected address (or all sequencers). The response also includes a `sequencers` array with the fee breakdown for each sequencer.
+Returns total priority fee, base fee, proving cost, verifying cost and optional L1 data cost for the selected address (or all sequencers). The response also includes a `sequencers` array with the fee breakdown for each sequencer.
 
 ### `/prove-cost`
 


### PR DESCRIPTION
## Summary
- extend `L2FeesResponse` with prove/verify cost fields
- expose these values in `/l2-fees` API
- document new response fields
- use new fields in dashboard data fetcher
- adjust TypeScript types and tests

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685d3e990cfc8328a1bed7d1e3425c81