### PR TITLE
Refine decimal formatting

### DIFF
--- a/dashboard/tests/helpers.test.ts
+++ b/dashboard/tests/helpers.test.ts
@@ -52,13 +52,13 @@ const metricsAllNull = createMetrics({
 
 describe('helpers', () => {
   it('creates metrics correctly', () => {
-    expect(metrics[0].value).toBe('3.00');
+    expect(metrics[0].value).toBe('3.0');
     expect(metrics[0].group).toBe('Network Performance');
     expect(metrics[1].value).toBe('60.0s');
     expect(metrics[1].group).toBe('Network Performance');
     expect(metrics[2].value).toBe('N/A');
     expect(metrics[2].group).toBe('Network Performance');
-    expect(metrics[3].value).toBe('1.20s');
+    expect(metrics[3].value).toBe('1.2s');
     expect(metrics[3].group).toBe('Network Health');
     expect(metrics[4].value).toBe('N/A');
     expect(metrics[4].group).toBe('Network Health');
@@ -78,11 +78,11 @@ describe('helpers', () => {
     expect(metrics[11].group).toBe('Network Economics');
     expect(metrics[12].value).toBe('41.0 ETH');
     expect(metrics[12].group).toBe('Network Economics');
-    expect(metrics[13].value).toBe('1.00 ETH');
+    expect(metrics[13].value).toBe('1.0 ETH');
     expect(metrics[13].group).toBe('Network Economics');
-    expect(metrics[14].value).toBe('2.00 ETH');
+    expect(metrics[14].value).toBe('2.0 ETH');
     expect(metrics[14].group).toBe('Network Economics');
-    expect(metrics[15].value).toBe('9.00 ETH');
+    expect(metrics[15].value).toBe('9.0 ETH');
     expect(metrics[15].group).toBe('Network Economics');
     expect(metrics[16].value).toBe('11.0 ETH');
     expect(metrics[16].group).toBe('Network Economics');

--- a/dashboard/tests/metricsCreator.test.ts
+++ b/dashboard/tests/metricsCreator.test.ts
@@ -29,17 +29,17 @@ describe('metricsCreator', () => {
     });
 
     expect(metrics).toHaveLength(19);
-    expect(metrics[0].value).toBe('1.23');
+    expect(metrics[0].value).toBe('1.2');
 
     const proveMetric = metrics.find((m) => m.title === 'Avg. Prove Time');
     const verifyMetric = metrics.find((m) => m.title === 'Avg. Verify Time');
-    expect(proveMetric?.value).toBe('2.00s');
-    expect(verifyMetric?.value).toBe('3.00s');
+    expect(proveMetric?.value).toBe('2.0s');
+    expect(verifyMetric?.value).toBe('3.0s');
 
     const proveCostMetric = metrics.find((m) => m.title === 'Prove Cost');
     const verifyCostMetric = metrics.find((m) => m.title === 'Verify Cost');
-    expect(proveCostMetric?.value).toBe('5.00 ETH');
-    expect(verifyCostMetric?.value).toBe('6.00 ETH');
+    expect(proveCostMetric?.value).toBe('5.0 ETH');
+    expect(verifyCostMetric?.value).toBe('6.0 ETH');
 
     const profitMetric = metrics.find((m) => m.title === 'Profit');
     expect(profitMetric?.value).toBe('39.0 ETH');

--- a/dashboard/tests/utils.extra.test.ts
+++ b/dashboard/tests/utils.extra.test.ts
@@ -4,7 +4,7 @@ import { formatDecimal, formatSeconds } from '../utils';
 describe('extra utils', () => {
   describe('formatDecimal', () => {
     it.each([
-      [-5.678, '-5.68'],
+      [-5.678, '-5.7'],
       [0, '0.00'],
       [12.345, '12.3'],
     ])('formats %p to %p', (input, expected) => {

--- a/dashboard/tests/utils.test.ts
+++ b/dashboard/tests/utils.test.ts
@@ -21,7 +21,7 @@ import {
 
 describe('utils', () => {
   it('formats numbers and durations', () => {
-    expect(formatDecimal(1)).toBe('1.00');
+    expect(formatDecimal(1)).toBe('1.0');
     expect(formatDecimal(12.345)).toBe('12.3');
 
     expect(formatSeconds(30)).toBe('30.0s');
@@ -29,12 +29,12 @@ describe('utils', () => {
     expect(formatSeconds(7200)).toBe('2h');
 
     expect(formatInterval(30, false, false)).toBe('30 seconds');
-    expect(formatInterval(180, false, true)).toBe('3.00 minutes');
-    expect(formatInterval(7200, true, false)).toBe('2.00 hours');
+    expect(formatInterval(180, false, true)).toBe('3.0 minutes');
+    expect(formatInterval(7200, true, false)).toBe('2.0 hours');
 
     expect(formatBatchDuration(45, false, false)).toBe('45 seconds');
-    expect(formatBatchDuration(150, false, true)).toBe('2.50 minutes');
-    expect(formatBatchDuration(7200, true, false)).toBe('2.00 hours');
+    expect(formatBatchDuration(150, false, true)).toBe('2.5 minutes');
+    expect(formatBatchDuration(7200, true, false)).toBe('2.0 hours');
   });
 
   it('computes batch duration flags', () => {
@@ -137,7 +137,7 @@ describe('utils', () => {
     expect(formatEth(187788.9e9)).toBe('187,788 Gwei');
     expect(formatEth(-1e8)).toBe('-100,000,000 wei');
     expect(formatEth(-345678.9e9)).toBe('-345,678 Gwei');
-    expect(formatEth(-1.2345e18)).toBe('-1.23 ETH');
+    expect(formatEth(-1.2345e18)).toBe('-1.2 ETH');
   });
 
   it('parses ETH and Gwei values', () => {

--- a/dashboard/utils.ts
+++ b/dashboard/utils.ts
@@ -63,7 +63,7 @@ export const addressLink = (
   );
 
 export const formatDecimal = (value: number): string => {
-  const decimals = Math.abs(value) >= 10 ? 1 : 2;
+  const decimals = Math.abs(value) >= 1 ? 1 : 2;
   const fixed = value.toFixed(decimals);
   return Number(fixed).toFixed(decimals);
 };


### PR DESCRIPTION
## Summary
- round small economics numbers to one decimal or two if below 1
- update test expectations to match new formatting

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68625f43d79c83288a8be4880dded7da