### PR TITLE
Fix subsidy node display

### DIFF
--- a/dashboard/components/FeeFlowChart.tsx
+++ b/dashboard/components/FeeFlowChart.tsx
@@ -245,8 +245,11 @@ export const FeeFlowChart: React.FC<FeeFlowChartProps> = ({
     remaining -= actualProveCost;
     const actualVerifyCost = safeValue(Math.min(verifyUsd, remaining));
     remaining -= actualVerifyCost;
-    const subsidyUsd = safeValue(l1CostUsd - actualL1Cost);
-    const subsidyWei = safeValue(ethPrice ? (subsidyUsd / ethPrice) * WEI_TO_ETH : 0);
+    const deficitUsd = safeValue(Math.max(0, -profitUsd));
+    const subsidyUsd = safeValue(Math.max(l1CostUsd - actualL1Cost, deficitUsd));
+    const subsidyWei = safeValue(
+      ethPrice ? (subsidyUsd / ethPrice) * WEI_TO_ETH : 0,
+    );
     const actualHardwareCostWei = safeValue(
       ethPrice ? (actualHardwareCost / ethPrice) * WEI_TO_ETH : 0,
     );


### PR DESCRIPTION
## Summary
- ensure Sankey diagram displays subsidy when a sequencer has negative profit

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_685e980a220883288a32ae889f084df7