### PR TITLE
Use l2-fees for economics metrics

### DIFF
--- a/dashboard/tests/dataFetcher.test.ts
+++ b/dashboard/tests/dataFetcher.test.ts
@@ -99,7 +99,6 @@ describe('dataFetcher', () => {
       fetchSequencerDistribution: ok([
         { name: 'foo', address: '0xfoo', value: 1, tps: null },
       ]),
-      fetchDashboardData: ok({}),
     });
 
     const res = await fetchEconomicsData('1h', null);
@@ -111,7 +110,7 @@ describe('dataFetcher', () => {
     expect(res.proveCost).toBe(5);
     expect(res.verifyCost).toBe(6);
     expect(res.sequencerDist[0].name).toBe('foo');
-    expect(res.badRequestResults).toHaveLength(5);
+    expect(res.badRequestResults).toHaveLength(4);
   });
 
   it('defaults economics costs to null when missing', async () => {
@@ -127,7 +126,6 @@ describe('dataFetcher', () => {
       fetchL2HeadBlock: ok(null),
       fetchL1HeadBlock: ok(null),
       fetchSequencerDistribution: ok(null),
-      fetchDashboardData: ok({}),
     });
 
     const res = await fetchEconomicsData('1h', null);
@@ -136,7 +134,7 @@ describe('dataFetcher', () => {
     expect(res.l1DataCost).toBeNull();
     expect(res.proveCost).toBeNull();
     expect(res.verifyCost).toBeNull();
-    expect(res.badRequestResults).toHaveLength(5);
+    expect(res.badRequestResults).toHaveLength(4);
   });
 
   it('resets isTimeRangeChanging on fetch error', async () => {

--- a/dashboard/utils/dataFetcher.ts
+++ b/dashboard/utils/dataFetcher.ts
@@ -132,8 +132,7 @@ export const fetchEconomicsData = async (
   selectedSequencer: string | null,
 ): Promise<EconomicsData> => {
   const normalizedRange = normalizeTimeRange(timeRange);
-  const [dashboardRes, l2FeesRes, l2BlockRes, l1BlockRes, sequencerDistRes] = await Promise.all([
-    fetchDashboardData(normalizedRange),
+  const [l2FeesRes, l2BlockRes, l1BlockRes, sequencerDistRes] = await Promise.all([
     fetchL2Fees(
       normalizedRange,
       selectedSequencer ? getSequencerAddress(selectedSequencer) : undefined,
@@ -147,13 +146,11 @@ export const fetchEconomicsData = async (
     priorityFee: l2FeesRes.data?.priority_fee ?? null,
     baseFee: l2FeesRes.data?.base_fee ?? null,
     l1DataCost: l2FeesRes.data?.l1_data_cost ?? null,
-    proveCost:
-      l2FeesRes.data?.prove_cost ?? dashboardRes.data?.prove_cost ?? null,
-    verifyCost:
-      l2FeesRes.data?.verify_cost ?? dashboardRes.data?.verify_cost ?? null,
+    proveCost: l2FeesRes.data?.prove_cost ?? null,
+    verifyCost: l2FeesRes.data?.verify_cost ?? null,
     l2Block: l2BlockRes.data,
     l1Block: l1BlockRes.data,
     sequencerDist: sequencerDistRes.data || [],
-    badRequestResults: [dashboardRes, l2FeesRes, l2BlockRes, l1BlockRes, sequencerDistRes],
+    badRequestResults: [l2FeesRes, l2BlockRes, l1BlockRes, sequencerDistRes],
   };
 };


### PR DESCRIPTION
## Summary
- use the `/l2-fees` endpoint as the sole source for Network Economics metrics
- adjust tests for new API call set

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685d432d3a0c83288b3f1e5217feab5c