### PR TITLE
Remove /tps alias

### DIFF
--- a/crates/api/src/routes/mod.rs
+++ b/crates/api/src/routes/mod.rs
@@ -37,7 +37,6 @@ pub fn router(state: ApiState) -> Router {
         .route("/l2-gas-used", get(l2_gas_used))
         .route("/l2-gas-used/aggregated", get(l2_gas_used_aggregated))
         .route("/l2-tps", get(l2_tps))
-        .route("/tps", get(l2_tps))
         .route("/sequencer-distribution", get(sequencer_distribution))
         .route("/sequencer-blocks", get(sequencer_blocks))
         .route("/block-transactions", get(block_transactions))


### PR DESCRIPTION
## Summary
- remove `/tps` route since `/l2-tps` already serves the same handler

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685d9e24a8c48328b9d3caca99c27f20