### PR TITLE
Add revenue and cost columns

### DIFF
--- a/dashboard/components/BlockProfitTables.tsx
+++ b/dashboard/components/BlockProfitTables.tsx
@@ -81,16 +81,16 @@ export const BlockProfitTables: React.FC<BlockProfitTablesProps> = ({
     title: string,
     items:
       | {
-          batch: number;
-          txHash: string;
-          sequencer: string;
-          revenue: number;
-          cost: number;
-          profit: number;
-          profitEth: number;
-          revenueEth: number;
-          costEth: number;
-        }[]
+        batch: number;
+        txHash: string;
+        sequencer: string;
+        revenue: number;
+        cost: number;
+        profit: number;
+        profitEth: number;
+        revenueEth: number;
+        costEth: number;
+      }[]
       | null,
   ) => (
     <div>
@@ -143,7 +143,7 @@ export const BlockProfitTables: React.FC<BlockProfitTablesProps> = ({
   );
 
   return (
-    <div className="mt-6 grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6">
+    <div className="mt-6 grid grid-cols-1 gap-4 md:gap-6">
       {renderTable('Top 5 Profitable Batches', topBatches)}
       {renderTable('Least 5 Profitable Batches', bottomBatches)}
     </div>

--- a/dashboard/components/BlockProfitTables.tsx
+++ b/dashboard/components/BlockProfitTables.tsx
@@ -44,7 +44,7 @@ export const BlockProfitTables: React.FC<BlockProfitTablesProps> = ({
     : 0;
 
   const profits = batchData.map((b) => {
-    const { profitEth } = calculateProfit({
+    const { revenueEth, costEth, profitEth } = calculateProfit({
       priorityFee: b.priority,
       baseFee: b.base,
       l1DataCost: b.l1Cost ?? 0,
@@ -54,13 +54,19 @@ export const BlockProfitTables: React.FC<BlockProfitTablesProps> = ({
       ethPrice,
     });
     const profitWei = profitEth * 1e9;
+    const revenueWei = revenueEth * 1e9;
+    const costWei = costEth * 1e9;
 
     return {
       batch: b.batch,
       txHash: b.txHash,
       sequencer: b.sequencer,
+      revenue: revenueWei,
+      cost: costWei,
       profit: profitWei, // Store as wei for consistency
       profitEth, // Store ETH value for sorting and display
+      revenueEth,
+      costEth,
     };
   });
 
@@ -74,7 +80,17 @@ export const BlockProfitTables: React.FC<BlockProfitTablesProps> = ({
   const renderTable = (
     title: string,
     items:
-      | { batch: number; txHash: string; sequencer: string; profit: number; profitEth: number }[]
+      | {
+          batch: number;
+          txHash: string;
+          sequencer: string;
+          revenue: number;
+          cost: number;
+          profit: number;
+          profitEth: number;
+          revenueEth: number;
+          costEth: number;
+        }[]
       | null,
   ) => (
     <div>
@@ -85,6 +101,8 @@ export const BlockProfitTables: React.FC<BlockProfitTablesProps> = ({
             <tr>
               <th className="px-2 py-1 text-left">Batch</th>
               <th className="px-2 py-1 text-left">Sequencer</th>
+              <th className="px-2 py-1 text-left">Revenue</th>
+              <th className="px-2 py-1 text-left">Cost</th>
               <th className="px-2 py-1 text-left">Profit</th>
             </tr>
           </thead>
@@ -98,6 +116,18 @@ export const BlockProfitTables: React.FC<BlockProfitTablesProps> = ({
                   {l1TxLink(b.txHash, b.batch.toLocaleString())}
                 </td>
                 <td className="px-2 py-1">{b.sequencer}</td>
+                <td
+                  className="px-2 py-1"
+                  title={`$${formatUsd(b.revenueEth * ethPrice)}`}
+                >
+                  {formatEth(b.revenue, 3)}
+                </td>
+                <td
+                  className="px-2 py-1"
+                  title={`$${formatUsd(b.costEth * ethPrice)}`}
+                >
+                  {formatEth(b.cost, 3)}
+                </td>
                 <td
                   className="px-2 py-1"
                   title={`$${formatUsd(b.profitEth * ethPrice)}`}

--- a/dashboard/tests/profit.test.ts
+++ b/dashboard/tests/profit.test.ts
@@ -12,9 +12,11 @@ describe('calculateProfit', () => {
       hardwareCostUsd: 100,
       ethPrice: 10,
     });
-    expect(res.profitEth).toBeCloseTo(
-      (2 + 0.75) - (100 / 10 + (0.5 + 0.1))
-    );
+    expect(res.revenueEth).toBeCloseTo(2.75);
+    expect(res.costEth).toBeCloseTo(10.6);
+    expect(res.profitEth).toBeCloseTo(2.75 - 10.6);
+    expect(res.revenueUsd).toBeCloseTo(27.5);
+    expect(res.costUsd).toBeCloseTo(106);
     expect(res.profitUsd).toBeCloseTo(res.profitEth * 10);
   });
 
@@ -28,7 +30,11 @@ describe('calculateProfit', () => {
       hardwareCostUsd: 50,
       ethPrice: 5,
     });
-    expect(res.profitEth).toBeCloseTo(-((50 / 5) + 1));
-    expect(res.profitUsd).toBeCloseTo(res.profitEth * 5);
+    expect(res.revenueEth).toBeCloseTo(0);
+    expect(res.costEth).toBeCloseTo(11);
+    expect(res.profitEth).toBeCloseTo(-11);
+    expect(res.revenueUsd).toBeCloseTo(0);
+    expect(res.costUsd).toBeCloseTo(55);
+    expect(res.profitUsd).toBeCloseTo(-55);
   });
 });

--- a/dashboard/utils/profit.ts
+++ b/dashboard/utils/profit.ts
@@ -9,6 +9,10 @@ export interface ProfitParams {
 }
 
 export interface ProfitResult {
+  revenueEth: number;
+  revenueUsd: number;
+  costEth: number;
+  costUsd: number;
   profitEth: number;
   profitUsd: number;
 }
@@ -31,5 +35,12 @@ export const calculateProfit = ({
   const costUsd = costEth * ethPrice;
   const profitUsd = revenueUsd - costUsd;
   const profitEth = revenueEth - costEth;
-  return { profitEth, profitUsd };
+  return {
+    revenueEth,
+    revenueUsd,
+    costEth,
+    costUsd,
+    profitEth,
+    profitUsd,
+  };
 };


### PR DESCRIPTION
## Summary
- expose revenue and cost information from `calculateProfit`
- display revenue and cost columns in block profit tables
- verify calculations with updated profit tests

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68664b4d779883289d93e238b44f83ee