### PR TITLE
Update dashboard to use ETH units

### DIFF
--- a/dashboard/tests/utils.test.ts
+++ b/dashboard/tests/utils.test.ts
@@ -129,14 +129,14 @@ describe('utils', () => {
 
   it('formats ETH amounts', () => {
     expect(formatEth(42e18)).toBe('42 ETH');
-    expect(formatEth(0)).toBe('0 wei');
-    expect(formatEth(1e8)).toBe('100,000,000 wei');
-    expect(formatEth(1334501e9)).toBe('1,334,501 Gwei');
-    expect(formatEth(1422636.1e9)).toBe('1,422,636 Gwei');
+    expect(formatEth(0)).toBe('0 ETH');
+    expect(formatEth(1e8)).toBe('0 ETH');
+    expect(formatEth(1334501e9)).toBe('0.001 ETH');
+    expect(formatEth(1422636.1e9)).toBe('0.001 ETH');
     expect(formatEth(1422636.1e18)).toBe('1,422,636 ETH');
-    expect(formatEth(187788.9e9)).toBe('187,788 Gwei');
-    expect(formatEth(-1e8)).toBe('-100,000,000 wei');
-    expect(formatEth(-345678.9e9)).toBe('-345,678 Gwei');
+    expect(formatEth(187788.9e9)).toBe('0 ETH');
+    expect(formatEth(-1e8)).toBe('0 ETH');
+    expect(formatEth(-345678.9e9)).toBe('0 ETH');
     expect(formatEth(-1.2345e18)).toBe('-1.2 ETH');
     expect(formatEth(0.01e18)).toBe('0.01 ETH');
     expect(formatEth(0.012e18)).toBe('0.012 ETH');
@@ -144,15 +144,13 @@ describe('utils', () => {
     expect(formatEth(1e18, 3)).toBe('1 ETH');
   });
 
-  it('parses ETH and Gwei values', () => {
+  it('parses ETH values', () => {
     expect(parseEthValue('0.6 ETH')).toBe(0.6);
-    expect(parseEthValue('1334501 Gwei')).toBeCloseTo(0.001334501);
     expect(parseEthValue('N/A')).toBe(0);
   });
 
-  it('parses negative ETH and Gwei values', () => {
+  it('parses negative ETH values', () => {
     expect(parseEthValue('-0.5 ETH')).toBe(-0.5);
-    expect(parseEthValue('-100 Gwei')).toBeCloseTo(-0.0000001);
   });
 
   it('converts bytes to hex', () => {

--- a/dashboard/utils.ts
+++ b/dashboard/utils.ts
@@ -2,8 +2,7 @@ import React from 'react';
 import { TAIKO_PINK } from './theme';
 
 const rawNetworkName =
-  import.meta.env.VITE_NETWORK_NAME ??
-  import.meta.env.NETWORK_NAME;
+  import.meta.env.VITE_NETWORK_NAME ?? import.meta.env.NETWORK_NAME;
 
 export const TAIKOSCAN_BASE =
   import.meta.env.VITE_TAIKOSCAN_BASE ??
@@ -33,7 +32,10 @@ export const blockLink = (
     text ?? block.toLocaleString(),
   );
 
-export const l1BlockLink = (block: number, text?: string | number): React.ReactElement =>
+export const l1BlockLink = (
+  block: number,
+  text?: string | number,
+): React.ReactElement =>
   React.createElement(
     'a',
     {
@@ -62,7 +64,10 @@ export const addressLink = (
     text ?? address,
   );
 
-export const formatDecimal = (value: number, decimalsOverride?: number): string => {
+export const formatDecimal = (
+  value: number,
+  decimalsOverride?: number,
+): string => {
   if (value === 0) {
     const decimals = decimalsOverride ?? 2;
     return `0.${'0'.repeat(decimals)}`;
@@ -104,35 +109,19 @@ export const formatWithCommas = (value: number): string =>
   value.toLocaleString();
 
 export const formatEth = (wei: number, decimals?: number): string => {
-  if (Math.abs(wei) < 1e9) {
-    return `${wei.toLocaleString()} wei`;
-  }
   const eth = wei / 1e18;
   if (Math.abs(eth) >= 1000) {
     return `${Math.trunc(eth).toLocaleString()} ETH`;
   }
   const ethFormatted = formatDecimal(eth, decimals);
   const ethTrimmed = String(Number(ethFormatted));
-  if (wei !== 0 && Math.abs(eth) < 0.005) {
-    const gwei = wei / 1e9;
-    if (Math.abs(gwei) >= 1000) {
-      return `${Math.trunc(gwei).toLocaleString()} Gwei`;
-    }
-    const gweiFormatted = Number.isInteger(gwei)
-      ? gwei.toLocaleString()
-      : formatDecimal(gwei, decimals);
-    return `${gweiFormatted} Gwei`;
-  }
   return `${ethTrimmed} ETH`;
 };
 
 export const parseEthValue = (value: string): number => {
-  const sanitized = value
-    .replace(/[^0-9.-]/g, '')
-    .replace(/(?!^)-/g, '');
+  const sanitized = value.replace(/[^0-9.-]/g, '').replace(/(?!^)-/g, '');
   const amount = parseFloat(sanitized);
-  if (!Number.isFinite(amount)) return 0;
-  return /gwei/i.test(value) ? amount / 1e9 : amount;
+  return Number.isFinite(amount) ? amount : 0;
 };
 
 export const formatUsd = (value: number): string => {


### PR DESCRIPTION
## Summary
- keep ETH as the only displayed unit in dashboard utils
- adjust parsing/formatting tests for ETH-only display

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6863943c846883289c083ed1f36382ff