### PR TITLE
Add amortized cost fields to batch fee components

### DIFF
--- a/crates/api-types/src/lib.rs
+++ b/crates/api-types/src/lib.rs
@@ -275,6 +275,10 @@ pub struct BatchFeeComponentRow {
     pub base_fee: u128,
     /// L1 data posting cost associated with the batch, if available
     pub l1_data_cost: Option<u128>,
+    /// Prover cost amortized across batches in the selected range
+    pub amortized_prove_cost: Option<u128>,
+    /// Verifier cost amortized across batches in the selected range
+    pub amortized_verify_cost: Option<u128>,
 }
 
 /// Fee components for each batch

--- a/crates/api/src/routes/aggregated.rs
+++ b/crates/api/src/routes/aggregated.rs
@@ -551,6 +551,20 @@ pub async fn batch_fee_components(
         ErrorResponse::database_error()
     })?;
 
+    let prove_total =
+        state.client.get_total_prove_cost(address, time_range).await.map_err(|e| {
+            tracing::error!(error = %e, "Failed to get prove cost");
+            ErrorResponse::database_error()
+        })?;
+    let verify_total =
+        state.client.get_total_verify_cost(address, time_range).await.map_err(|e| {
+            tracing::error!(error = %e, "Failed to get verify cost");
+            ErrorResponse::database_error()
+        })?;
+    let count = rows.len() as u128;
+    let amortized_prove = prove_total.and_then(|c| (count > 0).then_some(c / count));
+    let amortized_verify = verify_total.and_then(|c| (count > 0).then_some(c / count));
+
     let batches: Vec<BatchFeeComponentRow> = rows
         .into_iter()
         .map(|r| BatchFeeComponentRow {
@@ -560,6 +574,8 @@ pub async fn batch_fee_components(
             priority_fee: r.priority_fee,
             base_fee: r.base_fee,
             l1_data_cost: r.l1_data_cost,
+            amortized_prove_cost: amortized_prove,
+            amortized_verify_cost: amortized_verify,
         })
         .collect();
 
@@ -611,6 +627,20 @@ pub async fn batch_fee_components_aggregated(
         ErrorResponse::database_error()
     })?;
 
+    let prove_total =
+        state.client.get_total_prove_cost(address, time_range).await.map_err(|e| {
+            tracing::error!(error = %e, "Failed to get prove cost");
+            ErrorResponse::database_error()
+        })?;
+    let verify_total =
+        state.client.get_total_verify_cost(address, time_range).await.map_err(|e| {
+            tracing::error!(error = %e, "Failed to get verify cost");
+            ErrorResponse::database_error()
+        })?;
+    let count = rows.len() as u128;
+    let amortized_prove = prove_total.and_then(|c| (count > 0).then_some(c / count));
+    let amortized_verify = verify_total.and_then(|c| (count > 0).then_some(c / count));
+
     let batches: Vec<BatchFeeComponentRow> = rows
         .into_iter()
         .map(|r| BatchFeeComponentRow {
@@ -620,6 +650,8 @@ pub async fn batch_fee_components_aggregated(
             priority_fee: r.priority_fee,
             base_fee: r.base_fee,
             l1_data_cost: r.l1_data_cost,
+            amortized_prove_cost: amortized_prove,
+            amortized_verify_cost: amortized_verify,
         })
         .collect();
 

--- a/crates/messages/src/models.rs
+++ b/crates/messages/src/models.rs
@@ -358,6 +358,10 @@ pub struct BatchFeeComponentRow {
     pub base_fee: u128,
     /// L1 data posting cost associated with the batch, if available
     pub l1_data_cost: Option<u128>,
+    /// Prover cost amortized across batches in the selected range
+    pub amortized_prove_cost: Option<u128>,
+    /// Verifier cost amortized across batches in the selected range
+    pub amortized_verify_cost: Option<u128>,
 }
 
 /// Row representing the transactions per second for an L2 block

--- a/dashboard/components/BlockProfitTables.tsx
+++ b/dashboard/components/BlockProfitTables.tsx
@@ -10,8 +10,6 @@ interface BlockProfitTablesProps {
   timeRange: TimeRange;
   cloudCost: number;
   proverCost: number;
-  proveCost?: number;
-  verifyCost?: number;
   address?: string;
 }
 
@@ -28,8 +26,6 @@ export const BlockProfitTables: React.FC<BlockProfitTablesProps> = ({
   timeRange,
   cloudCost,
   proverCost,
-  proveCost = 0,
-  verifyCost = 0,
   address,
 }) => {
   const { data: ethPrice = 0 } = useEthPrice();
@@ -48,16 +44,17 @@ export const BlockProfitTables: React.FC<BlockProfitTablesProps> = ({
     : 0;
 
   // Prove and verify costs are per batch and should be attributed to each batch
-  const proveVerifyCostPerBatchUsd = proveCost + verifyCost;
-  const totalCostPerBatchUsd = operationalCostPerBatchUsd + proveVerifyCostPerBatchUsd;
+  const totalCostPerBatchUsd = operationalCostPerBatchUsd;
   const costPerBatchEth = ethPrice ? totalCostPerBatchUsd / ethPrice : 0;
 
   const profits = batchData.map((b) => {
     // Calculate revenue in ETH (priority + base - L1 data cost)
     const revenueEth = (b.priority + b.base - (b.l1Cost ?? 0)) / 1e18;
+    const proveEth = (b.amortizedProveCost ?? 0) / 1e18;
+    const verifyEth = (b.amortizedVerifyCost ?? 0) / 1e18;
 
     // Calculate profit as revenue minus all costs
-    const profitEth = revenueEth - costPerBatchEth;
+    const profitEth = revenueEth - (costPerBatchEth + proveEth + verifyEth);
     const profitWei = profitEth * 1e18;
 
     return {

--- a/dashboard/components/CostChart.tsx
+++ b/dashboard/components/CostChart.tsx
@@ -51,7 +51,9 @@ export const CostChart: React.FC<CostChartProps> = ({
 
   const data = feeData.map((b) => {
     const l1CostEth = (b.l1Cost ?? 0) / 1e18;
-    const costEth = baseCostPerBatchEth + l1CostEth;
+    const proveEth = (b.amortizedProveCost ?? 0) / 1e18;
+    const verifyEth = (b.amortizedVerifyCost ?? 0) / 1e18;
+    const costEth = baseCostPerBatchEth + proveEth + verifyEth + l1CostEth;
     const costUsd = costEth * ethPrice;
     return { batch: b.batch, costEth, costUsd };
   });

--- a/dashboard/components/EconomicsChart.tsx
+++ b/dashboard/components/EconomicsChart.tsx
@@ -19,8 +19,6 @@ interface EconomicsChartProps {
   timeRange: TimeRange;
   cloudCost: number;
   proverCost: number;
-  proveCost?: number;
-  verifyCost?: number;
   address?: string;
 }
 
@@ -28,8 +26,6 @@ export const EconomicsChart: React.FC<EconomicsChartProps> = ({
   timeRange,
   cloudCost,
   proverCost,
-  proveCost = 0,
-  verifyCost = 0,
   address,
 }) => {
   const { data: feeRes } = useSWR(
@@ -50,12 +46,14 @@ export const EconomicsChart: React.FC<EconomicsChartProps> = ({
   const hours = rangeToHours(timeRange);
   const HOURS_IN_MONTH = 30 * 24;
   const baseCostUsd = ((cloudCost + proverCost) / HOURS_IN_MONTH) * hours;
-  const baseCostPerBatchUsd = baseCostUsd / feeData.length + proveCost + verifyCost;
+  const baseCostPerBatchUsd = baseCostUsd / feeData.length;
   const baseCostPerBatchEth = ethPrice ? baseCostPerBatchUsd / ethPrice : 0;
 
   const data = feeData.map((b) => {
     const incomeEth = (b.priority + b.base) / 1e18;
-    const costEth = baseCostPerBatchEth + (b.l1Cost ?? 0) / 1e18;
+    const proveEth = (b.amortizedProveCost ?? 0) / 1e18;
+    const verifyEth = (b.amortizedVerifyCost ?? 0) / 1e18;
+    const costEth = baseCostPerBatchEth + proveEth + verifyEth + (b.l1Cost ?? 0) / 1e18;
     const profitEth = incomeEth - costEth;
     const incomeUsd = incomeEth * ethPrice;
     const costUsd = costEth * ethPrice;

--- a/dashboard/components/ProfitabilityChart.tsx
+++ b/dashboard/components/ProfitabilityChart.tsx
@@ -19,8 +19,6 @@ interface ProfitabilityChartProps {
   timeRange: TimeRange;
   cloudCost: number;
   proverCost: number;
-  proveCost?: number;
-  verifyCost?: number;
   address?: string;
 }
 
@@ -28,8 +26,6 @@ export const ProfitabilityChart: React.FC<ProfitabilityChartProps> = ({
   timeRange,
   cloudCost,
   proverCost,
-  proveCost = 0,
-  verifyCost = 0,
   address,
 }) => {
   const { data: feeRes } = useSWR(
@@ -50,14 +46,14 @@ export const ProfitabilityChart: React.FC<ProfitabilityChartProps> = ({
   const hours = rangeToHours(timeRange);
   const HOURS_IN_MONTH = 30 * 24;
   const costPerBatchUsd =
-    ((cloudCost + proverCost) / HOURS_IN_MONTH) * (hours / feeData.length) +
-    proveCost +
-    verifyCost;
+    ((cloudCost + proverCost) / HOURS_IN_MONTH) * (hours / feeData.length);
   const costPerBatchEth = ethPrice ? costPerBatchUsd / ethPrice : 0;
 
   const data = feeData.map((b) => {
     const revenueEth = (b.priority + b.base - (b.l1Cost ?? 0)) / 1e18;
-    const profitEth = revenueEth - costPerBatchEth;
+    const proveEth = (b.amortizedProveCost ?? 0) / 1e18;
+    const verifyEth = (b.amortizedVerifyCost ?? 0) / 1e18;
+    const profitEth = revenueEth - (costPerBatchEth + proveEth + verifyEth);
     const profitUsd = profitEth * ethPrice;
     return { batch: b.batch, profitEth, profitUsd };
   });

--- a/dashboard/components/views/DashboardView.tsx
+++ b/dashboard/components/views/DashboardView.tsx
@@ -332,14 +332,12 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
               onProverCostChange={setProverCost}
             />
             <div className="mt-6">
-              <EconomicsChart
-                timeRange={timeRange}
-                cloudCost={cloudCost}
-                proverCost={proverCost}
-                proveCost={proveCostUsd}
-                verifyCost={verifyCostUsd}
-                address={selectedSequencer || undefined}
-              />
+            <EconomicsChart
+              timeRange={timeRange}
+              cloudCost={cloudCost}
+              proverCost={proverCost}
+              address={selectedSequencer || undefined}
+            />
             </div>
             <ProfitRankingTable
               timeRange={timeRange}
@@ -352,8 +350,6 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
               timeRange={timeRange}
               cloudCost={cloudCost}
               proverCost={proverCost}
-              proveCost={proveCostUsd}
-              verifyCost={verifyCostUsd}
               address={selectedSequencer || undefined}
             />
           </>

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -808,6 +808,8 @@ export interface BatchFeeComponent {
   priority: number;
   base: number;
   l1Cost: number | null;
+  amortizedProveCost: number | null;
+  amortizedVerifyCost: number | null;
 }
 
 export const fetchFeeComponents = async (
@@ -854,6 +856,8 @@ export const fetchBatchFeeComponents = async (
       priority_fee: number;
       base_fee: number;
       l1_data_cost: number | null;
+      amortized_prove_cost: number | null;
+      amortized_verify_cost: number | null;
     }[];
   }>(url);
   return {
@@ -865,6 +869,8 @@ export const fetchBatchFeeComponents = async (
           priority: b.priority_fee,
           base: b.base_fee,
           l1Cost: b.l1_data_cost ?? null,
+          amortizedProveCost: b.amortized_prove_cost ?? null,
+          amortizedVerifyCost: b.amortized_verify_cost ?? null,
         }))
       : null,
     badRequest: res.badRequest,

--- a/dashboard/tests/blockProfitTables.test.ts
+++ b/dashboard/tests/blockProfitTables.test.ts
@@ -9,7 +9,16 @@ import * as priceService from '../services/priceService';
 import { BlockProfitTables } from '../components/BlockProfitTables';
 
 const feeData = [
-  { batch: 1, l1Block: 1, sequencer: 'SeqA', priority: 1e18, base: 1e18, l1Cost: 0 },
+  {
+    batch: 1,
+    l1Block: 1,
+    sequencer: 'SeqA',
+    priority: 1e18,
+    base: 1e18,
+    l1Cost: 0,
+    amortizedProveCost: 0,
+    amortizedVerifyCost: 0,
+  },
 ];
 
 describe('BlockProfitTables', () => {
@@ -26,8 +35,6 @@ describe('BlockProfitTables', () => {
         timeRange: '1h',
         cloudCost: 100,
         proverCost: 100,
-        proveCost: 5,
-        verifyCost: 2,
       }),
     );
 

--- a/dashboard/tests/costChart.test.ts
+++ b/dashboard/tests/costChart.test.ts
@@ -9,7 +9,14 @@ import { CostChart } from '../components/CostChart';
 import * as priceService from '../services/priceService';
 
 const feeData = [
-  { batch: 1, priority: 1, base: 1, l1Cost: 0 },
+  {
+    batch: 1,
+    priority: 1,
+    base: 1,
+    l1Cost: 0,
+    amortizedProveCost: 0,
+    amortizedVerifyCost: 0,
+  },
 ];
 
 describe('CostChart', () => {

--- a/dashboard/tests/economicsChart.test.ts
+++ b/dashboard/tests/economicsChart.test.ts
@@ -8,7 +8,16 @@ import type { BatchFeeComponent } from '../types';
 import * as priceService from '../services/priceService';
 import { EconomicsChart } from '../components/EconomicsChart';
 
-const feeData = [{ batch: 1, priority: 1, base: 1, l1Cost: 0 }];
+const feeData = [
+  {
+    batch: 1,
+    priority: 1,
+    base: 1,
+    l1Cost: 0,
+    amortizedProveCost: 0,
+    amortizedVerifyCost: 0,
+  },
+];
 
 describe('EconomicsChart', () => {
   it('renders with economics data', () => {
@@ -24,8 +33,6 @@ describe('EconomicsChart', () => {
         timeRange: '1h',
         cloudCost: 100,
         proverCost: 100,
-        proveCost: 5,
-        verifyCost: 2,
       }),
     );
 

--- a/dashboard/tests/incomeChart.test.ts
+++ b/dashboard/tests/incomeChart.test.ts
@@ -9,7 +9,14 @@ import * as priceService from '../services/priceService';
 import { IncomeChart } from '../components/IncomeChart';
 
 const feeData = [
-  { batch: 1, priority: 1, base: 1, l1Cost: 0 },
+  {
+    batch: 1,
+    priority: 1,
+    base: 1,
+    l1Cost: 0,
+    amortizedProveCost: 0,
+    amortizedVerifyCost: 0,
+  },
 ];
 
 describe('IncomeChart', () => {

--- a/dashboard/tests/profitabilityChart.test.ts
+++ b/dashboard/tests/profitabilityChart.test.ts
@@ -10,7 +10,14 @@ import { ProfitabilityChart } from '../components/ProfitabilityChart';
 
 // Helper data with negative profit
 const feeData = [
-  { batch: 1, priority: 0, base: 0, l1Cost: 0 },
+  {
+    batch: 1,
+    priority: 0,
+    base: 0,
+    l1Cost: 0,
+    amortizedProveCost: 0,
+    amortizedVerifyCost: 0,
+  },
 ];
 
 describe('ProfitabilityChart', () => {
@@ -27,8 +34,6 @@ describe('ProfitabilityChart', () => {
         timeRange: '1h',
         cloudCost: 1000,
         proverCost: 1000,
-        proveCost: 0,
-        verifyCost: 0,
       })
     );
 
@@ -48,8 +53,6 @@ describe('ProfitabilityChart', () => {
         timeRange: '1h',
         cloudCost: 1000,
         proverCost: 1000,
-        proveCost: 5,
-        verifyCost: 2,
       })
     );
 

--- a/dashboard/types.ts
+++ b/dashboard/types.ts
@@ -65,6 +65,8 @@ export interface BatchFeeComponent {
   priority: number;
   base: number;
   l1Cost: number | null;
+  amortizedProveCost: number | null;
+  amortizedVerifyCost: number | null;
 }
 
 export interface BlockProfit {

--- a/tests/api_integration.rs
+++ b/tests/api_integration.rs
@@ -419,7 +419,18 @@ async fn batch_fee_components_integration() {
     let body: serde_json::Value = resp.json().await.unwrap();
     assert_eq!(
         body,
-        serde_json::json!({ "batches": [ { "batch_id": 1, "priority_fee": 10, "base_fee": 20, "l1_data_cost": 5 } ] })
+        serde_json::json!({
+            "batches": [
+                {
+                    "batch_id": 1,
+                    "priority_fee": 10,
+                    "base_fee": 20,
+                    "l1_data_cost": 5,
+                    "amortized_prove_cost": null,
+                    "amortized_verify_cost": null
+                }
+            ]
+        })
     );
 
     server.abort();


### PR DESCRIPTION
## Summary
- include amortized prove and verify costs in BatchFeeComponentRow
- compute amortized costs in batch-fee-components endpoints
- aggregate amortized costs when bucketing
- expose new data in dashboard API client and types
- update charts and tables to use amortized costs
- adjust tests for new fields

## Testing
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_685d3f114f64832883e380f90be75b49