### PR TITLE
Fix negative parsing

### DIFF
--- a/dashboard/tests/utils.test.ts
+++ b/dashboard/tests/utils.test.ts
@@ -146,6 +146,11 @@ describe('utils', () => {
     expect(parseEthValue('N/A')).toBe(0);
   });
 
+  it('parses negative ETH and Gwei values', () => {
+    expect(parseEthValue('-0.5 ETH')).toBe(-0.5);
+    expect(parseEthValue('-100 Gwei')).toBeCloseTo(-0.0000001);
+  });
+
   it('converts bytes to hex', () => {
     expect(bytesToHex([0, 1, 255])).toBe('0x0001ff');
   });

--- a/dashboard/utils.ts
+++ b/dashboard/utils.ts
@@ -114,7 +114,10 @@ export const formatEth = (wei: number): string => {
 };
 
 export const parseEthValue = (value: string): number => {
-  const amount = parseFloat(value.replace(/[^0-9.]/g, ''));
+  const sanitized = value
+    .replace(/[^0-9.-]/g, '')
+    .replace(/(?!^)-/g, '');
+  const amount = parseFloat(sanitized);
   if (!Number.isFinite(amount)) return 0;
   return /gwei/i.test(value) ? amount / 1e9 : amount;
 };


### PR DESCRIPTION
## Summary
- handle optional negative sign in `parseEthValue`
- test negative ETH/Gwei parsing

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68625b05076c8328baacd46e53d77d0c