### PR TITLE
Improve ETH formatting precision

### DIFF
--- a/dashboard/tests/utils.test.ts
+++ b/dashboard/tests/utils.test.ts
@@ -139,6 +139,7 @@ describe('utils', () => {
     expect(formatEth(-345678.9e9)).toBe('-345,678 Gwei');
     expect(formatEth(-1.2345e18)).toBe('-1.2 ETH');
     expect(formatEth(0.01e18)).toBe('0.01 ETH');
+    expect(formatEth(0.012e18)).toBe('0.012 ETH');
     expect(formatEth(-0.04e18)).toBe('-0.04 ETH');
   });
 

--- a/dashboard/utils.ts
+++ b/dashboard/utils.ts
@@ -63,10 +63,20 @@ export const addressLink = (
   );
 
 export const formatDecimal = (value: number): string => {
-  const decimals = Math.abs(value) >= 1 ? 1 : 2;
+  if (value === 0) {
+    return '0.00';
+  }
+
+  const decimals = Math.abs(value) >= 1 ? 1 : 3;
   const factor = 10 ** decimals;
   const rounded = Math.round(value * factor) / factor;
-  return rounded.toFixed(decimals);
+  let result = rounded.toFixed(decimals);
+
+  if (Math.abs(value) < 1) {
+    result = result.replace(/0+$/, '');
+  }
+
+  return result;
 };
 
 export const formatSeconds = (seconds: number): string => {
@@ -101,7 +111,7 @@ export const formatEth = (wei: number): string => {
     return `${Math.trunc(eth).toLocaleString()} ETH`;
   }
   const ethFormatted = formatDecimal(eth);
-  if (wei !== 0 && ethFormatted === '0.00') {
+  if (wei !== 0 && Math.abs(eth) < 0.005) {
     const gwei = wei / 1e9;
     if (Math.abs(gwei) >= 1000) {
       return `${Math.trunc(gwei).toLocaleString()} Gwei`;


### PR DESCRIPTION
## Summary
- improve decimal precision for ETH amounts
- display values in gwei if ETH value is small
- test new rounding rules

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_686272db9a5c8328a9c5525bea7199a8