### PR TITLE
Rename dashboard heading

### DIFF
--- a/dashboard/components/views/DashboardView.tsx
+++ b/dashboard/components/views/DashboardView.tsx
@@ -356,7 +356,7 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
               height={400}
             />
             <div className="mt-6">
-              <h3 className="text-lg font-semibold mb-2">Cost & Revenue Trends</h3>
+              <h3 className="text-lg font-semibold mb-2">PnL Trend per Batch</h3>
               <EconomicsChart
                 timeRange={timeRange}
                 cloudCost={cloudCost}


### PR DESCRIPTION
## Summary
- rename "Cost & Revenue Trends" to "PnL Trend per Batch" on the dashboard

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68668acdac0483288ebb58e5742fd5f7