### PR TITLE
Fix minute display label

### DIFF
--- a/dashboard/components/DashboardHeader.tsx
+++ b/dashboard/components/DashboardHeader.tsx
@@ -316,8 +316,8 @@ export const RefreshRateInput: React.FC<RefreshRateInputProps> = ({
 }) => {
   const options = [
     { label: '60s', value: 60_000 },
-    { label: '5 min', value: 5 * 60_000 },
-    { label: '10 min', value: 10 * 60_000 },
+    { label: '5 mins', value: 5 * 60_000 },
+    { label: '10 mins', value: 10 * 60_000 },
   ];
 
   const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {

--- a/dashboard/tests/utils.extra.test.ts
+++ b/dashboard/tests/utils.extra.test.ts
@@ -18,7 +18,7 @@ describe('extra utils', () => {
     it.each([
       [0, '0.00s'],
       [119, '119.0s'],
-      [120, '2:00m'],
+      [120, '2:00min'],
       [7200, '2:00h'],
     ])('formats %p seconds to %p', (input, expected) => {
       expect(formatSeconds(input)).toBe(expected);

--- a/dashboard/tests/utils.extra.test.ts
+++ b/dashboard/tests/utils.extra.test.ts
@@ -18,7 +18,7 @@ describe('extra utils', () => {
     it.each([
       [0, '0.00s'],
       [119, '119.0s'],
-      [120, '2:00min'],
+      [120, '2:00mins'],
       [7200, '2:00h'],
     ])('formats %p seconds to %p', (input, expected) => {
       expect(formatSeconds(input)).toBe(expected);

--- a/dashboard/tests/utils.test.ts
+++ b/dashboard/tests/utils.test.ts
@@ -26,7 +26,7 @@ describe('utils', () => {
     expect(formatDecimal(12.345)).toBe('12.3');
 
     expect(formatSeconds(30)).toBe('30.0s');
-    expect(formatSeconds(150)).toBe('2:30min');
+    expect(formatSeconds(150)).toBe('2:30mins');
     expect(formatSeconds(7200)).toBe('2:00h');
     expect(formatHoursMinutes(9000)).toBe('2:30');
 

--- a/dashboard/tests/utils.test.ts
+++ b/dashboard/tests/utils.test.ts
@@ -26,7 +26,7 @@ describe('utils', () => {
     expect(formatDecimal(12.345)).toBe('12.3');
 
     expect(formatSeconds(30)).toBe('30.0s');
-    expect(formatSeconds(150)).toBe('2:30m');
+    expect(formatSeconds(150)).toBe('2:30min');
     expect(formatSeconds(7200)).toBe('2:00h');
     expect(formatHoursMinutes(9000)).toBe('2:30');
 

--- a/dashboard/utils.ts
+++ b/dashboard/utils.ts
@@ -105,7 +105,7 @@ export const formatMinutesSeconds = (seconds: number): string => {
   const secs = Math.floor(seconds);
   const mins = Math.floor(secs / 60);
   const rem = secs % 60;
-  return `${mins}:${rem.toString().padStart(2, '0')}m`;
+  return `${mins}:${rem.toString().padStart(2, '0')}min`;
 };
 
 export const formatSeconds = (seconds: number): string => {

--- a/dashboard/utils.ts
+++ b/dashboard/utils.ts
@@ -105,7 +105,7 @@ export const formatMinutesSeconds = (seconds: number): string => {
   const secs = Math.floor(seconds);
   const mins = Math.floor(secs / 60);
   const rem = secs % 60;
-  return `${mins}:${rem.toString().padStart(2, '0')}min`;
+  return `${mins}:${rem.toString().padStart(2, '0')}mins`;
 };
 
 export const formatSeconds = (seconds: number): string => {


### PR DESCRIPTION
## Summary
- show `min` instead of `m` for minute based durations
- adjust associated tests

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68668845aa788328a3e9a3e07f0e675a