### PR TITLE
Fix dashboard ETH unit handling

### DIFF
--- a/dashboard/components/BlockProfitTables.tsx
+++ b/dashboard/components/BlockProfitTables.tsx
@@ -53,7 +53,7 @@ export const BlockProfitTables: React.FC<BlockProfitTablesProps> = ({
       hardwareCostUsd: operationalCostPerBatchUsd,
       ethPrice,
     });
-    const profitWei = profitEth * 1e18;
+    const profitWei = profitEth * 1e9;
 
     return {
       batch: b.batch,

--- a/dashboard/components/CostChart.tsx
+++ b/dashboard/components/CostChart.tsx
@@ -51,8 +51,8 @@ export const CostChart: React.FC<CostChartProps> = ({
   const baseCostPerBatchEth = baseCostEth / feeData.length;
 
   const data = feeData.map((b) => {
-    const l1CostEth = (b.l1Cost ?? 0) / 1e18;
-    const proveEth = (b.amortizedProveCost ?? 0) / 1e18;
+    const l1CostEth = (b.l1Cost ?? 0) / 1e9;
+    const proveEth = (b.amortizedProveCost ?? 0) / 1e9;
     const verifyEth = 0;
     const costEth = baseCostPerBatchEth + proveEth + verifyEth + l1CostEth;
     const costUsd = costEth * ethPrice;
@@ -86,7 +86,7 @@ export const CostChart: React.FC<CostChartProps> = ({
             stroke="#666666"
             fontSize={12}
             domain={['auto', 'auto']}
-            tickFormatter={(v: number) => formatEth(v * 1e18, 3)}
+            tickFormatter={(v: number) => formatEth(v * 1e9, 3)}
             label={{
               value: 'Cost (ETH)',
               angle: -90,
@@ -99,7 +99,7 @@ export const CostChart: React.FC<CostChartProps> = ({
           <Tooltip
             labelFormatter={(v: number) => `Batch ${v}`}
             formatter={(value: number, _name: string, { payload }: Payload<number, string>) =>
-              [`${formatEth(value * 1e18, 3)} ($${payload.costUsd.toFixed(3)})`, 'Cost']
+              [`${formatEth(value * 1e9, 3)} ($${payload.costUsd.toFixed(3)})`, 'Cost']
             }
             contentStyle={{
               backgroundColor: 'rgba(255,255,255,0.8)',

--- a/dashboard/components/EconomicsChart.tsx
+++ b/dashboard/components/EconomicsChart.tsx
@@ -51,10 +51,10 @@ export const EconomicsChart: React.FC<EconomicsChartProps> = ({
   const baseCostPerBatchEth = ethPrice ? baseCostPerBatchUsd / ethPrice : 0;
 
   const data = feeData.map((b) => {
-    const revenueEth = (b.priority + b.base) / 1e18;
-    const proveEth = (b.amortizedProveCost ?? 0) / 1e18;
+    const revenueEth = (b.priority + b.base) / 1e9;
+    const proveEth = (b.amortizedProveCost ?? 0) / 1e9;
     const verifyEth = 0;
-    const costEth = baseCostPerBatchEth + proveEth + verifyEth + (b.l1Cost ?? 0) / 1e18;
+    const costEth = baseCostPerBatchEth + proveEth + verifyEth + (b.l1Cost ?? 0) / 1e9;
     const profitEth = revenueEth - costEth;
     const revenueUsd = revenueEth * ethPrice;
     const costUsd = costEth * ethPrice;
@@ -98,7 +98,7 @@ export const EconomicsChart: React.FC<EconomicsChartProps> = ({
             stroke="#666666"
             fontSize={12}
             domain={['auto', 'auto']}
-            tickFormatter={(v: number) => formatEth(v * 1e18, 3)}
+            tickFormatter={(v: number) => formatEth(v * 1e9, 3)}
             label={{
               value: 'ETH',
               angle: -90,
@@ -116,16 +116,16 @@ export const EconomicsChart: React.FC<EconomicsChartProps> = ({
             formatter={(value: number, name: string, { payload }: Payload<number, string>) => {
               if (name === 'Revenue')
                 return [
-                  `${formatEth(value * 1e18, 3)} ($${payload.revenueUsd.toFixed(3)})`,
+                  `${formatEth(value * 1e9, 3)} ($${payload.revenueUsd.toFixed(3)})`,
                   name,
                 ];
               if (name === 'Cost')
                 return [
-                  `${formatEth(value * 1e18, 3)} ($${payload.costUsd.toFixed(3)})`,
+                  `${formatEth(value * 1e9, 3)} ($${payload.costUsd.toFixed(3)})`,
                   name,
                 ];
               return [
-                `${formatEth(value * 1e18, 3)} ($${payload.profitUsd.toFixed(3)})`,
+                `${formatEth(value * 1e9, 3)} ($${payload.profitUsd.toFixed(3)})`,
                 name,
               ];
             }}

--- a/dashboard/components/FeeFlowChart.tsx
+++ b/dashboard/components/FeeFlowChart.tsx
@@ -24,7 +24,7 @@ interface FeeFlowChartProps {
 }
 
 const MONTH_HOURS = 30 * 24;
-const WEI_TO_ETH = 1e18;
+const WEI_TO_ETH = 1e9;
 
 // Format numbers as USD without grouping
 const formatUsd = (value: number) => `$${value.toFixed(1)}`;

--- a/dashboard/components/IncomeChart.tsx
+++ b/dashboard/components/IncomeChart.tsx
@@ -40,7 +40,7 @@ export const RevenueChart: React.FC<RevenueChartProps> = ({
   }
 
   const data = feeData.map((b) => {
-    const revenueEth = (b.priority + b.base) / 1e18;
+    const revenueEth = (b.priority + b.base) / 1e9;
     const revenueUsd = revenueEth * ethPrice;
     return { batch: b.batch, revenueEth, revenueUsd };
   });
@@ -72,7 +72,7 @@ export const RevenueChart: React.FC<RevenueChartProps> = ({
             stroke="#666666"
             fontSize={12}
             domain={['auto', 'auto']}
-            tickFormatter={(v: number) => formatEth(v * 1e18, 3)}
+            tickFormatter={(v: number) => formatEth(v * 1e9, 3)}
             label={{
               value: 'Revenue (ETH)',
               angle: -90,
@@ -85,7 +85,7 @@ export const RevenueChart: React.FC<RevenueChartProps> = ({
           <Tooltip
             labelFormatter={(v: number) => `Batch ${v}`}
             formatter={(value: number, _name: string, { payload }: Payload<number, string>) =>
-              [`${formatEth(value * 1e18, 3)} ($${payload.revenueUsd.toFixed(3)})`, 'Revenue']
+              [`${formatEth(value * 1e9, 3)} ($${payload.revenueUsd.toFixed(3)})`, 'Revenue']
             }
             contentStyle={{
               backgroundColor: 'rgba(255,255,255,0.8)',

--- a/dashboard/components/ProfitRankingTable.tsx
+++ b/dashboard/components/ProfitRankingTable.tsx
@@ -94,7 +94,7 @@ export const ProfitRankingTable: React.FC<ProfitRankingTableProps> = ({
     const addr = seq.address || getSequencerAddress(seq.name) || '';
     const batchCount = batchCounts?.get(addr.toLowerCase()) ?? null;
     const fees = feeDataMap.get(addr.toLowerCase());
-    const proveEth = (fees?.prove_cost ?? 0) / 1e18;
+    const proveEth = (fees?.prove_cost ?? 0) / 1e9;
     const verifyEth = 0;
     const extraEth = proveEth + verifyEth;
     const extraUsd = extraEth * ethPrice;
@@ -114,8 +114,8 @@ export const ProfitRankingTable: React.FC<ProfitRankingTableProps> = ({
       };
     }
     const revenueEth =
-      ((fees.priority_fee ?? 0) + (fees.base_fee ?? 0) * 0.75) / 1e18;
-    const l1CostEth = (fees.l1_data_cost ?? 0) / 1e18;
+      ((fees.priority_fee ?? 0) + (fees.base_fee ?? 0) * 0.75) / 1e9;
+    const l1CostEth = (fees.l1_data_cost ?? 0) / 1e9;
     const revenueUsd = revenueEth * ethPrice;
     const l1CostUsd = l1CostEth * ethPrice;
     const costEth = costPerSeqEth + l1CostEth + extraEth;
@@ -317,11 +317,11 @@ export const ProfitRankingTable: React.FC<ProfitRankingTableProps> = ({
                   }
                 >
                   {row.revenueEth != null
-                    ? formatEth(row.revenueEth * 1e18, 3)
+                    ? formatEth(row.revenueEth * 1e9, 3)
                     : 'N/A'}
                 </td>
                 <td className="px-2 py-1" title={`$${formatUsd(row.costUsd)}`}>
-                  {formatEth(row.costEth * 1e18, 3)}
+                  {formatEth(row.costEth * 1e9, 3)}
                 </td>
                 <td
                   className="px-2 py-1"
@@ -332,7 +332,7 @@ export const ProfitRankingTable: React.FC<ProfitRankingTableProps> = ({
                   }
                 >
                   {row.profitEth != null
-                    ? formatEth(row.profitEth * 1e18, 3)
+                    ? formatEth(row.profitEth * 1e9, 3)
                     : 'N/A'}
                 </td>
                 <td className="px-2 py-1">

--- a/dashboard/components/ProfitabilityChart.tsx
+++ b/dashboard/components/ProfitabilityChart.tsx
@@ -90,7 +90,7 @@ export const ProfitabilityChart: React.FC<ProfitabilityChartProps> = ({
             stroke="#666666"
             fontSize={12}
             domain={['auto', 'auto']}
-            tickFormatter={(v: number) => formatEth(v * 1e18, 3)}
+            tickFormatter={(v: number) => formatEth(v * 1e9, 3)}
             label={{
               value: ' (ETH)',
               angle: -90,
@@ -103,7 +103,7 @@ export const ProfitabilityChart: React.FC<ProfitabilityChartProps> = ({
           <Tooltip
             labelFormatter={(v: number) => `Batch ${v}`}
             formatter={(value: number, _name: string, { payload }: Payload<number, string>) =>
-              [`${formatEth(value * 1e18, 3)} ($${payload.profitUsd.toFixed(3)})`, 'Profit']
+              [`${formatEth(value * 1e9, 3)} ($${payload.profitUsd.toFixed(3)})`, 'Profit']
             }
             contentStyle={{
               backgroundColor: 'rgba(255,255,255,0.8)',

--- a/dashboard/components/RevenueChart.tsx
+++ b/dashboard/components/RevenueChart.tsx
@@ -40,7 +40,7 @@ export const RevenueChart: React.FC<RevenueChartProps> = ({
   }
 
   const data = feeData.map((b) => {
-    const revenueEth = (b.priority + b.base) / 1e18;
+    const revenueEth = (b.priority + b.base) / 1e9;
     const revenueUsd = revenueEth * ethPrice;
     return { batch: b.batch, revenueEth, revenueUsd };
   });
@@ -72,7 +72,7 @@ export const RevenueChart: React.FC<RevenueChartProps> = ({
             stroke="#666666"
             fontSize={12}
             domain={['auto', 'auto']}
-            tickFormatter={(v: number) => formatEth(v * 1e18, 3)}
+            tickFormatter={(v: number) => formatEth(v * 1e9, 3)}
             label={{
               value: 'Revenue (ETH)',
               angle: -90,
@@ -85,7 +85,7 @@ export const RevenueChart: React.FC<RevenueChartProps> = ({
           <Tooltip
             labelFormatter={(v: number) => `Batch ${v}`}
             formatter={(value: number, _name: string, { payload }: Payload<number, string>) =>
-              [`${formatEth(value * 1e18, 3)} ($${payload.revenueUsd.toFixed(3)})`, 'Revenue']
+              [`${formatEth(value * 1e9, 3)} ($${payload.revenueUsd.toFixed(3)})`, 'Revenue']
             }
             contentStyle={{
               backgroundColor: 'rgba(255,255,255,0.8)',

--- a/dashboard/components/views/DashboardView.tsx
+++ b/dashboard/components/views/DashboardView.tsx
@@ -97,7 +97,7 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
     const sequencerCount = chartsData.sequencerDistribution.length || 1;
     const costUsd =
       ((cloudCost + proverCost) * sequencerCount) / HOURS_IN_MONTH * hours;
-    const costWei = ethPrice > 0 ? (costUsd / ethPrice) * 1e18 : null;
+    const costWei = ethPrice > 0 ? (costUsd / ethPrice) * 1e9 : null;
     const hardwareMetric: MetricData = {
       title: 'Hardware Costs',
       value: costWei != null ? formatEth(costWei, 3) : 'N/A',
@@ -112,7 +112,7 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
       const profitIdx = list.findIndex((m) => m.title === 'Profit');
       if (profitIdx >= 0) {
         const profitEth = parseEthValue(list[profitIdx].value);
-        const profitWei = profitEth * 1e18;
+        const profitWei = profitEth * 1e9;
         const newProfitWei = profitWei - costWei;
         list[profitIdx] = {
           ...list[profitIdx],

--- a/dashboard/tests/blockProfitTables.test.ts
+++ b/dashboard/tests/blockProfitTables.test.ts
@@ -13,8 +13,8 @@ const feeData = [
     batch: 1,
     txHash: '0x00',
     sequencer: 'SeqA',
-    priority: 1e18,
-    base: 1e18,
+    priority: 1e9,
+    base: 1e9,
     l1Cost: 0,
     amortizedProveCost: 0,
 

--- a/dashboard/tests/helpers.test.ts
+++ b/dashboard/tests/helpers.test.ts
@@ -15,12 +15,12 @@ const metrics = createMetrics({
   forcedInclusions: 0,
   l2Block: 100,
   l1Block: 50,
-  priorityFee: 41e18,
-  baseFee: 1e18,
-  proveCost: 9e18,
+  priorityFee: 41e9,
+  baseFee: 1e9,
+  proveCost: 9e9,
 
-  l1DataCost: 2e18,
-  profit: 40e18,
+  l1DataCost: 2e9,
+  profit: 40e9,
 });
 
 const results = [

--- a/dashboard/tests/l1DataCostMap.test.ts
+++ b/dashboard/tests/l1DataCostMap.test.ts
@@ -5,7 +5,7 @@ describe('l1-data-cost mapData', () => {
   const mapData = TABLE_CONFIGS['l1-data-cost'].mapData!;
 
   it('formats block number as link and cost as ETH', () => {
-    const rows = mapData([{ block: 100, cost: 42e18 }]);
+    const rows = mapData([{ block: 100, cost: 42e9 }]);
 
     // value should be React element from blockLink
     expect(typeof rows[0].block).toBe('object');

--- a/dashboard/tests/metricsCreator.test.ts
+++ b/dashboard/tests/metricsCreator.test.ts
@@ -18,12 +18,12 @@ describe('metricsCreator', () => {
       l2Reorgs: 1,
       slashings: 2,
       forcedInclusions: 3,
-      priorityFee: 40e18,
-      baseFee: 2e18,
-      proveCost: 5e18,
+      priorityFee: 40e9,
+      baseFee: 2e9,
+      proveCost: 5e9,
 
-      l1DataCost: 3e18,
-      profit: 39e18,
+      l1DataCost: 3e9,
+      profit: 39e9,
       l2Block: 100,
       l1Block: 50,
     });

--- a/dashboard/tests/profit.test.ts
+++ b/dashboard/tests/profit.test.ts
@@ -4,10 +4,10 @@ import { calculateProfit } from '../utils/profit';
 describe('calculateProfit', () => {
   it('computes positive profit', () => {
     const res = calculateProfit({
-      priorityFee: 2e18,
-      baseFee: 1e18,
-      l1DataCost: 5e17,
-      proveCost: 1e17,
+      priorityFee: 2e9,
+      baseFee: 1e9,
+      l1DataCost: 5e8,
+      proveCost: 1e8,
 
       hardwareCostUsd: 100,
       ethPrice: 10,
@@ -22,7 +22,7 @@ describe('calculateProfit', () => {
     const res = calculateProfit({
       priorityFee: 0,
       baseFee: 0,
-      l1DataCost: 1e18,
+      l1DataCost: 1e9,
       proveCost: 0,
 
       hardwareCostUsd: 50,

--- a/dashboard/tests/profitRankingTable.test.ts
+++ b/dashboard/tests/profitRankingTable.test.ts
@@ -26,22 +26,22 @@ describe('ProfitRankingTable', () => {
       .mockReturnValueOnce({
         data: {
           data: {
-            priority_fee: 3e18,
-            base_fee: 1.5e18,
+            priority_fee: 3e9,
+            base_fee: 1.5e9,
             l1_data_cost: 0,
             prove_cost: 0,
             sequencers: [
               {
                 address: '0xseqA',
-                priority_fee: 2e18,
-                base_fee: 1e18,
+                priority_fee: 2e9,
+                base_fee: 1e9,
                 l1_data_cost: 0,
                 prove_cost: 0,
               },
               {
                 address: '0xseqB',
-                priority_fee: 1e18,
-                base_fee: 0.5e18,
+                priority_fee: 1e9,
+                base_fee: 0.5e9,
                 l1_data_cost: 0,
                 prove_cost: 0,
               },
@@ -66,22 +66,22 @@ describe('ProfitRankingTable', () => {
     } as RequestResult<SequencerDistributionDataItem[]>);
     vi.spyOn(api, 'fetchL2Fees').mockResolvedValue({
       data: {
-        priority_fee: 3e18,
-        base_fee: 1.5e18,
+        priority_fee: 3e9,
+        base_fee: 1.5e9,
         l1_data_cost: 0,
         prove_cost: 0,
         sequencers: [
           {
             address: '0xseqA',
-            priority_fee: 2e18,
-            base_fee: 1e18,
+            priority_fee: 2e9,
+            base_fee: 1e9,
             l1_data_cost: 0,
             prove_cost: 0,
           },
           {
             address: '0xseqB',
-            priority_fee: 1e18,
-            base_fee: 0.5e18,
+            priority_fee: 1e9,
+            base_fee: 0.5e9,
             l1_data_cost: 0,
             prove_cost: 0,
           },
@@ -123,25 +123,25 @@ describe('ProfitRankingTable', () => {
         } as RequestResult<SequencerDistributionDataItem[]>,
       } as unknown as ReturnType<typeof swr.default>)
       .mockReturnValueOnce({
-        data: new Map([['0xseqa', 1e16]]),
+        data: new Map([['0xseqa', 1e7]]),
       } as unknown as ReturnType<typeof swr.default>)
       .mockReturnValueOnce({
-        data: new Map([['0xseqa', 2e16]]),
+        data: new Map([['0xseqa', 2e7]]),
       } as unknown as ReturnType<typeof swr.default>)
       .mockReturnValueOnce({
         data: {
           data: {
-            priority_fee: 1e18,
+            priority_fee: 1e9,
             base_fee: 0,
-            l1_data_cost: 5e17,
-            prove_cost: 1e16,
+            l1_data_cost: 5e8,
+            prove_cost: 1e7,
             sequencers: [
               {
                 address: '0xseqA',
-                priority_fee: 1e18,
+                priority_fee: 1e9,
                 base_fee: 0,
-                l1_data_cost: 5e17,
-                prove_cost: 1e16,
+                l1_data_cost: 5e8,
+                prove_cost: 1e7,
               },
             ],
           },
@@ -158,17 +158,17 @@ describe('ProfitRankingTable', () => {
     } as RequestResult<SequencerDistributionDataItem[]>);
     vi.spyOn(api, 'fetchL2Fees').mockResolvedValue({
       data: {
-        priority_fee: 1e18,
+        priority_fee: 1e9,
         base_fee: 0,
-        l1_data_cost: 5e17,
-        prove_cost: 1e16,
+        l1_data_cost: 5e8,
+        prove_cost: 1e7,
         sequencers: [
           {
             address: '0xseqA',
-            priority_fee: 1e18,
+            priority_fee: 1e9,
             base_fee: 0,
-            l1_data_cost: 5e17,
-            prove_cost: 1e16,
+            l1_data_cost: 5e8,
+            prove_cost: 1e7,
           },
         ],
       },

--- a/dashboard/tests/proveCostMap.test.ts
+++ b/dashboard/tests/proveCostMap.test.ts
@@ -5,7 +5,7 @@ describe('prove-cost mapData', () => {
   const mapData = TABLE_CONFIGS['prove-cost'].mapData!;
 
   it('formats batch number and cost correctly', () => {
-    const rows = mapData([{ batch: 1000, cost: 42e18 }]);
+    const rows = mapData([{ batch: 1000, cost: 42e9 }]);
     expect(rows[0].batch).toBe('1,000');
     expect(rows[0].cost).toBe('42 ETH');
   });

--- a/dashboard/tests/utils.test.ts
+++ b/dashboard/tests/utils.test.ts
@@ -130,20 +130,20 @@ describe('utils', () => {
   });
 
   it('formats ETH amounts', () => {
-    expect(formatEth(42e18)).toBe('42 ETH');
+    expect(formatEth(42e9)).toBe('42 ETH');
     expect(formatEth(0)).toBe('0 ETH');
-    expect(formatEth(1e8)).toBe('0 ETH');
-    expect(formatEth(1334501e9)).toBe('0.001 ETH');
-    expect(formatEth(1422636.1e9)).toBe('0.001 ETH');
-    expect(formatEth(1422636.1e18)).toBe('1,422,636 ETH');
-    expect(formatEth(187788.9e9)).toBe('0 ETH');
-    expect(formatEth(-1e8)).toBe('0 ETH');
-    expect(formatEth(-345678.9e9)).toBe('0 ETH');
-    expect(formatEth(-1.2345e18)).toBe('-1.2 ETH');
-    expect(formatEth(0.01e18)).toBe('0.01 ETH');
-    expect(formatEth(0.012e18)).toBe('0.012 ETH');
-    expect(formatEth(-0.04e18)).toBe('-0.04 ETH');
-    expect(formatEth(1e18, 3)).toBe('1 ETH');
+    expect(formatEth(0.1)).toBe('0 ETH');
+    expect(formatEth(1334501)).toBe('0.001 ETH');
+    expect(formatEth(1422636.1)).toBe('0.001 ETH');
+    expect(formatEth(1422636.1e9)).toBe('1,422,636 ETH');
+    expect(formatEth(187788.9)).toBe('0 ETH');
+    expect(formatEth(-0.1)).toBe('0 ETH');
+    expect(formatEth(-345678.9)).toBe('0 ETH');
+    expect(formatEth(-1.2345e9)).toBe('-1.2 ETH');
+    expect(formatEth(0.01e9)).toBe('0.01 ETH');
+    expect(formatEth(0.012e9)).toBe('0.012 ETH');
+    expect(formatEth(-0.04e9)).toBe('-0.04 ETH');
+    expect(formatEth(1e9, 3)).toBe('1 ETH');
   });
 
   it('parses ETH values', () => {

--- a/dashboard/utils.ts
+++ b/dashboard/utils.ts
@@ -139,7 +139,7 @@ export const formatWithCommas = (value: number): string =>
   value.toLocaleString();
 
 export const formatEth = (wei: number, decimals?: number): string => {
-  const eth = wei / 1e18;
+  const eth = wei / 1e9;
   if (Math.abs(eth) >= 1000) {
     return `${Math.trunc(eth).toLocaleString()} ETH`;
   }

--- a/dashboard/utils/profit.ts
+++ b/dashboard/utils/profit.ts
@@ -13,7 +13,7 @@ export interface ProfitResult {
   profitUsd: number;
 }
 
-const WEI_TO_ETH = 1e18;
+const WEI_TO_ETH = 1e9;
 
 export const calculateProfit = ({
   priorityFee = 0,


### PR DESCRIPTION
## Summary
- adjust `formatEth` to divide by 1e9
- update profit calculations to expect gwei inputs
- replace 1e18 divisors/multipliers across dashboard components
- convert hardware/profit calculations to use gwei
- update unit tests for gwei amounts

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_686642bef7308328a91295bc688133c0