### PR TITLE
Hide sequencer selector in economics view

### DIFF
--- a/dashboard/components/DashboardHeader.tsx
+++ b/dashboard/components/DashboardHeader.tsx
@@ -57,6 +57,7 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({
   const { navigateToDashboard, updateSearchParams } = useRouterNavigation();
   const { errorMessage } = useErrorHandler();
   const [searchParams] = useSearchParams();
+  const isEconomicsView = searchParams.get('view') === 'economics';
   React.useEffect(() => {
     if (errorMessage) {
       showToast(errorMessage);
@@ -115,11 +116,13 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({
           lastRefresh={lastRefresh}
           onRefresh={onManualRefresh}
         />
-        <SequencerSelector
-          sequencers={sequencers}
-          value={selectedSequencer}
-          onChange={onSequencerChange}
-        />
+        {!isEconomicsView && (
+          <SequencerSelector
+            sequencers={sequencers}
+            value={selectedSequencer}
+            onChange={onSequencerChange}
+          />
+        )}
         {/* Dark mode toggle removed as per request */}
       </div>
     </header>

--- a/dashboard/tests/dashboardHeader.test.ts
+++ b/dashboard/tests/dashboardHeader.test.ts
@@ -41,7 +41,7 @@ describe('DashboardHeader', () => {
     expect(html.includes('Economics')).toBe(true);
   });
 
-  it('shows sequencer selector in economics view', () => {
+  it('hides sequencer selector in economics view', () => {
     const html = renderToStaticMarkup(
       React.createElement(
         ThemeProvider,
@@ -67,6 +67,6 @@ describe('DashboardHeader', () => {
         ),
       ),
     );
-    expect(html.includes('All Sequencers')).toBe(true);
+    expect(html.includes('All Sequencers')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- hide sequencer selector when the economics view is active
- update header test

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68669a0d28f88328b2ae4dd3292a260c