### PR TITLE
Fix L2 reorg table pagination

### DIFF
--- a/dashboard/components/routes/TableRoute.tsx
+++ b/dashboard/components/routes/TableRoute.tsx
@@ -127,7 +127,11 @@ export const TableRoute: React.FC = () => {
 
         let res;
         let aggRes;
-        if (config.supportsPagination) {
+        if (tableType === 'reorgs') {
+          [res] = await Promise.all([
+            config.fetcher(range, PAGE_LIMIT, startingAfter, endingBefore),
+          ]);
+        } else if (config.supportsPagination) {
           const address = fetcherArgs.pop();
           if (config.aggregatedFetcher) {
             [res, aggRes] = await Promise.all([
@@ -151,10 +155,6 @@ export const TableRoute: React.FC = () => {
               ),
             ]);
           }
-        } else if (tableType === 'reorgs') {
-          [res] = await Promise.all([
-            config.fetcher(range, PAGE_LIMIT, startingAfter, endingBefore),
-          ]);
         } else {
           [res, aggRes] = await (config.aggregatedFetcher
             ? Promise.all([


### PR DESCRIPTION
## Summary
- fix argument order when fetching paginated reorg events

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685e5380ca7883288ad72e0e0110199e