### PR TITLE
Type Recharts tooltip payloads

### DIFF
--- a/dashboard/components/CostChart.tsx
+++ b/dashboard/components/CostChart.tsx
@@ -8,6 +8,7 @@ import {
   Tooltip,
   ResponsiveContainer,
 } from 'recharts';
+import type { Payload } from 'recharts/types/component/DefaultTooltipContent';
 import useSWR from 'swr';
 import { fetchBatchFeeComponents } from '../services/apiService';
 import { TimeRange, BatchFeeComponent } from '../types';
@@ -97,7 +98,7 @@ export const CostChart: React.FC<CostChartProps> = ({
         />
         <Tooltip
           labelFormatter={(v: number) => `Batch ${v}`}
-          formatter={(value: number, _name: string, { payload }: any) =>
+          formatter={(value: number, _name: string, { payload }: Payload<number, string>) =>
             [`${formatEth(value * 1e18)} ($${payload.costUsd.toFixed(2)})`, 'Cost']
           }
           contentStyle={{

--- a/dashboard/components/EconomicsChart.tsx
+++ b/dashboard/components/EconomicsChart.tsx
@@ -8,6 +8,7 @@ import {
   Tooltip,
   ResponsiveContainer,
 } from 'recharts';
+import type { Payload } from 'recharts/types/component/DefaultTooltipContent';
 import useSWR from 'swr';
 import { useEthPrice } from '../services/priceService';
 import { fetchBatchFeeComponents } from '../services/apiService';
@@ -108,7 +109,7 @@ export const EconomicsChart: React.FC<EconomicsChartProps> = ({
           />
           <Tooltip
             labelFormatter={(v: number) => `Batch ${v}`}
-            formatter={(value: number, name: string, { payload }: any) => {
+            formatter={(value: number, name: string, { payload }: Payload<number, string>) => {
               if (name === 'Income')
                 return [
                   `${formatEth(value * 1e18)} ($${payload.incomeUsd.toFixed(2)})`,

--- a/dashboard/components/FeeFlowChart.tsx
+++ b/dashboard/components/FeeFlowChart.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { ResponsiveContainer, Sankey, Tooltip } from 'recharts';
+import type { TooltipProps } from 'recharts';
 import { formatEth } from '../utils';
 import { TAIKO_PINK, lightTheme, darkTheme } from '../theme';
 import { useTheme } from '../contexts/ThemeContext';
@@ -546,10 +547,10 @@ export const FeeFlowChart: React.FC<FeeFlowChartProps> = ({
     return usd;
   };
 
-  const tooltipContent = ({ active, payload }: any) => {
+  const tooltipContent = ({ active, payload }: TooltipProps<number, string>) => {
     if (!active || !payload?.[0]) return null;
 
-    const { value, payload: itemData } = payload[0];
+    const { value = 0, payload: itemData } = payload![0];
 
     if (itemData.source != null && itemData.target != null) {
       const sourceNode = data.nodes[itemData.source] as any;

--- a/dashboard/components/IncomeChart.tsx
+++ b/dashboard/components/IncomeChart.tsx
@@ -8,6 +8,7 @@ import {
   Tooltip,
   ResponsiveContainer,
 } from 'recharts';
+import type { Payload } from 'recharts/types/component/DefaultTooltipContent';
 import useSWR from 'swr';
 import { useEthPrice } from '../services/priceService';
 import { formatEth } from '../utils';
@@ -83,7 +84,7 @@ export const IncomeChart: React.FC<IncomeChartProps> = ({
           />
           <Tooltip
             labelFormatter={(v: number) => `Batch ${v}`}
-            formatter={(value: number, _name: string, { payload }: any) =>
+            formatter={(value: number, _name: string, { payload }: Payload<number, string>) =>
               [`${formatEth(value * 1e18)} ($${payload.incomeUsd.toFixed(2)})`, 'Income']
             }
             contentStyle={{

--- a/dashboard/components/ProfitabilityChart.tsx
+++ b/dashboard/components/ProfitabilityChart.tsx
@@ -8,6 +8,7 @@ import {
   Tooltip,
   ResponsiveContainer,
 } from 'recharts';
+import type { Payload } from 'recharts/types/component/DefaultTooltipContent';
 import useSWR from 'swr';
 import { useEthPrice } from '../services/priceService';
 import { fetchBatchFeeComponents } from '../services/apiService';
@@ -101,7 +102,7 @@ export const ProfitabilityChart: React.FC<ProfitabilityChartProps> = ({
           />
           <Tooltip
             labelFormatter={(v: number) => `Batch ${v}`}
-            formatter={(value: number, _name: string, { payload }: any) =>
+            formatter={(value: number, _name: string, { payload }: Payload<number, string>) =>
               [`${formatEth(value * 1e18)} ($${payload.profitUsd.toFixed(2)})`, 'Profit']
             }
             contentStyle={{


### PR DESCRIPTION
## Summary
- add `Payload` and `TooltipProps` imports for Recharts charts
- type `Tooltip` formatter callbacks with `Payload`

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_b_685d8eaa874c8328853321680d7a457f