### PR TITLE
Handle fee fields as bigint

### DIFF
--- a/dashboard/components/BlockProfitTables.tsx
+++ b/dashboard/components/BlockProfitTables.tsx
@@ -4,7 +4,7 @@ import { fetchBatchFeeComponents } from '../services/apiService';
 import { useEthPrice } from '../services/priceService';
 import { TimeRange } from '../types';
 import { rangeToHours } from '../utils/timeRange';
-import { formatEth, l1BlockLink } from '../utils';
+import { formatEth, l1BlockLink, toBigInt } from '../utils';
 import { calculateProfit } from '../utils/profit';
 
 interface BlockProfitTablesProps {
@@ -44,16 +44,20 @@ export const BlockProfitTables: React.FC<BlockProfitTablesProps> = ({
     : 0;
 
   const profits = batchData.map((b) => {
+    const priorityWei = toBigInt(b.priority);
+    const baseWei = toBigInt(b.base);
+    const l1CostWei = toBigInt(b.l1Cost);
+    const proveWei = toBigInt(b.amortizedProveCost);
     const { profitEth } = calculateProfit({
-      priorityFee: b.priority,
-      baseFee: b.base,
-      l1DataCost: b.l1Cost ?? 0,
-      proveCost: b.amortizedProveCost ?? 0,
+      priorityFee: Number(priorityWei),
+      baseFee: Number(baseWei),
+      l1DataCost: Number(l1CostWei ?? 0n),
+      proveCost: Number(proveWei ?? 0n),
 
       hardwareCostUsd: operationalCostPerBatchUsd,
       ethPrice,
     });
-    const profitWei = profitEth * 1e18;
+    const profitWei = toBigInt(Math.round(profitEth * 1e18));
 
     return {
       batch: b.batch,

--- a/dashboard/components/ProfitRankingTable.tsx
+++ b/dashboard/components/ProfitRankingTable.tsx
@@ -8,7 +8,7 @@ import {
 } from '../services/apiService';
 import * as apiService from '../services/apiService';
 import { getSequencerAddress } from '../sequencerConfig';
-import { addressLink, formatEth, formatDecimal } from '../utils';
+import { addressLink, formatEth, formatDecimal, toBigInt } from '../utils';
 import { calculateProfit } from '../utils/profit';
 import { useEthPrice } from '../services/priceService';
 import { rangeToHours } from '../utils/timeRange';
@@ -113,18 +113,22 @@ export const ProfitRankingTable: React.FC<ProfitRankingTableProps> = ({
         ratio: null as number | null,
       };
     }
-    const revenueEth =
-      ((fees.priority_fee ?? 0) + (fees.base_fee ?? 0) * 0.75) / 1e18;
-    const l1CostEth = (fees.l1_data_cost ?? 0) / 1e18;
+    const priorityWei = toBigInt(fees.priority_fee);
+    const baseWei = (toBigInt(fees.base_fee) * 75n) / 100n;
+    const l1CostWei = toBigInt(fees.l1_data_cost);
+    const proveWei = toBigInt(fees.prove_cost);
+
+    const revenueEth = Number(priorityWei + baseWei) / 1e18;
+    const l1CostEth = Number(l1CostWei) / 1e18;
     const revenueUsd = revenueEth * ethPrice;
     const l1CostUsd = l1CostEth * ethPrice;
     const costEth = costPerSeqEth + l1CostEth + extraEth;
     const costUsd = costPerSeqUsd + l1CostUsd + extraUsd;
     const { profitEth, profitUsd } = calculateProfit({
-      priorityFee: fees.priority_fee,
-      baseFee: fees.base_fee,
-      l1DataCost: fees.l1_data_cost,
-      proveCost: fees.prove_cost,
+      priorityFee: Number(priorityWei),
+      baseFee: Number(toBigInt(fees.base_fee)),
+      l1DataCost: Number(l1CostWei),
+      proveCost: Number(proveWei),
 
       hardwareCostUsd: costPerSeqUsd,
       ethPrice,

--- a/dashboard/components/ProfitabilityChart.tsx
+++ b/dashboard/components/ProfitabilityChart.tsx
@@ -14,7 +14,7 @@ import { useEthPrice } from '../services/priceService';
 import { fetchBatchFeeComponents } from '../services/apiService';
 import { TimeRange, BatchFeeComponent } from '../types';
 import { rangeToHours } from '../utils/timeRange';
-import { formatEth } from '../utils';
+import { formatEth, toBigInt } from '../utils';
 import { calculateProfit } from '../utils/profit';
 
 interface ProfitabilityChartProps {
@@ -52,10 +52,10 @@ export const ProfitabilityChart: React.FC<ProfitabilityChartProps> = ({
 
   const data = feeData.map((b) => {
     const { profitEth, profitUsd } = calculateProfit({
-      priorityFee: b.priority,
-      baseFee: b.base,
-      l1DataCost: b.l1Cost ?? 0,
-      proveCost: b.amortizedProveCost ?? 0,
+      priorityFee: Number(toBigInt(b.priority)),
+      baseFee: Number(toBigInt(b.base)),
+      l1DataCost: Number(toBigInt(b.l1Cost)),
+      proveCost: Number(toBigInt(b.amortizedProveCost)),
 
       hardwareCostUsd: costPerBatchUsd,
       ethPrice,

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -813,17 +813,17 @@ export const fetchAvgL2Tps = async (
 
 export interface SequencerFee {
   address: string;
-  priority_fee: number;
-  base_fee: number;
-  l1_data_cost: number | null;
-  prove_cost: number | null;
+  priority_fee: string;
+  base_fee: string;
+  l1_data_cost: string | null;
+  prove_cost: string | null;
 }
 
 export interface L2FeesResponse {
-  priority_fee: number | null;
-  base_fee: number | null;
-  l1_data_cost: number | null;
-  prove_cost: number | null;
+  priority_fee: string | null;
+  base_fee: string | null;
+  l1_data_cost: string | null;
+  prove_cost: string | null;
   sequencers: SequencerFee[];
 }
 
@@ -844,19 +844,19 @@ export const fetchL2Fees = async (
 
 export interface FeeComponent {
   block: number;
-  priority: number;
-  base: number;
-  l1Cost: number | null;
+  priority: string;
+  base: string;
+  l1Cost: string | null;
 }
 
 export interface BatchFeeComponent {
   batch: number;
   l1Block: number;
   sequencer: string;
-  priority: number;
-  base: number;
-  l1Cost: number | null;
-  amortizedProveCost: number | null;
+  priority: string;
+  base: string;
+  l1Cost: string | null;
+  amortizedProveCost: string | null;
 }
 
 export const fetchFeeComponents = async (
@@ -869,9 +869,9 @@ export const fetchFeeComponents = async (
   const res = await fetchJson<{
     blocks: {
       l2_block_number: number;
-      priority_fee: number;
-      base_fee: number;
-      l1_data_cost: number | null;
+      priority_fee: string;
+      base_fee: string;
+      l1_data_cost: string | null;
     }[];
   }>(url);
   return {
@@ -900,10 +900,10 @@ export const fetchBatchFeeComponents = async (
       batch_id: number;
       l1_block_number: number;
       sequencer: string;
-      priority_fee: number;
-      base_fee: number;
-      l1_data_cost: number | null;
-      amortized_prove_cost: number | null;
+      priority_fee: string;
+      base_fee: string;
+      l1_data_cost: string | null;
+      amortized_prove_cost: string | null;
 
     }[];
   }>(url);
@@ -1113,9 +1113,9 @@ export interface DashboardDataResponse {
   forced_inclusions: number;
   l2_head_block: number | null;
   l1_head_block: number | null;
-  priority_fee: number | null;
-  base_fee: number | null;
-  prove_cost: number | null;
+  priority_fee: string | null;
+  base_fee: string | null;
+  prove_cost: string | null;
   cloud_cost: number | null;
 }
 

--- a/dashboard/tests/app.integration.test.ts
+++ b/dashboard/tests/app.integration.test.ts
@@ -135,15 +135,15 @@ const responses: Record<string, Record<string, unknown>> = {
     ],
   },
   [`/v1/l2-fees?${q1h}`]: {
-    priority_fee: 600,
-    base_fee: 400,
+    priority_fee: '600',
+    base_fee: '400',
     l1_data_cost: null,
     prove_cost: 5,
     sequencers: [],
   },
   [`/v1/l2-fees?${q15m}`]: {
-    priority_fee: 600,
-    base_fee: 400,
+    priority_fee: '600',
+    base_fee: '400',
     l1_data_cost: null,
     prove_cost: 5,
     sequencers: [],
@@ -167,14 +167,14 @@ const responses: Record<string, Record<string, unknown>> = {
     forced_inclusions: 8,
     l2_head_block: 9,
     l1_head_block: 10,
-    priority_fee: 11,
-    base_fee: 12,
+    priority_fee: '11',
+    base_fee: '12',
     prove_cost: 13,
     cloud_cost: 14,
   },
   [`/v1/l2-fees?${q24h}`]: {
-    priority_fee: 1200,
-    base_fee: 800,
+    priority_fee: '1200',
+    base_fee: '800',
     l1_data_cost: null,
     prove_cost: 10,
     sequencers: [],
@@ -226,8 +226,10 @@ async function fetchData(range: TimeRange, state: State, economics = false) {
     ]);
 
     const l2FeeData = l2FeesRes.data;
-    const priorityFee = l2FeeData?.priority_fee ?? null;
-    const baseFee = l2FeeData?.base_fee ?? null;
+    const priorityFee =
+      l2FeeData?.priority_fee != null ? BigInt(l2FeeData.priority_fee) : null;
+    const baseFee =
+      l2FeeData?.base_fee != null ? BigInt(l2FeeData.base_fee) : null;
     const l2Block = l2BlockRes.data;
     const l1Block = l1BlockRes.data;
 
@@ -319,8 +321,10 @@ async function fetchData(range: TimeRange, state: State, economics = false) {
   const l2Gas = l2GasUsedRes.data || [];
   const sequencerDist = sequencerDistRes.data || [];
   const l2FeeData = l2FeesRes.data;
-  const priorityFee = l2FeeData?.priority_fee ?? null;
-  const baseFee = l2FeeData?.base_fee ?? null;
+  const priorityFee =
+    l2FeeData?.priority_fee != null ? BigInt(l2FeeData.priority_fee) : null;
+  const baseFee =
+    l2FeeData?.base_fee != null ? BigInt(l2FeeData.base_fee) : null;
 
   const anyBadRequest = hasBadRequest([
     l2CadenceRes,
@@ -479,8 +483,8 @@ it('fetches dashboard data correctly', async () => {
     forced_inclusions: 8,
     l2_head_block: 9,
     l1_head_block: 10,
-    priority_fee: 11,
-    base_fee: 12,
+    priority_fee: '11',
+    base_fee: '12',
     prove_cost: 13,
     cloud_cost: 14,
   });

--- a/dashboard/tests/blockProfitTables.test.ts
+++ b/dashboard/tests/blockProfitTables.test.ts
@@ -13,10 +13,10 @@ const feeData = [
     batch: 1,
     l1Block: 1,
     sequencer: 'SeqA',
-    priority: 1e18,
-    base: 1e18,
-    l1Cost: 0,
-    amortizedProveCost: 0,
+    priority: '1000000000000000000',
+    base: '1000000000000000000',
+    l1Cost: '0',
+    amortizedProveCost: '0',
 
   },
 ];

--- a/dashboard/tests/dataFetcher.test.ts
+++ b/dashboard/tests/dataFetcher.test.ts
@@ -39,8 +39,8 @@ describe('dataFetcher', () => {
         forced_inclusions: 8,
         l2_head_block: 10,
         l1_head_block: 11,
-        priority_fee: 12,
-        base_fee: 5,
+        priority_fee: '12',
+        base_fee: '5',
         cloud_cost: 13,
       }),
       fetchProveTimes: ok([{ name: '1', value: 1, timestamp: 0 }]),
@@ -84,10 +84,10 @@ describe('dataFetcher', () => {
   it('fetches economics data', async () => {
     setAll({
       fetchL2Fees: ok({
-        priority_fee: 1,
-        base_fee: 2,
-        l1_data_cost: 4,
-        prove_cost: 5,
+        priority_fee: '1',
+        base_fee: '2',
+        l1_data_cost: '4',
+        prove_cost: '5',
         sequencers: [],
       }),
       fetchL2HeadBlock: ok(2),

--- a/dashboard/tests/helpers.test.ts
+++ b/dashboard/tests/helpers.test.ts
@@ -15,12 +15,12 @@ const metrics = createMetrics({
   forcedInclusions: 0,
   l2Block: 100,
   l1Block: 50,
-  priorityFee: 41e18,
-  baseFee: 1e18,
-  proveCost: 9e18,
+  priorityFee: 41000000000000000000n,
+  baseFee: 1000000000000000000n,
+  proveCost: 9000000000000000000n,
 
-  l1DataCost: 2e18,
-  profit: 40e18,
+  l1DataCost: 2000000000000000000n,
+  profit: 40000000000000000000n,
 });
 
 const results = [

--- a/dashboard/tests/metricsCreator.test.ts
+++ b/dashboard/tests/metricsCreator.test.ts
@@ -18,12 +18,12 @@ describe('metricsCreator', () => {
       l2Reorgs: 1,
       slashings: 2,
       forcedInclusions: 3,
-      priorityFee: 40e18,
-      baseFee: 2e18,
-      proveCost: 5e18,
+      priorityFee: 40000000000000000000n,
+      baseFee: 2000000000000000000n,
+      proveCost: 5000000000000000000n,
 
-      l1DataCost: 3e18,
-      profit: 39e18,
+      l1DataCost: 3000000000000000000n,
+      profit: 39000000000000000000n,
       l2Block: 100,
       l1Block: 50,
     });

--- a/dashboard/tests/profitRankingTable.test.ts
+++ b/dashboard/tests/profitRankingTable.test.ts
@@ -26,24 +26,24 @@ describe('ProfitRankingTable', () => {
       .mockReturnValueOnce({
         data: {
           data: {
-            priority_fee: 3e18,
-            base_fee: 1.5e18,
-            l1_data_cost: 0,
-            prove_cost: 0,
+            priority_fee: '3000000000000000000',
+            base_fee: '1500000000000000000',
+            l1_data_cost: '0',
+            prove_cost: '0',
             sequencers: [
               {
                 address: '0xseqA',
-                priority_fee: 2e18,
-                base_fee: 1e18,
-                l1_data_cost: 0,
-                prove_cost: 0,
+                priority_fee: '2000000000000000000',
+                base_fee: '1000000000000000000',
+                l1_data_cost: '0',
+                prove_cost: '0',
               },
               {
                 address: '0xseqB',
-                priority_fee: 1e18,
-                base_fee: 0.5e18,
-                l1_data_cost: 0,
-                prove_cost: 0,
+                priority_fee: '1000000000000000000',
+                base_fee: '500000000000000000',
+                l1_data_cost: '0',
+                prove_cost: '0',
               },
             ],
           },
@@ -66,24 +66,24 @@ describe('ProfitRankingTable', () => {
     } as RequestResult<SequencerDistributionDataItem[]>);
     vi.spyOn(api, 'fetchL2Fees').mockResolvedValue({
       data: {
-        priority_fee: 3e18,
-        base_fee: 1.5e18,
-        l1_data_cost: 0,
-        prove_cost: 0,
+        priority_fee: '3000000000000000000',
+        base_fee: '1500000000000000000',
+        l1_data_cost: '0',
+        prove_cost: '0',
         sequencers: [
           {
             address: '0xseqA',
-            priority_fee: 2e18,
-            base_fee: 1e18,
-            l1_data_cost: 0,
-            prove_cost: 0,
+            priority_fee: '2000000000000000000',
+            base_fee: '1000000000000000000',
+            l1_data_cost: '0',
+            prove_cost: '0',
           },
           {
             address: '0xseqB',
-            priority_fee: 1e18,
-            base_fee: 0.5e18,
-            l1_data_cost: 0,
-            prove_cost: 0,
+            priority_fee: '1000000000000000000',
+            base_fee: '500000000000000000',
+            l1_data_cost: '0',
+            prove_cost: '0',
           },
         ],
       },
@@ -131,17 +131,17 @@ describe('ProfitRankingTable', () => {
       .mockReturnValueOnce({
         data: {
           data: {
-            priority_fee: 1e18,
-            base_fee: 0,
-            l1_data_cost: 5e17,
-            prove_cost: 1e16,
+            priority_fee: '1000000000000000000',
+            base_fee: '0',
+            l1_data_cost: '500000000000000000',
+            prove_cost: '10000000000000000',
             sequencers: [
               {
                 address: '0xseqA',
-                priority_fee: 1e18,
-                base_fee: 0,
-                l1_data_cost: 5e17,
-                prove_cost: 1e16,
+                priority_fee: '1000000000000000000',
+                base_fee: '0',
+                l1_data_cost: '500000000000000000',
+                prove_cost: '10000000000000000',
               },
             ],
           },
@@ -158,17 +158,17 @@ describe('ProfitRankingTable', () => {
     } as RequestResult<SequencerDistributionDataItem[]>);
     vi.spyOn(api, 'fetchL2Fees').mockResolvedValue({
       data: {
-        priority_fee: 1e18,
-        base_fee: 0,
-        l1_data_cost: 5e17,
-        prove_cost: 1e16,
+        priority_fee: '1000000000000000000',
+        base_fee: '0',
+        l1_data_cost: '500000000000000000',
+        prove_cost: '10000000000000000',
         sequencers: [
           {
             address: '0xseqA',
-            priority_fee: 1e18,
-            base_fee: 0,
-            l1_data_cost: 5e17,
-            prove_cost: 1e16,
+            priority_fee: '1000000000000000000',
+            base_fee: '0',
+            l1_data_cost: '500000000000000000',
+            prove_cost: '10000000000000000',
           },
         ],
       },

--- a/dashboard/types.ts
+++ b/dashboard/types.ts
@@ -55,19 +55,19 @@ export interface ErrorResponse {
 
 export interface FeeComponent {
   block: number;
-  priority: number;
-  base: number;
-  l1Cost: number | null;
+  priority: string;
+  base: string;
+  l1Cost: string | null;
 }
 
 export interface BatchFeeComponent {
   batch: number;
   l1Block: number;
   sequencer: string;
-  priority: number;
-  base: number;
-  l1Cost: number | null;
-  amortizedProveCost: number | null;
+  priority: string;
+  base: string;
+  l1Cost: string | null;
+  amortizedProveCost: string | null;
 }
 
 export interface BlockProfit {

--- a/dashboard/utils.ts
+++ b/dashboard/utils.ts
@@ -115,6 +115,23 @@ export const formatLargeNumber = (value: number): string => {
 export const formatWithCommas = (value: number): string =>
   value.toLocaleString();
 
+export const toBigInt = (
+  value: string | number | bigint | null | undefined,
+): bigint => {
+  try {
+    return value == null ? 0n : BigInt(value);
+  } catch {
+    return 0n;
+  }
+};
+
+export const weiToEth = (wei: bigint): number => Number(wei) / 1e18;
+
+export const formatEthBigInt = (
+  wei: bigint | null | undefined,
+  decimals?: number,
+): string => formatEth(Number(wei ?? 0n), decimals);
+
 export const formatEth = (wei: number, decimals?: number): string => {
   const eth = wei / 1e18;
   if (Math.abs(eth) >= 1000) {

--- a/dashboard/utils/dataFetcher.ts
+++ b/dashboard/utils/dataFetcher.ts
@@ -1,6 +1,7 @@
 import { TimeRange, type TimeSeriesData } from '../types';
 import { getSequencerAddress } from '../sequencerConfig';
 import { normalizeTimeRange } from './timeRange';
+import { toBigInt } from '../utils';
 import {
   fetchDashboardData,
   fetchProveTimesAggregated,
@@ -39,17 +40,17 @@ export interface MainDashboardData {
   sequencerDist: SequencerDistributionDataItem[];
   txPerBlock: BlockTransaction[];
   blobsPerBatch: BatchBlobCount[];
-  priorityFee: number | null;
-  baseFee: number | null;
-  proveCost: number | null;
+  priorityFee: bigint | null;
+  baseFee: bigint | null;
+  proveCost: bigint | null;
   badRequestResults: RequestResult<unknown>[];
 }
 
 export interface EconomicsData {
-  priorityFee: number | null;
-  baseFee: number | null;
-  l1DataCost: number | null;
-  proveCost: number | null;
+  priorityFee: bigint | null;
+  baseFee: bigint | null;
+  l1DataCost: bigint | null;
+  proveCost: bigint | null;
   l2Block: number | null;
   l1Block: number | null;
   sequencerDist: SequencerDistributionDataItem[];
@@ -121,9 +122,9 @@ export const fetchMainDashboardData = async (
     sequencerDist: sequencerDistRes.data || [],
     txPerBlock: blockTxRes.data || [],
     blobsPerBatch: batchBlobCountsRes.data || [],
-    priorityFee: data?.priority_fee ?? null,
-    baseFee: data?.base_fee ?? null,
-    proveCost: data?.prove_cost ?? null,
+    priorityFee: toBigInt(data?.priority_fee),
+    baseFee: toBigInt(data?.base_fee),
+    proveCost: toBigInt(data?.prove_cost),
 
     badRequestResults: allResults.slice(1),
   };
@@ -145,10 +146,10 @@ export const fetchEconomicsData = async (
   ]);
 
   return {
-    priorityFee: l2FeesRes.data?.priority_fee ?? null,
-    baseFee: l2FeesRes.data?.base_fee ?? null,
-    l1DataCost: l2FeesRes.data?.l1_data_cost ?? null,
-    proveCost: l2FeesRes.data?.prove_cost ?? null,
+    priorityFee: toBigInt(l2FeesRes.data?.priority_fee),
+    baseFee: toBigInt(l2FeesRes.data?.base_fee),
+    l1DataCost: toBigInt(l2FeesRes.data?.l1_data_cost),
+    proveCost: toBigInt(l2FeesRes.data?.prove_cost),
 
     l2Block: l2BlockRes.data,
     l1Block: l1BlockRes.data,

--- a/dashboard/utils/metricsCreator.ts
+++ b/dashboard/utils/metricsCreator.ts
@@ -2,7 +2,7 @@ import { type MetricData } from '../types';
 import {
   formatSeconds,
   formatDecimal,
-  formatEth,
+  formatEthBigInt,
   formatWithCommas,
   TAIKOSCAN_BASE,
 } from '../utils';
@@ -22,11 +22,11 @@ export interface MetricInputData {
   forcedInclusions: number | null;
   l2Block: number | null;
   l1Block: number | null;
-  priorityFee: number | null;
-  baseFee: number | null;
-  l1DataCost?: number | null;
-  profit?: number | null;
-  proveCost?: number | null;
+  priorityFee: bigint | null;
+  baseFee: bigint | null;
+  l1DataCost?: bigint | null;
+  profit?: bigint | null;
+  proveCost?: bigint | null;
 
 }
 
@@ -116,27 +116,27 @@ export const createMetrics = (data: MetricInputData): MetricData[] => [
   },
   {
     title: 'Profit',
-    value: data.profit != null ? formatEth(data.profit, 3) : 'N/A',
+    value: data.profit != null ? formatEthBigInt(data.profit, 3) : 'N/A',
     group: 'Network Economics',
   },
   {
     title: 'Priority Fee',
-    value: data.priorityFee != null ? formatEth(data.priorityFee, 3) : 'N/A',
+    value: data.priorityFee != null ? formatEthBigInt(data.priorityFee, 3) : 'N/A',
     group: 'Network Economics',
   },
   {
     title: 'Base Fee',
-    value: data.baseFee != null ? formatEth(data.baseFee, 3) : 'N/A',
+    value: data.baseFee != null ? formatEthBigInt(data.baseFee, 3) : 'N/A',
     group: 'Network Economics',
   },
   {
     title: 'Propose Batch Cost',
-    value: data.l1DataCost != null ? formatEth(data.l1DataCost, 3) : 'N/A',
+    value: data.l1DataCost != null ? formatEthBigInt(data.l1DataCost, 3) : 'N/A',
     group: 'Network Economics',
   },
   {
     title: 'Prove Cost',
-    value: data.proveCost != null ? formatEth(data.proveCost, 3) : 'N/A',
+    value: data.proveCost != null ? formatEthBigInt(data.proveCost, 3) : 'N/A',
     group: 'Network Economics',
   },
   {


### PR DESCRIPTION
## Summary
- treat fee-related fields from API as strings
- add bigint helpers for wei conversions
- adjust metrics creator and charts to use bigint helpers
- update tests and fixtures for new bigint types

## Testing
- `just ci` *(fails: check-dashboard)*

------
https://chatgpt.com/codex/tasks/task_b_6863bc19fa8083289bc7b08455237946