### PR TITLE
Add sequencer info for reorg events

### DIFF
--- a/crates/api-types/src/lib.rs
+++ b/crates/api-types/src/lib.rs
@@ -9,8 +9,7 @@
 use clickhouse_lib::{
     BatchBlobCountRow, BatchPostingTimeRow, BatchProveTimeRow, BatchVerifyTimeRow,
     BlockFeeComponentRow, ForcedInclusionProcessedRow, L1BlockTimeRow, L1DataCostRow,
-    L2BlockTimeRow, L2GasUsedRow, L2ReorgRow, L2TpsRow, ProveCostRow, SlashingEventRow,
-    VerifyCostRow,
+    L2BlockTimeRow, L2GasUsedRow, L2TpsRow, ProveCostRow, SlashingEventRow, VerifyCostRow,
 };
 
 use axum::{Json, http::StatusCode, response::IntoResponse};
@@ -105,11 +104,26 @@ pub struct ForcedInclusionEventsResponse {
     pub events: Vec<ForcedInclusionProcessedRow>,
 }
 
+/// Single L2 reorg event with sequencer addresses.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct L2ReorgEvent {
+    /// Block number that became the new head.
+    pub l2_block_number: u64,
+    /// Number of blocks replaced by the reorg.
+    pub depth: u16,
+    /// Address of the sequencer that produced the replaced block.
+    pub old_sequencer: String,
+    /// Address of the sequencer that produced the new block.
+    pub new_sequencer: String,
+    /// Time the reorg was recorded.
+    pub inserted_at: DateTime<Utc>,
+}
+
 /// Detected L2 reorg events.
 #[derive(Debug, Serialize, ToSchema)]
 pub struct ReorgEventsResponse {
     /// Detected L2 reorg events.
-    pub events: Vec<L2ReorgRow>,
+    pub events: Vec<L2ReorgEvent>,
 }
 
 /// Gateways that submitted batches in the requested range.

--- a/crates/clickhouse/migrations/010_add_reorg_sequencers.sql
+++ b/crates/clickhouse/migrations/010_add_reorg_sequencers.sql
@@ -1,0 +1,7 @@
+-- Migration 010: add old_sequencer and new_sequencer columns to l2_reorgs
+
+ALTER TABLE ${DB}.l2_reorgs
+ADD COLUMN IF NOT EXISTS old_sequencer FixedString(20) AFTER depth;
+
+ALTER TABLE ${DB}.l2_reorgs
+ADD COLUMN IF NOT EXISTS new_sequencer FixedString(20) AFTER old_sequencer;

--- a/crates/clickhouse/src/models.rs
+++ b/crates/clickhouse/src/models.rs
@@ -135,6 +135,10 @@ pub struct L2ReorgInsertRow {
     pub l2_block_number: u64,
     /// Depth
     pub depth: u16,
+    /// Sequencer that produced the replaced block
+    pub old_sequencer: AddressBytes,
+    /// Sequencer that produced the new block
+    pub new_sequencer: AddressBytes,
 }
 
 /// L2 reorg row
@@ -144,6 +148,10 @@ pub struct L2ReorgRow {
     pub l2_block_number: u64,
     /// Depth
     pub depth: u16,
+    /// Sequencer that produced the replaced block
+    pub old_sequencer: AddressBytes,
+    /// Sequencer that produced the new block
+    pub new_sequencer: AddressBytes,
     /// Time the reorg was recorded.
     /// This is populated when reading from the database.
     pub inserted_at: Option<DateTime<Utc>>,

--- a/crates/clickhouse/src/reader.rs
+++ b/crates/clickhouse/src/reader.rs
@@ -537,11 +537,13 @@ impl ClickhouseReader {
         struct RawRow {
             l2_block_number: u64,
             depth: u16,
+            old_sequencer: AddressBytes,
+            new_sequencer: AddressBytes,
             ts: u64,
         }
 
         let query = format!(
-            "SELECT l2_block_number, depth, \
+            "SELECT l2_block_number, depth, old_sequencer, new_sequencer, \
                     toUInt64(toUnixTimestamp64Milli(inserted_at)) AS ts \
              FROM {}.l2_reorgs \
              WHERE inserted_at > toDateTime64({}, 3) \
@@ -557,6 +559,8 @@ impl ClickhouseReader {
                 Some(L2ReorgRow {
                     l2_block_number: r.l2_block_number,
                     depth: r.depth,
+                    old_sequencer: r.old_sequencer,
+                    new_sequencer: r.new_sequencer,
                     inserted_at: Some(ts),
                 })
             })
@@ -576,11 +580,13 @@ impl ClickhouseReader {
         struct RawRow {
             l2_block_number: u64,
             depth: u16,
+            old_sequencer: AddressBytes,
+            new_sequencer: AddressBytes,
             ts: u64,
         }
 
         let mut query = format!(
-            "SELECT l2_block_number, depth, \
+            "SELECT l2_block_number, depth, old_sequencer, new_sequencer, \
                     toUInt64(toUnixTimestamp64Milli(inserted_at)) AS ts \
              FROM {db}.l2_reorgs \
              WHERE inserted_at > toDateTime64({since}, 3)",
@@ -606,6 +612,8 @@ impl ClickhouseReader {
                 Some(L2ReorgRow {
                     l2_block_number: r.l2_block_number,
                     depth: r.depth,
+                    old_sequencer: r.old_sequencer,
+                    new_sequencer: r.new_sequencer,
                     inserted_at: Some(ts),
                 })
             })

--- a/crates/messages/src/models.rs
+++ b/crates/messages/src/models.rs
@@ -128,6 +128,10 @@ pub struct L2ReorgInsertRow {
     pub l2_block_number: u64,
     /// Depth
     pub depth: u16,
+    /// Sequencer that produced the replaced block
+    pub old_sequencer: AddressBytes,
+    /// Sequencer that produced the new block
+    pub new_sequencer: AddressBytes,
 }
 
 /// L2 reorg row
@@ -137,6 +141,10 @@ pub struct L2ReorgRow {
     pub l2_block_number: u64,
     /// Depth
     pub depth: u16,
+    /// Sequencer that produced the replaced block
+    pub old_sequencer: AddressBytes,
+    /// Sequencer that produced the new block
+    pub new_sequencer: AddressBytes,
     /// Time the reorg was recorded.
     /// This is populated when reading from the database.
     pub inserted_at: Option<DateTime<Utc>>,

--- a/dashboard/config/tableConfig.ts
+++ b/dashboard/config/tableConfig.ts
@@ -79,12 +79,16 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
       { key: 'timestamp', label: 'Time' },
       { key: 'l2_block_number', label: 'L2 Block Number' },
       { key: 'depth', label: 'Depth' },
+      { key: 'old_sequencer', label: 'Old Sequencer' },
+      { key: 'new_sequencer', label: 'New Sequencer' },
     ],
     mapData: (data) =>
       (data as L2ReorgEvent[]).map((e) => ({
         timestamp: formatDateTime(e.timestamp),
         l2_block_number: blockLink(e.l2_block_number),
         depth: e.depth.toLocaleString(),
+        old_sequencer: getSequencerName(e.old_sequencer),
+        new_sequencer: getSequencerName(e.new_sequencer),
       })),
     urlKey: 'reorgs',
     reverseOrder: false,

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -173,13 +173,21 @@ export const fetchL2ReorgEvents = async (
     url += `&ending_before=${endingBefore}`;
   }
   const res = await fetchJson<{
-    events: { l2_block_number: number; depth: number; inserted_at: string }[];
+    events: {
+      l2_block_number: number;
+      depth: number;
+      old_sequencer: string;
+      new_sequencer: string;
+      inserted_at: string;
+    }[];
   }>(url);
   return {
     data: res.data?.events
       ? res.data.events.map((e) => ({
           l2_block_number: e.l2_block_number,
           depth: e.depth,
+          old_sequencer: e.old_sequencer,
+          new_sequencer: e.new_sequencer,
           timestamp: Date.parse(e.inserted_at),
         }))
       : null,

--- a/dashboard/types.ts
+++ b/dashboard/types.ts
@@ -28,6 +28,8 @@ export interface MetricData {
 export interface L2ReorgEvent {
   l2_block_number: number;
   depth: number;
+  old_sequencer: string;
+  new_sequencer: string;
   timestamp: number;
 }
 


### PR DESCRIPTION
## Summary
- store old and new sequencer addresses for reorgs
- expose new sequencer fields in API and dashboard
- handle sequencer addresses in driver and ClickHouse models
- create migration for reorg sequencer columns

## Testing
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_68623dac2f2c83289c84dfa6575c7e07