### PR TITLE
Sort L2 reorgs by time descending

### DIFF
--- a/crates/clickhouse/src/reader.rs
+++ b/crates/clickhouse/src/reader.rs
@@ -561,7 +561,7 @@ impl ClickhouseReader {
     }
 
     /// Get L2 reorg events since the given cutoff with cursor-based pagination.
-    /// Results are returned in descending order by block number.
+    /// Results are returned in descending order by time recorded.
     pub async fn get_l2_reorgs_paginated(
         &self,
         since: DateTime<Utc>,
@@ -592,7 +592,7 @@ impl ClickhouseReader {
             query.push_str(&format!(" AND l2_block_number > {}", end));
         }
 
-        query.push_str(" ORDER BY l2_block_number DESC");
+        query.push_str(" ORDER BY inserted_at DESC");
         query.push_str(&format!(" LIMIT {}", limit));
 
         let rows = self.execute::<RawRow>(&query).await.context("fetching reorg events failed")?;

--- a/dashboard/config/tableConfig.ts
+++ b/dashboard/config/tableConfig.ts
@@ -87,7 +87,7 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
         depth: e.depth.toLocaleString(),
       })),
     urlKey: 'reorgs',
-    reverseOrder: true,
+    reverseOrder: false,
     supportsPagination: true,
   },
 

--- a/tests/pagination.rs
+++ b/tests/pagination.rs
@@ -54,7 +54,7 @@ async fn l2_reorgs_paginated_builds_query() {
     assert!(query.contains("l2_block_number < 100"));
     assert!(query.contains("l2_block_number > 50"));
     assert!(query.contains("LIMIT 5"));
-    assert!(query.contains("ORDER BY l2_block_number DESC"));
+    assert!(query.contains("ORDER BY inserted_at DESC"));
 }
 
 #[tokio::test]
@@ -105,14 +105,14 @@ async fn reorgs_endpoint_returns_items_with_pagination() {
     let expected = serde_json::json!({
         "events": [
             {
-                "l2_block_number": 9,
-                "depth": 1,
-                "inserted_at": Utc.timestamp_millis_opt(1000).single().unwrap().to_rfc3339()
-            },
-            {
                 "l2_block_number": 8,
                 "depth": 2,
                 "inserted_at": Utc.timestamp_millis_opt(2000).single().unwrap().to_rfc3339()
+            },
+            {
+                "l2_block_number": 9,
+                "depth": 1,
+                "inserted_at": Utc.timestamp_millis_opt(1000).single().unwrap().to_rfc3339()
             }
         ]
     });


### PR DESCRIPTION
## Summary
- order reorg events by `inserted_at` in the Clickhouse reader
- update pagination tests for new ordering
- show reorg table results in descending order by removing reversal

## Testing
- `just lint`
- `just lint-dashboard`
- `just test`
- `just check-dashboard`
- `just test-dashboard`


------
https://chatgpt.com/codex/tasks/task_b_685e71392d5c8328b3d86fbeb2d8f746