### PR TITLE
Remove l1Block from BatchFeeComponent

### DIFF
--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -851,7 +851,6 @@ export interface FeeComponent {
 
 export interface BatchFeeComponent {
   batch: number;
-  l1Block: number;
   txHash: string;
   sequencer: string;
   priority: number;
@@ -913,7 +912,6 @@ export const fetchBatchFeeComponents = async (
     data: res.data
       ? res.data.batches.map((b) => ({
         batch: b.batch_id,
-        l1Block: b.l1_block_number,
         txHash: b.l1_tx_hash,
         sequencer: getSequencerName(b.sequencer),
         priority: b.priority_fee,


### PR DESCRIPTION
## Summary
- remove `l1Block` property from `BatchFeeComponent` in `apiService`
- drop mapping of `l1Block` when retrieving batch fee components

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6864efcd61c083289fd09597915179c1