### PR TITLE
Remove L2 Block Times table

### DIFF
--- a/dashboard/components/layout/ChartsGrid.tsx
+++ b/dashboard/components/layout/ChartsGrid.tsx
@@ -131,11 +131,7 @@ export const ChartsGrid: React.FC<ChartsGridProps> = ({
           barColor="#A0CBE8"
         />
       </ChartCard>
-      <ChartCard
-        title="L2 Block Time Distribution"
-        onMore={() => onOpenTable('l2-block-times', timeRange)}
-        loading={isLoading}
-      >
+      <ChartCard title="L2 Block Time Distribution" loading={isLoading}>
         <BlockTimeDistributionChart
           key={timeRange}
           data={chartsData.l2BlockTimeData}

--- a/dashboard/components/routes/TableRoute.tsx
+++ b/dashboard/components/routes/TableRoute.tsx
@@ -115,9 +115,7 @@ export const TableRoute: React.FC = () => {
             fetcherArgs.push(address);
             extraParams.address = address;
           }
-        } else if (
-          ['l2-block-times', 'l2-gas-used', 'l2-tps'].includes(tableType)
-        ) {
+        } else if (['l2-gas-used', 'l2-tps'].includes(tableType)) {
           fetcherArgs.push(
             selectedSequencer
               ? getSequencerAddress(selectedSequencer)

--- a/dashboard/components/views/DashboardView.tsx
+++ b/dashboard/components/views/DashboardView.tsx
@@ -271,7 +271,6 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
       <ChartCard
         key="block-times"
         title="L2 Block Time Distribution"
-        onMore={() => onOpenTable('l2-block-times', timeRange)}
         loading={isLoadingData}
       >
         <BlockTimeDistributionChart

--- a/dashboard/config/tableConfig.ts
+++ b/dashboard/config/tableConfig.ts
@@ -18,8 +18,6 @@ import {
   fetchVerifyTimesAggregated,
   fetchAllBlockTransactions,
   fetchBlockTransactionsAggregated,
-  fetchL2BlockTimes,
-  fetchL2BlockTimesAggregated,
   fetchL2GasUsed,
   fetchL2GasUsedAggregated,
   fetchL1DataCost,
@@ -216,35 +214,6 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
     supportsPagination: true,
   },
 
-  'l2-block-times': {
-    title: 'L2 Block Times',
-    description: 'Interval between consecutive L2 blocks.',
-    fetcher: fetchL2BlockTimes,
-    aggregatedFetcher: fetchL2BlockTimesAggregated,
-    columns: [
-      { key: 'value', label: 'L2 Block Number' },
-      { key: 'timestamp', label: 'Interval (s)' },
-    ],
-    mapData: (data) =>
-      (data as { value: number; timestamp: number }[]).map((d) => ({
-        value: blockLink(d.value),
-        timestamp: d.timestamp.toLocaleString(),
-      })),
-    chart: (data) => {
-      const BlockTimeDistributionChart = React.lazy(() =>
-        import('../components/BlockTimeDistributionChart').then((m) => ({
-          default: m.BlockTimeDistributionChart,
-        })),
-      );
-      return React.createElement(BlockTimeDistributionChart, {
-        data,
-        barColor: '#FAA43A',
-      });
-    },
-    urlKey: 'l2-block-times',
-    reverseOrder: false,
-    supportsPagination: true,
-  },
 
   'l2-gas-used': {
     title: 'Gas Used Per Block',


### PR DESCRIPTION
## Summary
- remove `l2-block-times` table definition
- drop references to this table in layouts and routing

## Testing
- `just lint`
- `just lint-dashboard`
- `just test`
- `just check-dashboard`
- `just test-dashboard`
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_68678e35e9a08328ad5d9474eadf851c