### PR TITLE
Improve chart time formatting

### DIFF
--- a/dashboard/components/BatchProcessChart.tsx
+++ b/dashboard/components/BatchProcessChart.tsx
@@ -14,6 +14,7 @@ import {
   formatDecimal,
   formatBatchDuration,
   computeBatchDurationFlags,
+  formatHoursMinutes,
 } from '../utils';
 
 interface BatchProcessChartProps {
@@ -64,7 +65,7 @@ const BatchProcessChartComponent: React.FC<BatchProcessChartProps> = ({
           fontSize={12}
           tickFormatter={(v) =>
             showHours
-              ? Number(formatDecimal(v / 3600))
+              ? formatHoursMinutes(v)
               : showMinutes
                 ? Number(formatDecimal(v / 60))
                 : v.toString()

--- a/dashboard/components/BlockTimeChart.tsx
+++ b/dashboard/components/BlockTimeChart.tsx
@@ -17,6 +17,7 @@ import {
   formatInterval,
   computeIntervalFlags,
   formatDateTime,
+  formatHoursMinutes,
 } from '../utils';
 
 interface BlockTimeChartProps {
@@ -69,7 +70,7 @@ const BlockTimeChartComponent: React.FC<BlockTimeChartProps> = ({
           domain={['auto', 'auto']}
           tickFormatter={(v) =>
             showHours
-              ? String(Number(formatDecimal(v / (seconds ? 3600 : 3600000))))
+              ? formatHoursMinutes(seconds ? v : v / 1000)
               : showMinutes
                 ? String(Number(formatDecimal(v / (seconds ? 60 : 60000))))
                 : String(Number(formatDecimal(seconds ? v : v / 1000)))

--- a/dashboard/tests/utils.extra.test.ts
+++ b/dashboard/tests/utils.extra.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatDecimal, formatSeconds } from '../utils';
+import { formatDecimal, formatSeconds, formatHoursMinutes } from '../utils';
 
 describe('extra utils', () => {
   describe('formatDecimal', () => {
@@ -22,6 +22,16 @@ describe('extra utils', () => {
       [7200, '2h'],
     ])('formats %p seconds to %p', (input, expected) => {
       expect(formatSeconds(input)).toBe(expected);
+    });
+  });
+
+  describe('formatHoursMinutes', () => {
+    it.each([
+      [3600, '1:00h'],
+      [3661, '1:01h'],
+      [9000, '2:30h'],
+    ])('formats %p seconds to %p', (input, expected) => {
+      expect(formatHoursMinutes(input)).toBe(expected);
     });
   });
 });

--- a/dashboard/tests/utils.test.ts
+++ b/dashboard/tests/utils.test.ts
@@ -17,6 +17,7 @@ import {
   loadRefreshRate,
   saveRefreshRate,
   isValidRefreshRate,
+  formatHoursMinutes,
 } from '../utils';
 
 describe('utils', () => {
@@ -27,6 +28,7 @@ describe('utils', () => {
     expect(formatSeconds(30)).toBe('30.0s');
     expect(formatSeconds(150)).toBe('2.5m');
     expect(formatSeconds(7200)).toBe('2h');
+    expect(formatHoursMinutes(9000)).toBe('2:30h');
 
     expect(formatInterval(30, false, false)).toBe('30 seconds');
     expect(formatInterval(180, false, true)).toBe('3.0 minutes');

--- a/dashboard/utils.ts
+++ b/dashboard/utils.ts
@@ -95,6 +95,13 @@ export const formatSeconds = (seconds: number): string => {
   return `${formatDecimal(seconds)}s`;
 };
 
+export const formatHoursMinutes = (seconds: number): string => {
+  const secs = Math.round(seconds);
+  const hrs = Math.floor(secs / 3600);
+  const mins = Math.floor((secs % 3600) / 60);
+  return `${hrs}:${mins.toString().padStart(2, '0')}h`;
+};
+
 export const formatLargeNumber = (value: number): string => {
   if (Math.abs(value) >= 1_000_000) {
     return `${Number(formatDecimal(value / 1_000_000))}M`;


### PR DESCRIPTION
## Summary
- add `formatHoursMinutes` to display hours with minutes cleanly
- show hours and minutes on BatchProcessChart and BlockTimeChart axes
- test new time formatting

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6863ae7e14c8832884de2835fa5097c9