### PR TITLE
Fix empty block profit tables

### DIFF
--- a/dashboard/components/BlockProfitTables.tsx
+++ b/dashboard/components/BlockProfitTables.tsx
@@ -39,6 +39,14 @@ export const BlockProfitTables: React.FC<BlockProfitTablesProps> = ({
   const HOURS_IN_MONTH = 30 * 24;
   const hours = rangeToHours(timeRange);
 
+  if (batchData.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-full text-gray-500">
+        No data available
+      </div>
+    );
+  }
+
   const operationalCostPerBatchUsd = batchCount > 0
     ? ((cloudCost + proverCost) / HOURS_IN_MONTH) * (hours / batchCount)
     : 0;


### PR DESCRIPTION
## Summary
- return a friendly message when batch profit tables have no data

## Testing
- `just ci` *(fails: `cargo` and `npm` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685da4c8c6e083288686775624389787