### PR TITLE
Remove h suffix from formatHoursMinutes

### DIFF
--- a/dashboard/tests/utils.extra.test.ts
+++ b/dashboard/tests/utils.extra.test.ts
@@ -27,9 +27,9 @@ describe('extra utils', () => {
 
   describe('formatHoursMinutes', () => {
     it.each([
-      [3600, '1:00h'],
-      [3661, '1:01h'],
-      [9000, '2:30h'],
+      [3600, '1:00'],
+      [3661, '1:01'],
+      [9000, '2:30'],
     ])('formats %p seconds to %p', (input, expected) => {
       expect(formatHoursMinutes(input)).toBe(expected);
     });

--- a/dashboard/tests/utils.test.ts
+++ b/dashboard/tests/utils.test.ts
@@ -28,7 +28,7 @@ describe('utils', () => {
     expect(formatSeconds(30)).toBe('30.0s');
     expect(formatSeconds(150)).toBe('2.5m');
     expect(formatSeconds(7200)).toBe('2h');
-    expect(formatHoursMinutes(9000)).toBe('2:30h');
+    expect(formatHoursMinutes(9000)).toBe('2:30');
 
     expect(formatInterval(30, false, false)).toBe('30 seconds');
     expect(formatInterval(180, false, true)).toBe('3.0 minutes');

--- a/dashboard/utils.ts
+++ b/dashboard/utils.ts
@@ -99,7 +99,7 @@ export const formatHoursMinutes = (seconds: number): string => {
   const secs = Math.round(seconds);
   const hrs = Math.floor(secs / 3600);
   const mins = Math.floor((secs % 3600) / 60);
-  return `${hrs}:${mins.toString().padStart(2, '0')}h`;
+  return `${hrs}:${mins.toString().padStart(2, '0')}`;
 };
 
 export const formatLargeNumber = (value: number): string => {


### PR DESCRIPTION
## Summary
- remove trailing `h` from `formatHoursMinutes`
- update related tests

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6863b9d36658832894b8a187f854ffe9