### PR TITLE
Fix profit calculation excluding DAO fee

### DIFF
--- a/dashboard/hooks/useDataFetcher.ts
+++ b/dashboard/hooks/useDataFetcher.ts
@@ -83,7 +83,7 @@ export const useDataFetcher = ({
             data.l1DataCost != null &&
             data.proveCost != null
             ? data.priorityFee +
-            data.baseFee -
+            data.baseFee * 0.75 -
             data.l1DataCost -
             data.proveCost
             : null,


### PR DESCRIPTION
## Summary
- exclude Taiko DAO share from `profit` metric in data fetcher

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_686642a136c0832885af3f8c1d5c2de4