### PR TITLE
Display time in tooltips using short format

### DIFF
--- a/dashboard/components/BatchProcessChart.tsx
+++ b/dashboard/components/BatchProcessChart.tsx
@@ -12,9 +12,9 @@ import { useIsMobile } from '../hooks/useIsMobile';
 import { TimeSeriesData } from '../types';
 import {
   formatDecimal,
-  formatBatchDuration,
   computeBatchDurationFlags,
   formatHoursMinutes,
+  formatSeconds,
 } from '../utils';
 
 interface BatchProcessChartProps {
@@ -36,8 +36,7 @@ const BatchProcessChartComponent: React.FC<BatchProcessChartProps> = ({
   }
 
   const { showHours, showMinutes } = computeBatchDurationFlags(data);
-  const formatValue = (value: number) =>
-    formatBatchDuration(value, showHours, showMinutes);
+  const formatValue = (value: number) => formatSeconds(value);
 
   return (
     <ResponsiveContainer width="100%" height="100%">

--- a/dashboard/components/BlockTimeChart.tsx
+++ b/dashboard/components/BlockTimeChart.tsx
@@ -14,7 +14,7 @@ import { useIsMobile } from '../hooks/useIsMobile';
 import { TimeSeriesData } from '../types';
 import {
   formatDecimal,
-  formatInterval,
+  formatSeconds,
   computeIntervalFlags,
   formatDateTime,
   formatHoursMinutes,
@@ -95,11 +95,7 @@ const BlockTimeChartComponent: React.FC<BlockTimeChartProps> = ({
             return `Block ${label.toLocaleString()} (${timeStr})`;
           }}
           formatter={(value: number) => [
-            formatInterval(
-              seconds ? value : value / 1000,
-              showHours,
-              showMinutes,
-            ),
+            formatSeconds(seconds ? value : value / 1000),
           ]}
           contentStyle={{
             backgroundColor: 'rgba(255, 255, 255, 0.8)',

--- a/dashboard/components/BlockTimeDistributionChart.tsx
+++ b/dashboard/components/BlockTimeDistributionChart.tsx
@@ -9,7 +9,7 @@ import {
   ResponsiveContainer,
 } from 'recharts';
 import { TimeSeriesData } from '../types';
-import { formatInterval, shouldShowMinutes } from '../utils';
+import { formatInterval, formatSeconds, shouldShowMinutes } from '../utils';
 
 // Constants for histogram configuration
 const MIN_BIN_COUNT = 5;
@@ -125,7 +125,7 @@ const BlockTimeDistributionChartComponent: React.FC<
         />
         <Tooltip
           labelFormatter={(label: number) =>
-            formatInterval(label, false, showMinutes)
+            formatSeconds(label)
           }
           formatter={(value: number) => [value.toLocaleString(), 'blocks']}
           contentStyle={{


### PR DESCRIPTION
## Summary
- use `formatSeconds` in block time and batch charts
- show durations like `2:01h` and `25:58m` in chart tooltips

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6863f24547948328b4c239229de6f738