### PR TITLE
Set default prover cost to 0

### DIFF
--- a/dashboard/components/views/DashboardView.tsx
+++ b/dashboard/components/views/DashboardView.tsx
@@ -87,7 +87,7 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
   const isEconomicsView = searchParams.get('view') === 'economics';
   // Default monthly costs in USD
   const [cloudCost, setCloudCost] = useState(1000);
-  const [proverCost, setProverCost] = useState(1000);
+  const [proverCost, setProverCost] = useState(0);
 
   const { data: ethPrice = 0 } = useEthPrice();
   const metricsWithHardware = React.useMemo(() => {


### PR DESCRIPTION
## Summary
- start the dashboard with a zero prover cost

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685e983bb38c8328a6a6801c3bdb6559