### PR TITLE
style(dashboard): emphasize economics button

### DIFF
--- a/dashboard/components/DashboardHeader.tsx
+++ b/dashboard/components/DashboardHeader.tsx
@@ -87,7 +87,7 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({
             }
             updateSearchParams({ view: 'economics', table: null });
           }}
-          className="text-sm hover:underline"
+          className="px-2 py-1 text-sm border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700"
           style={{ color: TAIKO_PINK }}
         >
           Economics


### PR DESCRIPTION
## Summary
- highlight Economics as a real button using borders and background styles

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_68669a2d718c83288f8829d9dfdbdbdd