### PR TITLE
Fix hardware cost calculation for multiple sequencers

### DIFF
--- a/dashboard/components/FeeFlowChart.tsx
+++ b/dashboard/components/FeeFlowChart.tsx
@@ -207,8 +207,11 @@ export const FeeFlowChart: React.FC<FeeFlowChartProps> = ({
 
   // Scale operational costs to the selected time range
   const hours = rangeToHours(timeRange);
-  const hardwareCostPerSeq = safeValue(((cloudCost + proverCost) / MONTH_HOURS) * hours);
-  const totalHardwareCost = hardwareCostPerSeq;
+  const sequencerCount = Math.max(1, sequencerFees.length);
+  const hardwareCostPerSeq = safeValue(
+    ((cloudCost + proverCost) / MONTH_HOURS) * hours,
+  );
+  const totalHardwareCost = hardwareCostPerSeq * sequencerCount;
 
   const seqData = sequencerFees.map((f) => {
     const priorityWei = f.priority_fee ?? 0;

--- a/dashboard/components/views/DashboardView.tsx
+++ b/dashboard/components/views/DashboardView.tsx
@@ -94,7 +94,9 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
     if (!isEconomicsView) return metricsData.metrics;
     const HOURS_IN_MONTH = 30 * 24;
     const hours = rangeToHours(timeRange);
-    const costUsd = ((cloudCost + proverCost) / HOURS_IN_MONTH) * hours;
+    const sequencerCount = chartsData.sequencerDistribution.length || 1;
+    const costUsd =
+      ((cloudCost + proverCost) * sequencerCount) / HOURS_IN_MONTH * hours;
     const costWei = ethPrice > 0 ? (costUsd / ethPrice) * 1e18 : null;
     const hardwareMetric: MetricData = {
       title: 'Hardware Costs',


### PR DESCRIPTION
## Summary
- update network economics hardware cost to multiply by number of sequencers
- adjust fee flow chart to use sequencer count

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68623bad4c14832892b4bfb0e7226db9