### PR TITLE
store L1 data cost per batch

### DIFF
--- a/crates/clickhouse/migrations/009_change_l1_data_costs_to_batch.sql
+++ b/crates/clickhouse/migrations/009_change_l1_data_costs_to_batch.sql
@@ -1,0 +1,5 @@
+ALTER TABLE ${DB}.l1_data_costs
+ADD COLUMN IF NOT EXISTS batch_id UInt64 AFTER l1_block_number;
+
+ALTER TABLE ${DB}.l1_data_costs
+DROP COLUMN IF EXISTS l2_block_number;

--- a/crates/clickhouse/src/models.rs
+++ b/crates/clickhouse/src/models.rs
@@ -271,13 +271,13 @@ pub struct L1DataCostRow {
     pub cost: u128,
 }
 
-/// Row used for inserting L1 data cost with mapping to an L2 block
+/// Row used for inserting L1 data cost for a batch
 #[derive(Debug, Row, Serialize, Deserialize, PartialEq, Eq)]
 pub struct L1DataCostInsertRow {
     /// L1 block number
     pub l1_block_number: u64,
-    /// L2 block number this cost corresponds to
-    pub l2_block_number: u64,
+    /// Batch ID this cost corresponds to
+    pub batch_id: u64,
     /// Total cost in wei for data posting transactions
     pub cost: u128,
 }

--- a/crates/clickhouse/src/schema.rs
+++ b/crates/clickhouse/src/schema.rs
@@ -136,10 +136,10 @@ pub const TABLE_SCHEMAS: &[TableSchema] = &[
     TableSchema {
         name: "l1_data_costs",
         columns: "l1_block_number UInt64,
-                 l2_block_number UInt64,
+                 batch_id UInt64,
                  cost UInt128,
                  inserted_at DateTime64(3) DEFAULT now64()",
-        order_by: "l1_block_number",
+        order_by: "l1_block_number, batch_id",
     },
     TableSchema {
         name: "prove_costs",

--- a/crates/clickhouse/src/writer.rs
+++ b/crates/clickhouse/src/writer.rs
@@ -334,11 +334,11 @@ impl ClickhouseWriter {
     pub async fn insert_l1_data_cost(
         &self,
         l1_block_number: u64,
-        l2_block_number: u64,
+        batch_id: u64,
         cost: u128,
     ) -> Result<()> {
         let client = self.base.clone();
-        let row = L1DataCostInsertRow { l1_block_number, l2_block_number, cost };
+        let row = L1DataCostInsertRow { l1_block_number, batch_id, cost };
         let mut insert = client.insert(&format!("{}.l1_data_costs", self.db_name))?;
         insert.write(&row).await?;
         insert.end().await?;
@@ -737,13 +737,10 @@ mod tests {
         let url = Url::parse(mock.url()).unwrap();
         let writer = ClickhouseWriter::new(url, "db".to_owned(), "user".into(), "pass".into());
 
-        writer.insert_l1_data_cost(10, 11, 42).await.unwrap();
+        writer.insert_l1_data_cost(10, 7, 42).await.unwrap();
 
         let rows: Vec<L1DataCostInsertRow> = ctl.collect().await;
-        assert_eq!(
-            rows,
-            vec![L1DataCostInsertRow { l1_block_number: 10, l2_block_number: 11, cost: 42 }]
-        );
+        assert_eq!(rows, vec![L1DataCostInsertRow { l1_block_number: 10, batch_id: 7, cost: 42 }]);
     }
 
     #[tokio::test]

--- a/crates/driver/src/lib.rs
+++ b/crates/driver/src/lib.rs
@@ -555,7 +555,7 @@ impl Driver {
                 let cost = primitives::l1_data_cost::cost_from_receipt(&receipt);
                 if let Err(e) = self
                     .clickhouse
-                    .insert_l1_data_cost(batch.info.proposedIn, self.last_proposed_l2_block, cost)
+                    .insert_l1_data_cost(batch.info.proposedIn, batch.meta.batchId, cost)
                     .await
                 {
                     tracing::error!(

--- a/crates/messages/src/models.rs
+++ b/crates/messages/src/models.rs
@@ -264,13 +264,13 @@ pub struct L1DataCostRow {
     pub cost: u128,
 }
 
-/// Row used for inserting L1 data cost with mapping to an L2 block
+/// Row used for inserting L1 data cost for a batch
 #[derive(Debug, Serialize, Deserialize)]
 pub struct L1DataCostInsertRow {
     /// L1 block number
     pub l1_block_number: u64,
-    /// L2 block number this cost corresponds to
-    pub l2_block_number: u64,
+    /// Batch ID this cost corresponds to
+    pub batch_id: u64,
     /// Total cost in wei for data posting transactions
     pub cost: u128,
 }


### PR DESCRIPTION
## Summary
- store L1 data cost per batch instead of per block
- adjust schema and migrations
- update driver and writer to insert by batch
- fix reader queries and tests to use batch-based cost

## Testing
- `just lint`
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685e2fa05d0c83289e8c1c9ff46f6e3a