### PR TITLE
Add Tx Count chart to TPS table

### DIFF
--- a/dashboard/config/tableConfig.ts
+++ b/dashboard/config/tableConfig.ts
@@ -404,6 +404,7 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
     title: 'Transactions Per Second',
     description: 'Transactions per second for each L2 block.',
     fetcher: fetchL2Tps,
+    aggregatedFetcher: fetchBlockTransactionsAggregated,
     columns: [
       { key: 'block', label: 'Block Number' },
       { key: 'tps', label: 'TPS' },
@@ -413,6 +414,17 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
         block: blockLink(d.block),
         tps: d.tps.toFixed(2),
       })),
+    chart: (data) => {
+      const BlockTxChart = React.lazy(() =>
+        import('../components/BlockTxChart').then((m) => ({
+          default: m.BlockTxChart,
+        })),
+      );
+      return React.createElement(BlockTxChart, {
+        data,
+        lineColor: '#4E79A7',
+      });
+    },
     urlKey: 'l2-tps',
     supportsPagination: true,
   },


### PR DESCRIPTION
## Summary
- include aggregated block transaction data for TPS table
- show BlockTxChart on the Transactions Per Second table

## Testing
- `npm run check`
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68622293050483288dece5fddb01c5c4