### PR TITLE
Sync profit calculations

### DIFF
--- a/dashboard/components/views/DashboardView.tsx
+++ b/dashboard/components/views/DashboardView.tsx
@@ -322,6 +322,7 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
               cloudCost={cloudCost}
               proverCost={proverCost}
               l1ProveCost={l1ProveCostUsd}
+              l1VerifyCost={verifyCostUsd}
               address={selectedSequencer || undefined}
             />
             <ProfitCalculator


### PR DESCRIPTION
## Summary
- update FeeFlowChart profit logic to include prove and verify costs
- show negative profit instead of clamping to zero
- add `l1VerifyCost` prop and display verify cost node in sankey
- pass verify cost into FeeFlowChart from DashboardView

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685d3de0cda08328bb4a2059648457ef