### PR TITLE
Upgrade Rust to 1.88

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.87.0
+          toolchain: 1.88.0
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         # Need to specify @master above to work with toolchain var
         with:
-          toolchain: 1.87.0
+          toolchain: 1.88.0
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Run with Debian, libclang has issues with Alpine.
 # Make sure to update rust-toolchain.toml when updating the base image,
 # and vice versa.
-FROM rust:1.87-bookworm AS base
+FROM rust:1.88-bookworm AS base
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -3,7 +3,7 @@
 # Run with Debian, libclang has issues with Alpine.
 # Make sure to update rust-toolchain.toml when updating the base image,
 # and vice versa.
-FROM rust:1.87-bookworm AS base
+FROM rust:1.88-bookworm AS base
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "stable"
-version = "1.87.0"
+version = "1.88.0"


### PR DESCRIPTION
## Summary
- update rust-toolchain to 1.88
- bump Dockerfiles and CI workflows to use Rust 1.88

## Testing
- `just ci` *(fails: network error during dashboard tests)*

------
https://chatgpt.com/codex/tasks/task_b_68625df4305483289ca382527b4be3a7