### PR TITLE
Show custom date picker always

### DIFF
--- a/dashboard/components/DashboardHeader.tsx
+++ b/dashboard/components/DashboardHeader.tsx
@@ -26,7 +26,6 @@ const rawNetworkName =
 const NETWORK_NAME =
   rawNetworkName.charAt(0).toUpperCase() +
   rawNetworkName.slice(1).toLowerCase();
-const SHOW_CUSTOM_TIME_PICKER = rawNetworkName.toLowerCase() !== 'hekla';
 const DASHBOARD_TITLE = `Taikoscope ${NETWORK_NAME}`;
 
 interface DashboardHeaderProps {
@@ -257,49 +256,47 @@ export const TimeRangeSelector: React.FC<TimeRangeSelectorProps> = ({
             {r}
           </button>
         ))}
-        {SHOW_CUSTOM_TIME_PICKER && (
-          <div className="pt-1 border-t border-gray-200 dark:border-gray-700 mt-1 space-y-1">
-            <DayPicker
-              mode="single"
-              selected={date}
-              onSelect={(d) => {
-                const newDate = d ?? undefined;
-                setDate(newDate);
-                if (d && !fromTime && !toTime) {
-                  setFromTime('00:00');
-                  setToTime('23:59');
-                }
-              }}
-              defaultMonth={date}
+        <div className="pt-1 border-t border-gray-200 dark:border-gray-700 mt-1 space-y-1">
+          <DayPicker
+            mode="single"
+            selected={date}
+            onSelect={(d) => {
+              const newDate = d ?? undefined;
+              setDate(newDate);
+              if (d && !fromTime && !toTime) {
+                setFromTime('00:00');
+                setToTime('23:59');
+              }
+            }}
+            defaultMonth={date}
+          />
+          <div className="flex items-center space-x-2">
+            <input
+              type="time"
+              step="900"
+              placeholder="hh:mm"
+              value={fromTime}
+              onChange={(e) => setFromTime(e.target.value)}
+              className="border rounded p-1 text-sm bg-white dark:bg-gray-800"
             />
-            <div className="flex items-center space-x-2">
-              <input
-                type="time"
-                step="900"
-                placeholder="hh:mm"
-                value={fromTime}
-                onChange={(e) => setFromTime(e.target.value)}
-                className="border rounded p-1 text-sm bg-white dark:bg-gray-800"
-              />
-              <span className="text-sm">to</span>
-              <input
-                type="time"
-                step="900"
-                placeholder="hh:mm"
-                value={toTime}
-                onChange={(e) => setToTime(e.target.value)}
-                className="border rounded p-1 text-sm bg-white dark:bg-gray-800"
-              />
-            </div>
-            <button
-              onClick={applyCustom}
-              disabled={isChanging || !date || !fromTime || !toTime}
-              className="mt-1 px-2 py-1 text-sm rounded-md bg-gray-200 dark:bg-gray-700 w-full"
-            >
-              Apply
-            </button>
+            <span className="text-sm">to</span>
+            <input
+              type="time"
+              step="900"
+              placeholder="hh:mm"
+              value={toTime}
+              onChange={(e) => setToTime(e.target.value)}
+              className="border rounded p-1 text-sm bg-white dark:bg-gray-800"
+            />
           </div>
-        )}
+          <button
+            onClick={applyCustom}
+            disabled={isChanging || !date || !fromTime || !toTime}
+            className="mt-1 px-2 py-1 text-sm rounded-md bg-gray-200 dark:bg-gray-700 w-full"
+          >
+            Apply
+          </button>
+        </div>
       </Popover.Content>
     </Popover.Root>
   );


### PR DESCRIPTION
## Summary
- remove network based toggle for custom date picker
- always render date picker in the dashboard header

## Testing
- `just lint-dashboard`
- `just check-dashboard`
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_6863bda81db88328a8663927fb5036db