### PR TITLE
Fix economics view back navigation

### DIFF
--- a/dashboard/hooks/useTableActions.ts
+++ b/dashboard/hooks/useTableActions.ts
@@ -1,5 +1,5 @@
 import React, { useState, useCallback } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useSearchParams } from 'react-router-dom';
 import { TimeRange } from '../types';
 import { TABLE_CONFIGS } from '../config/tableConfig';
 import { getSequencerAddress } from '../sequencerConfig';
@@ -57,6 +57,7 @@ export const useTableActions = (
   const [seqDistTxPage, setSeqDistTxPage] = useState<number>(0);
   const { navigateToTable } = useRouterNavigation();
   const location = useLocation();
+  const [searchParams] = useSearchParams();
 
   const setTableUrl = useCallback(
     (
@@ -69,12 +70,16 @@ export const useTableActions = (
           if (v !== undefined) cleanParams[k] = v;
         });
 
+        if (searchParams.get('view') === 'economics') {
+          cleanParams.view = 'economics';
+        }
+
         navigateToTable(name, cleanParams, timeRange);
       } catch (err) {
         console.error('Failed to set table URL:', err);
       }
     },
-    [navigateToTable, timeRange],
+    [navigateToTable, timeRange, searchParams],
   );
 
   const openTable = useCallback(

--- a/dashboard/tests/openGenericTable.test.ts
+++ b/dashboard/tests/openGenericTable.test.ts
@@ -18,6 +18,7 @@ vi.mock('react-router-dom', async () => {
     ...actual,
     useLocation: () => ({ pathname: '/' }),
     useNavigate: () => navSpy,
+    useSearchParams: () => [new URLSearchParams(), vi.fn()],
   };
 });
 


### PR DESCRIPTION
## Summary
- keep `view=economics` when navigating to tables
- mock `useSearchParams` in table action tests

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685e999019a48328b897aa43f88a7049