### PR TITLE
Add Chainbound links to dashboard footer

### DIFF
--- a/dashboard/components/DashboardFooter.tsx
+++ b/dashboard/components/DashboardFooter.tsx
@@ -58,5 +58,28 @@ export const DashboardFooter: React.FC<DashboardFooterProps> = ({
         </p>
       </div>
     </div>
+    <div className="mt-4 text-sm text-gray-500 dark:text-gray-400 text-center">
+      Made by Chainbound
+      <span className="mx-2">|</span>
+      <a
+        href="https://x.com/chainbound_"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="hover:underline"
+        style={{ color: TAIKO_PINK }}
+      >
+        X
+      </a>
+      <span className="mx-1">|</span>
+      <a
+        href="https://github.com/chainbound/taikoscope/"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="hover:underline"
+        style={{ color: TAIKO_PINK }}
+      >
+        GitHub
+      </a>
+    </div>
   </footer>
 );

--- a/dashboard/tests/dashboardFooter.test.ts
+++ b/dashboard/tests/dashboardFooter.test.ts
@@ -17,5 +17,8 @@ describe('DashboardFooter', () => {
     expect(html.includes('3,951,872')).toBe(true);
     expect(html.includes('/block/409253')).toBe(true);
     expect(html.includes('/block/3951872')).toBe(true);
+    expect(html.includes('Made by Chainbound')).toBe(true);
+    expect(html.includes('https://x.com/chainbound_')).toBe(true);
+    expect(html.includes('https://github.com/chainbound/taikoscope/')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- show credits to Chainbound in the dashboard footer
- link to Chainbound's X profile and GitHub repository
- update footer tests

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_686689cbc9c883288d332dcfb9c34e7f