### PR TITLE
Remove unused amortized verify check

### DIFF
--- a/tests/api_integration.rs
+++ b/tests/api_integration.rs
@@ -106,8 +106,7 @@ async fn batch_fee_components_filters_unverified() {
                     "priority_fee": 10,
                     "base_fee": 20,
                     "l1_data_cost": 5,
-                    "amortized_prove_cost": null,
-                    "amortized_verify_cost": null
+                    "amortized_prove_cost": null
                 }
             ]
         })
@@ -485,8 +484,7 @@ async fn batch_fee_components_integration() {
                     "priority_fee": 10,
                     "base_fee": 20,
                     "l1_data_cost": 5,
-                    "amortized_prove_cost": null,
-                    "amortized_verify_cost": null
+                    "amortized_prove_cost": null
                 }
             ]
         })


### PR DESCRIPTION
## Summary
- update batch-fee-components tests
- clean up expected JSON to no longer mention amortized_verify_cost

## Testing
- `just test`
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_6863fa03670c832882224a1f74a849aa