### PR TITLE
Return ETH amounts

### DIFF
--- a/crates/api-types/src/lib.rs
+++ b/crates/api-types/src/lib.rs
@@ -189,14 +189,14 @@ pub struct AvgL2TpsResponse {
 /// Total L2 fees broken down by component.
 #[derive(Debug, Serialize, ToSchema)]
 pub struct L2FeesResponse {
-    /// Sum of priority fees for the range.
-    pub priority_fee: Option<u128>,
-    /// Sum of base fees for the range.
-    pub base_fee: Option<u128>,
-    /// Total L1 data posting cost for the range.
-    pub l1_data_cost: Option<u128>,
-    /// Total proving cost for the range.
-    pub prove_cost: Option<u128>,
+    /// Sum of priority fees for the range in ETH.
+    pub priority_fee: Option<f64>,
+    /// Sum of base fees for the range in ETH.
+    pub base_fee: Option<f64>,
+    /// Total L1 data posting cost for the range in ETH.
+    pub l1_data_cost: Option<f64>,
+    /// Total proving cost for the range in ETH.
+    pub prove_cost: Option<f64>,
     /// Fee breakdown for each sequencer.
     pub sequencers: Vec<SequencerFeeRow>,
 }
@@ -274,13 +274,17 @@ pub struct BatchFeeComponentRow {
     /// Sequencer address that proposed the batch
     pub sequencer: String,
     /// Total priority fee for the batch
-    pub priority_fee: u128,
+    /// Total priority fee for the batch in ETH
+    pub priority_fee: f64,
     /// Total base fee for the batch
-    pub base_fee: u128,
+    /// Total base fee for the batch in ETH
+    pub base_fee: f64,
     /// L1 data posting cost associated with the batch, if available
-    pub l1_data_cost: Option<u128>,
+    /// L1 data posting cost associated with the batch, if available, in ETH
+    pub l1_data_cost: Option<f64>,
     /// Prover cost amortized across batches in the selected range
-    pub amortized_prove_cost: Option<u128>,
+    /// Prover cost amortized across batches in the selected range in ETH
+    pub amortized_prove_cost: Option<f64>,
 }
 
 /// Fee components for each batch
@@ -356,8 +360,8 @@ pub struct BlockTransactionsResponse {
 pub struct BlockProfitItem {
     /// Block number.
     pub block: u64,
-    /// Profit in wei (priority + base - L1 cost).
-    pub profit: i128,
+    /// Profit in ETH (priority + base - L1 cost).
+    pub profit: f64,
 }
 
 /// Collection of block profit entries.
@@ -372,8 +376,8 @@ pub struct BlockProfitsResponse {
 pub struct ProposerCostItem {
     /// Proposer address.
     pub address: String,
-    /// Total cost in wei.
-    pub cost: u128,
+    /// Total cost in ETH.
+    pub cost: f64,
 }
 
 /// Aggregated cost results grouped by proposer.
@@ -389,13 +393,17 @@ pub struct SequencerFeeRow {
     /// Sequencer address.
     pub address: String,
     /// Sum of priority fees for the sequencer.
-    pub priority_fee: u128,
+    /// Sum of priority fees for the sequencer in ETH.
+    pub priority_fee: f64,
     /// Sum of base fees for the sequencer.
-    pub base_fee: u128,
+    /// Sum of base fees for the sequencer in ETH.
+    pub base_fee: f64,
     /// Total L1 data posting cost for the sequencer.
-    pub l1_data_cost: Option<u128>,
+    /// Total L1 data posting cost for the sequencer in ETH.
+    pub l1_data_cost: Option<f64>,
     /// Total proving cost for the sequencer.
-    pub prove_cost: Option<u128>,
+    /// Total proving cost for the sequencer in ETH.
+    pub prove_cost: Option<f64>,
 }
 
 /// Blob count per batch.
@@ -474,12 +482,12 @@ pub struct DashboardDataResponse {
     pub l2_head_block: Option<u64>,
     /// Number of the most recent L1 block.
     pub l1_head_block: Option<u64>,
-    /// Sum of priority fees for the range.
-    pub priority_fee: Option<u128>,
-    /// Sum of base fees for the range.
-    pub base_fee: Option<u128>,
-    /// Total prover cost for the range.
-    pub prove_cost: Option<u128>,
+    /// Sum of priority fees for the range in ETH.
+    pub priority_fee: Option<f64>,
+    /// Sum of base fees for the range in ETH.
+    pub base_fee: Option<f64>,
+    /// Total prover cost for the range in ETH.
+    pub prove_cost: Option<f64>,
     /// Estimated infrastructure cost in USD for the requested range.
     pub cloud_cost: Option<f64>,
 }

--- a/crates/api/src/helpers/conversion.rs
+++ b/crates/api/src/helpers/conversion.rs
@@ -1,0 +1,23 @@
+//! Unit conversion helpers
+
+/// Convert wei to ETH with 4 decimal precision.
+pub fn wei_to_eth(value: u128) -> f64 {
+    let eth = value as f64 / 1e18_f64;
+    (eth * 1e4_f64).round() / 1e4_f64
+}
+
+/// Convert signed wei to ETH with 4 decimal precision.
+pub fn wei_to_eth_signed(value: i128) -> f64 {
+    let eth = value as f64 / 1e18_f64;
+    (eth * 1e4_f64).round() / 1e4_f64
+}
+
+/// Convert optional wei to ETH.
+pub fn opt_wei_to_eth(value: Option<u128>) -> Option<f64> {
+    value.map(wei_to_eth)
+}
+
+/// Convert optional signed wei to ETH.
+pub fn opt_wei_to_eth_signed(value: Option<i128>) -> Option<f64> {
+    value.map(wei_to_eth_signed)
+}

--- a/crates/api/src/helpers/mod.rs
+++ b/crates/api/src/helpers/mod.rs
@@ -1,5 +1,7 @@
 //! Helper functions for API operations
 
 pub mod aggregation;
+pub mod conversion;
 
 pub use aggregation::*;
+pub use conversion::*;

--- a/dashboard/components/CostChart.tsx
+++ b/dashboard/components/CostChart.tsx
@@ -51,8 +51,8 @@ export const CostChart: React.FC<CostChartProps> = ({
   const baseCostPerBatchEth = baseCostEth / feeData.length;
 
   const data = feeData.map((b) => {
-    const l1CostEth = (b.l1Cost ?? 0) / 1e18;
-    const proveEth = (b.amortizedProveCost ?? 0) / 1e18;
+    const l1CostEth = b.l1Cost ?? 0;
+    const proveEth = b.amortizedProveCost ?? 0;
     const verifyEth = 0;
     const costEth = baseCostPerBatchEth + proveEth + verifyEth + l1CostEth;
     const costUsd = costEth * ethPrice;

--- a/dashboard/components/EconomicsChart.tsx
+++ b/dashboard/components/EconomicsChart.tsx
@@ -51,10 +51,10 @@ export const EconomicsChart: React.FC<EconomicsChartProps> = ({
   const baseCostPerBatchEth = ethPrice ? baseCostPerBatchUsd / ethPrice : 0;
 
   const data = feeData.map((b) => {
-    const revenueEth = (b.priority + b.base) / 1e18;
-    const proveEth = (b.amortizedProveCost ?? 0) / 1e18;
+    const revenueEth = b.priority + b.base;
+    const proveEth = b.amortizedProveCost ?? 0;
     const verifyEth = 0;
-    const costEth = baseCostPerBatchEth + proveEth + verifyEth + (b.l1Cost ?? 0) / 1e18;
+    const costEth = baseCostPerBatchEth + proveEth + verifyEth + (b.l1Cost ?? 0);
     const profitEth = revenueEth - costEth;
     const revenueUsd = revenueEth * ethPrice;
     const costUsd = costEth * ethPrice;

--- a/dashboard/components/FeeFlowChart.tsx
+++ b/dashboard/components/FeeFlowChart.tsx
@@ -192,13 +192,13 @@ export const FeeFlowChart: React.FC<FeeFlowChartProps> = ({
   const safeValue = (value: number) => (isFinite(value) ? value : 0);
 
   // Convert fees to USD
-  const priorityFeeUsd = safeValue(((priorityFee ?? 0) / WEI_TO_ETH) * ethPrice);
-  const baseFeeUsd = safeValue(((baseFee ?? 0) / WEI_TO_ETH) * ethPrice);
+  const priorityFeeUsd = safeValue((priorityFee ?? 0) * ethPrice);
+  const baseFeeUsd = safeValue((baseFee ?? 0) * ethPrice);
   const l1DataCostTotalUsd = safeValue(
-    ((feeRes?.data?.l1_data_cost ?? 0) / WEI_TO_ETH) * ethPrice,
+    (feeRes?.data?.l1_data_cost ?? 0) * ethPrice,
   );
   const l1ProveCost = safeValue(
-    ((feeRes?.data?.prove_cost ?? 0) / WEI_TO_ETH) * ethPrice,
+    (feeRes?.data?.prove_cost ?? 0) * ethPrice,
   );
 
   const baseFeeDaoUsd = safeValue(baseFeeUsd * 0.25);
@@ -212,25 +212,25 @@ export const FeeFlowChart: React.FC<FeeFlowChartProps> = ({
   const totalHardwareCost = hardwareCostPerSeq * sequencerCount;
 
   const seqData = sequencerFees.map((f) => {
-    const priorityWei = f.priority_fee ?? 0;
-    const baseWei = (f.base_fee ?? 0) * 0.75;
-    const l1CostWei = f.l1_data_cost ?? 0;
-    const proveWei = f.prove_cost ?? 0;
+    const priorityEth = f.priority_fee ?? 0;
+    const baseEth = (f.base_fee ?? 0) * 0.75;
+    const l1CostEth = f.l1_data_cost ?? 0;
+    const proveEth = f.prove_cost ?? 0;
 
-    const priorityUsd = safeValue((priorityWei / WEI_TO_ETH) * ethPrice);
-    const baseUsd = safeValue((baseWei / WEI_TO_ETH) * ethPrice);
-    const l1CostUsd = safeValue((l1CostWei / WEI_TO_ETH) * ethPrice);
-    const proveUsd = safeValue((proveWei / WEI_TO_ETH) * ethPrice);
+    const priorityUsd = safeValue(priorityEth * ethPrice);
+    const baseUsd = safeValue(baseEth * ethPrice);
+    const l1CostUsd = safeValue(l1CostEth * ethPrice);
+    const proveUsd = safeValue(proveEth * ethPrice);
 
 
     const revenue = safeValue(priorityUsd + baseUsd);
-    const revenueWei = safeValue(priorityWei + baseWei);
+    const revenueWei = safeValue((priorityEth + baseEth) * WEI_TO_ETH);
 
     const { profitUsd, profitEth } = calculateProfit({
-      priorityFee: priorityWei,
+      priorityFee: priorityEth,
       baseFee: f.base_fee ?? 0,
-      l1DataCost: l1CostWei,
-      proveCost: proveWei,
+      l1DataCost: l1CostEth,
+      proveCost: proveEth,
 
       hardwareCostUsd: hardwareCostPerSeq,
       ethPrice,
@@ -301,15 +301,15 @@ export const FeeFlowChart: React.FC<FeeFlowChartProps> = ({
     remaining -= actualProveCost;
 
     const sequencerProfit = safeValue(Math.max(0, remaining));
-    const sequencerRevenueWei = safeValue((priorityFee ?? 0) + (baseFee ?? 0) * 0.75);
+    const sequencerRevenueWei = safeValue(((priorityFee ?? 0) + (baseFee ?? 0) * 0.75) * WEI_TO_ETH);
     const sequencerProfitWei = safeValue(
       ethPrice ? (sequencerProfit / ethPrice) * WEI_TO_ETH : 0,
     );
 
     nodes = [
       { name: 'Subsidy', value: l1Subsidy, usd: true },
-      { name: 'Priority Fee', value: priorityFeeUsd, wei: priorityFee ?? 0 },
-      { name: 'Base Fee', value: baseFeeUsd, wei: baseFee ?? 0 },
+      { name: 'Priority Fee', value: priorityFeeUsd, wei: (priorityFee ?? 0) * WEI_TO_ETH },
+      { name: 'Base Fee', value: baseFeeUsd, wei: (baseFee ?? 0) * WEI_TO_ETH },
       { name: 'Sequencers', value: sequencerRevenue, wei: sequencerRevenueWei },
       { name: 'Hardware Cost', value: totalHardwareCost, usd: true },
       { name: 'Propose Batch Cost', value: l1DataCostTotalUsd, usd: true },
@@ -395,8 +395,8 @@ export const FeeFlowChart: React.FC<FeeFlowChartProps> = ({
         value: s.subsidyUsd,
         usd: true,
       })),
-      { name: 'Priority Fee', value: priorityFeeUsd, wei: priorityFee ?? 0 },
-      { name: 'Base Fee', value: baseFeeUsd, wei: baseFee ?? 0 },
+      { name: 'Priority Fee', value: priorityFeeUsd, wei: (priorityFee ?? 0) * WEI_TO_ETH },
+      { name: 'Base Fee', value: baseFeeUsd, wei: (baseFee ?? 0) * WEI_TO_ETH },
       ...seqData.map((s) => ({
         name: '',
         address: s.address,

--- a/dashboard/components/IncomeChart.tsx
+++ b/dashboard/components/IncomeChart.tsx
@@ -40,7 +40,7 @@ export const RevenueChart: React.FC<RevenueChartProps> = ({
   }
 
   const data = feeData.map((b) => {
-    const revenueEth = (b.priority + b.base) / 1e18;
+    const revenueEth = b.priority + b.base;
     const revenueUsd = revenueEth * ethPrice;
     return { batch: b.batch, revenueEth, revenueUsd };
   });

--- a/dashboard/components/ProfitRankingTable.tsx
+++ b/dashboard/components/ProfitRankingTable.tsx
@@ -94,7 +94,7 @@ export const ProfitRankingTable: React.FC<ProfitRankingTableProps> = ({
     const addr = seq.address || getSequencerAddress(seq.name) || '';
     const batchCount = batchCounts?.get(addr.toLowerCase()) ?? null;
     const fees = feeDataMap.get(addr.toLowerCase());
-    const proveEth = (fees?.prove_cost ?? 0) / 1e18;
+    const proveEth = fees?.prove_cost ?? 0;
     const verifyEth = 0;
     const extraEth = proveEth + verifyEth;
     const extraUsd = extraEth * ethPrice;
@@ -114,8 +114,8 @@ export const ProfitRankingTable: React.FC<ProfitRankingTableProps> = ({
       };
     }
     const revenueEth =
-      ((fees.priority_fee ?? 0) + (fees.base_fee ?? 0) * 0.75) / 1e18;
-    const l1CostEth = (fees.l1_data_cost ?? 0) / 1e18;
+      (fees.priority_fee ?? 0) + (fees.base_fee ?? 0) * 0.75;
+    const l1CostEth = fees.l1_data_cost ?? 0;
     const revenueUsd = revenueEth * ethPrice;
     const l1CostUsd = l1CostEth * ethPrice;
     const costEth = costPerSeqEth + l1CostEth + extraEth;

--- a/dashboard/components/RevenueChart.tsx
+++ b/dashboard/components/RevenueChart.tsx
@@ -40,7 +40,7 @@ export const RevenueChart: React.FC<RevenueChartProps> = ({
   }
 
   const data = feeData.map((b) => {
-    const revenueEth = (b.priority + b.base) / 1e18;
+    const revenueEth = b.priority + b.base;
     const revenueUsd = revenueEth * ethPrice;
     return { batch: b.batch, revenueEth, revenueUsd };
   });

--- a/dashboard/tests/blockProfitTables.test.ts
+++ b/dashboard/tests/blockProfitTables.test.ts
@@ -13,8 +13,8 @@ const feeData = [
     batch: 1,
     l1Block: 1,
     sequencer: 'SeqA',
-    priority: 1e18,
-    base: 1e18,
+    priority: 1,
+    base: 1,
     l1Cost: 0,
     amortizedProveCost: 0,
 

--- a/dashboard/tests/helpers.test.ts
+++ b/dashboard/tests/helpers.test.ts
@@ -15,12 +15,12 @@ const metrics = createMetrics({
   forcedInclusions: 0,
   l2Block: 100,
   l1Block: 50,
-  priorityFee: 41e18,
-  baseFee: 1e18,
-  proveCost: 9e18,
+  priorityFee: 41,
+  baseFee: 1,
+  proveCost: 9,
 
-  l1DataCost: 2e18,
-  profit: 40e18,
+  l1DataCost: 2,
+  profit: 40,
 });
 
 const results = [

--- a/dashboard/tests/profit.test.ts
+++ b/dashboard/tests/profit.test.ts
@@ -4,10 +4,10 @@ import { calculateProfit } from '../utils/profit';
 describe('calculateProfit', () => {
   it('computes positive profit', () => {
     const res = calculateProfit({
-      priorityFee: 2e18,
-      baseFee: 1e18,
-      l1DataCost: 5e17,
-      proveCost: 1e17,
+      priorityFee: 2,
+      baseFee: 1,
+      l1DataCost: 0.5,
+      proveCost: 0.1,
 
       hardwareCostUsd: 100,
       ethPrice: 10,
@@ -22,7 +22,7 @@ describe('calculateProfit', () => {
     const res = calculateProfit({
       priorityFee: 0,
       baseFee: 0,
-      l1DataCost: 1e18,
+      l1DataCost: 1,
       proveCost: 0,
 
       hardwareCostUsd: 50,

--- a/dashboard/tests/profitRankingTable.test.ts
+++ b/dashboard/tests/profitRankingTable.test.ts
@@ -26,22 +26,22 @@ describe('ProfitRankingTable', () => {
       .mockReturnValueOnce({
         data: {
           data: {
-            priority_fee: 3e18,
-            base_fee: 1.5e18,
+            priority_fee: 3,
+            base_fee: 1.5,
             l1_data_cost: 0,
             prove_cost: 0,
             sequencers: [
               {
                 address: '0xseqA',
-                priority_fee: 2e18,
-                base_fee: 1e18,
+                priority_fee: 2,
+                base_fee: 1,
                 l1_data_cost: 0,
                 prove_cost: 0,
               },
               {
                 address: '0xseqB',
-                priority_fee: 1e18,
-                base_fee: 0.5e18,
+                priority_fee: 1,
+                base_fee: 0.5,
                 l1_data_cost: 0,
                 prove_cost: 0,
               },
@@ -66,22 +66,22 @@ describe('ProfitRankingTable', () => {
     } as RequestResult<SequencerDistributionDataItem[]>);
     vi.spyOn(api, 'fetchL2Fees').mockResolvedValue({
       data: {
-        priority_fee: 3e18,
-        base_fee: 1.5e18,
+        priority_fee: 3,
+        base_fee: 1.5,
         l1_data_cost: 0,
         prove_cost: 0,
         sequencers: [
           {
             address: '0xseqA',
-            priority_fee: 2e18,
-            base_fee: 1e18,
+            priority_fee: 2,
+            base_fee: 1,
             l1_data_cost: 0,
             prove_cost: 0,
           },
           {
             address: '0xseqB',
-            priority_fee: 1e18,
-            base_fee: 0.5e18,
+            priority_fee: 1,
+            base_fee: 0.5,
             l1_data_cost: 0,
             prove_cost: 0,
           },
@@ -131,14 +131,14 @@ describe('ProfitRankingTable', () => {
       .mockReturnValueOnce({
         data: {
           data: {
-            priority_fee: 1e18,
+            priority_fee: 1,
             base_fee: 0,
             l1_data_cost: 5e17,
             prove_cost: 1e16,
             sequencers: [
               {
                 address: '0xseqA',
-                priority_fee: 1e18,
+                priority_fee: 1,
                 base_fee: 0,
                 l1_data_cost: 5e17,
                 prove_cost: 1e16,
@@ -158,14 +158,14 @@ describe('ProfitRankingTable', () => {
     } as RequestResult<SequencerDistributionDataItem[]>);
     vi.spyOn(api, 'fetchL2Fees').mockResolvedValue({
       data: {
-        priority_fee: 1e18,
+        priority_fee: 1,
         base_fee: 0,
         l1_data_cost: 5e17,
         prove_cost: 1e16,
         sequencers: [
           {
             address: '0xseqA',
-            priority_fee: 1e18,
+            priority_fee: 1,
             base_fee: 0,
             l1_data_cost: 5e17,
             prove_cost: 1e16,

--- a/dashboard/utils/metricsCreator.ts
+++ b/dashboard/utils/metricsCreator.ts
@@ -116,27 +116,27 @@ export const createMetrics = (data: MetricInputData): MetricData[] => [
   },
   {
     title: 'Profit',
-    value: data.profit != null ? formatEth(data.profit, 3) : 'N/A',
+    value: data.profit != null ? formatEth(data.profit * 1e18, 3) : 'N/A',
     group: 'Network Economics',
   },
   {
     title: 'Priority Fee',
-    value: data.priorityFee != null ? formatEth(data.priorityFee, 3) : 'N/A',
+    value: data.priorityFee != null ? formatEth(data.priorityFee * 1e18, 3) : 'N/A',
     group: 'Network Economics',
   },
   {
     title: 'Base Fee',
-    value: data.baseFee != null ? formatEth(data.baseFee, 3) : 'N/A',
+    value: data.baseFee != null ? formatEth(data.baseFee * 1e18, 3) : 'N/A',
     group: 'Network Economics',
   },
   {
     title: 'Propose Batch Cost',
-    value: data.l1DataCost != null ? formatEth(data.l1DataCost, 3) : 'N/A',
+    value: data.l1DataCost != null ? formatEth(data.l1DataCost * 1e18, 3) : 'N/A',
     group: 'Network Economics',
   },
   {
     title: 'Prove Cost',
-    value: data.proveCost != null ? formatEth(data.proveCost, 3) : 'N/A',
+    value: data.proveCost != null ? formatEth(data.proveCost * 1e18, 3) : 'N/A',
     group: 'Network Economics',
   },
   {

--- a/dashboard/utils/profit.ts
+++ b/dashboard/utils/profit.ts
@@ -13,8 +13,6 @@ export interface ProfitResult {
   profitUsd: number;
 }
 
-const WEI_TO_ETH = 1e18;
-
 export const calculateProfit = ({
   priorityFee = 0,
   baseFee = 0,
@@ -23,11 +21,12 @@ export const calculateProfit = ({
   hardwareCostUsd,
   ethPrice,
 }: ProfitParams): ProfitResult => {
-  const revenueEth = ((priorityFee ?? 0) + (baseFee ?? 0) * 0.75) / WEI_TO_ETH;
+  const revenueEth = (priorityFee ?? 0) + (baseFee ?? 0) * 0.75;
   const revenueUsd = revenueEth * ethPrice;
   const costEth =
     hardwareCostUsd / ethPrice +
-    ((l1DataCost ?? 0) + (proveCost ?? 0)) / WEI_TO_ETH;
+    (l1DataCost ?? 0) +
+    (proveCost ?? 0);
   const costUsd = costEth * ethPrice;
   const profitUsd = revenueUsd - costUsd;
   const profitEth = revenueEth - costEth;

--- a/tests/api_integration.rs
+++ b/tests/api_integration.rs
@@ -103,9 +103,9 @@ async fn batch_fee_components_filters_unverified() {
             "batches": [
                 {
                     "batch_id": 1,
-                    "priority_fee": 10,
-                    "base_fee": 20,
-                    "l1_data_cost": 5,
+                    "priority_fee": 0.0,
+                    "base_fee": 0.0,
+                    "l1_data_cost": 0.0,
                     "amortized_prove_cost": null,
                     "amortized_verify_cost": null
                 }
@@ -365,7 +365,7 @@ async fn l2_fee_components_aggregated_integration() {
     let body: serde_json::Value = resp.json().await.unwrap();
     assert_eq!(
         body,
-        serde_json::json!({ "blocks": [ { "l2_block_number": 0, "priority_fee": 5, "base_fee": 8, "l1_data_cost": 3 } ] })
+        serde_json::json!({ "blocks": [ { "l2_block_number": 0, "priority_fee": 0.0, "base_fee": 0.0, "l1_data_cost": 0.0 } ] })
     );
 
     let resp = reqwest::get(
@@ -433,7 +433,7 @@ async fn block_profits_integration() {
     .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
     let body: serde_json::Value = resp.json().await.unwrap();
-    assert_eq!(body, serde_json::json!({ "blocks": [ { "block": 1, "profit": 12 } ] }));
+    assert_eq!(body, serde_json::json!({ "blocks": [ { "block": 1, "profit": 0.0 } ] }));
 
     let resp = reqwest::get(
         format!("http://{addr}/{API_VERSION}/block-profits?created[gte]=0&created[lte]=3600000&limit=1&order=asc"),
@@ -442,7 +442,7 @@ async fn block_profits_integration() {
     .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
     let body: serde_json::Value = resp.json().await.unwrap();
-    assert_eq!(body, serde_json::json!({ "blocks": [ { "block": 2, "profit": -6 } ] }));
+    assert_eq!(body, serde_json::json!({ "blocks": [ { "block": 2, "profit": 0.0 } ] }));
 
     server.abort();
 }
@@ -596,17 +596,17 @@ async fn l2_fees_integration() {
     assert_eq!(
         body,
         serde_json::json!({
-            "priority_fee": 600,
-            "base_fee": 400,
-            "l1_data_cost": 10,
-            "prove_cost": 5,
+            "priority_fee": 0.0,
+            "base_fee": 0.0,
+            "l1_data_cost": 0.0,
+            "prove_cost": 0.0,
             "sequencers": [
                 {
                     "address": format!("0x{}", hex::encode([1u8; 20])),
-                    "priority_fee": 600,
-                    "base_fee": 400,
-                    "l1_data_cost": 10,
-                    "prove_cost": 5
+                    "priority_fee": 0.0,
+                    "base_fee": 0.0,
+                    "l1_data_cost": 0.0,
+                    "prove_cost": 0.0
                 }
             ]
         })
@@ -648,17 +648,17 @@ async fn batch_fees_integration() {
     assert_eq!(
         body,
         serde_json::json!({
-            "priority_fee": 10,
-            "base_fee": 20,
-            "l1_data_cost": 5,
+            "priority_fee": 0.0,
+            "base_fee": 0.0,
+            "l1_data_cost": 0.0,
             "prove_cost": null,
             "sequencers": [
                 {
                     "address": format!("0x{}", hex::encode([2u8; 20])),
-                    "priority_fee": 10,
-                    "base_fee": 20,
-                    "l1_data_cost": 5,
-                    "prove_cost": 1
+                    "priority_fee": 0.0,
+                    "base_fee": 0.0,
+                    "l1_data_cost": 0.0,
+                    "prove_cost": 0.0
                 }
             ]
         })


### PR DESCRIPTION
## Summary
- convert API to return ETH values instead of wei
- update dashboard to consume ETH amounts
- fix related tests and helpers

## Testing
- `just lint`
- `just test` *(passed)*
- `just check-dashboard`
- `just test-dashboard` *(failed: network errors)*

------
https://chatgpt.com/codex/tasks/task_b_6863cca5ec208328a16414bb8d8dda36