### PR TITLE
Change priority/base fee node color

### DIFF
--- a/dashboard/components/FeeFlowChart.tsx
+++ b/dashboard/components/FeeFlowChart.tsx
@@ -43,10 +43,7 @@ const createSankeyNode = (textColor: string) => {
       payload.name === 'Subsidy' ||
       (typeof payload.name === 'string' && payload.name.includes('Subsidy'));
     const isProfitNode = payload.name === 'Profit' || payload.profitNode;
-    const isPinkNode =
-      payload.name === 'Taiko DAO' ||
-      payload.name === 'Priority Fee' ||
-      payload.name === 'Base Fee';
+    const isPinkNode = payload.name === 'Taiko DAO';
     const hideLabel = payload.hideLabel;
     const addressLabel = payload.addressLabel;
 


### PR DESCRIPTION
## Summary
- show priority fee and base fee nodes using the same green color as income nodes

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685d88dda0b08328ac5089489133563a