### PR TITLE
feat(dashboard): show time in colon format

### DIFF
--- a/dashboard/tests/utils.extra.test.ts
+++ b/dashboard/tests/utils.extra.test.ts
@@ -18,8 +18,8 @@ describe('extra utils', () => {
     it.each([
       [0, '0.00s'],
       [119, '119.0s'],
-      [120, '2m'],
-      [7200, '2h'],
+      [120, '2:00m'],
+      [7200, '2:00h'],
     ])('formats %p seconds to %p', (input, expected) => {
       expect(formatSeconds(input)).toBe(expected);
     });

--- a/dashboard/tests/utils.test.ts
+++ b/dashboard/tests/utils.test.ts
@@ -26,8 +26,8 @@ describe('utils', () => {
     expect(formatDecimal(12.345)).toBe('12.3');
 
     expect(formatSeconds(30)).toBe('30.0s');
-    expect(formatSeconds(150)).toBe('2.5m');
-    expect(formatSeconds(7200)).toBe('2h');
+    expect(formatSeconds(150)).toBe('2:30m');
+    expect(formatSeconds(7200)).toBe('2:00h');
     expect(formatHoursMinutes(9000)).toBe('2:30');
 
     expect(formatInterval(30, false, false)).toBe('30 seconds');
@@ -166,8 +166,8 @@ describe('utils', () => {
       setItem: (k: string, v: string) => {
         store[k] = v;
       },
-      removeItem: () => {},
-      clear: () => {},
+      removeItem: () => { },
+      clear: () => { },
       key: () => null,
       length: 0,
     } as Storage;

--- a/dashboard/utils.ts
+++ b/dashboard/utils.ts
@@ -86,7 +86,7 @@ export const formatDecimal = (
 };
 
 export const formatMinutesSeconds = (seconds: number): string => {
-  const secs = Math.round(seconds);
+  const secs = Math.floor(seconds);
   const mins = Math.floor(secs / 60);
   const rem = secs % 60;
   return `${mins}:${rem.toString().padStart(2, '0')}m`;

--- a/dashboard/utils.ts
+++ b/dashboard/utils.ts
@@ -85,12 +85,19 @@ export const formatDecimal = (
   return result;
 };
 
+export const formatMinutesSeconds = (seconds: number): string => {
+  const secs = Math.round(seconds);
+  const mins = Math.floor(secs / 60);
+  const rem = secs % 60;
+  return `${mins}:${rem.toString().padStart(2, '0')}m`;
+};
+
 export const formatSeconds = (seconds: number): string => {
   if (seconds >= 120 * 60) {
-    return `${Number(formatDecimal(seconds / 3600))}h`;
+    return formatHoursMinutes(seconds) + 'h';
   }
   if (seconds >= 120) {
-    return `${Number(formatDecimal(seconds / 60))}m`;
+    return formatMinutesSeconds(seconds);
   }
   return `${formatDecimal(seconds)}s`;
 };


### PR DESCRIPTION
## Summary
- display fractional minutes and hours using `mm:ss` or `hh:mm` format
- update related tests

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6863bb6256d48328821fbea751faf71a