### PR TITLE
Add Chainbound link to footer

### DIFF
--- a/dashboard/components/DashboardFooter.tsx
+++ b/dashboard/components/DashboardFooter.tsx
@@ -59,7 +59,16 @@ export const DashboardFooter: React.FC<DashboardFooterProps> = ({
       </div>
     </div>
     <div className="mt-4 text-sm text-gray-500 dark:text-gray-400 text-center">
-      Made by Chainbound
+      Made by{' '}
+      <a
+        href="https://chainbound.io/"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="hover:underline"
+        style={{ color: TAIKO_PINK }}
+      >
+        Chainbound
+      </a>
       <span className="mx-2">|</span>
       <a
         href="https://x.com/chainbound_"

--- a/dashboard/tests/dashboardFooter.test.ts
+++ b/dashboard/tests/dashboardFooter.test.ts
@@ -17,8 +17,11 @@ describe('DashboardFooter', () => {
     expect(html.includes('3,951,872')).toBe(true);
     expect(html.includes('/block/409253')).toBe(true);
     expect(html.includes('/block/3951872')).toBe(true);
-    expect(html.includes('Made by Chainbound')).toBe(true);
+    expect(html.includes('Made by')).toBe(true);
+    expect(html.includes('https://chainbound.io/')).toBe(true);
     expect(html.includes('https://x.com/chainbound_')).toBe(true);
-    expect(html.includes('https://github.com/chainbound/taikoscope/')).toBe(true);
+    expect(html.includes('https://github.com/chainbound/taikoscope/')).toBe(
+      true,
+    );
   });
 });


### PR DESCRIPTION
## Summary
- link Chainbound name in dashboard footer to website
- update dashboard footer tests

## Testing
- `just check-dashboard`
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_686695e03b908328bc5bae21764f3551