### PR TITLE
Center footer block headers

### DIFF
--- a/dashboard/components/DashboardFooter.tsx
+++ b/dashboard/components/DashboardFooter.tsx
@@ -12,7 +12,7 @@ export const DashboardFooter: React.FC<DashboardFooterProps> = ({
   l1HeadBlock,
 }) => (
   <footer className="mt-8 px-4 py-6 md:px-6 lg:px-8 border-t border-gray-200 dark:border-gray-700">
-    <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-center md:text-left">
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-center">
       <div>
         <span className="text-sm text-gray-500 dark:text-gray-400">
           L2 Head Block


### PR DESCRIPTION
## Summary
- keep L1 and L2 head block indicators centered in the dashboard footer

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_686691b04888832884ea8856e5029fac