### PR TITLE
Increase precision in economics view

### DIFF
--- a/dashboard/components/BlockProfitTables.tsx
+++ b/dashboard/components/BlockProfitTables.tsx
@@ -120,19 +120,19 @@ export const BlockProfitTables: React.FC<BlockProfitTablesProps> = ({
                   className="px-2 py-1"
                   title={`$${formatUsd(b.revenueEth * ethPrice)}`}
                 >
-                  {formatEth(b.revenue, 3)}
+                  {formatEth(b.revenue, 4)}
                 </td>
                 <td
                   className="px-2 py-1"
                   title={`$${formatUsd(b.costEth * ethPrice)}`}
                 >
-                  {formatEth(b.cost, 3)}
+                  {formatEth(b.cost, 4)}
                 </td>
                 <td
                   className="px-2 py-1"
                   title={`$${formatUsd(b.profitEth * ethPrice)}`}
                 >
-                  {formatEth(b.profit, 3)}
+                  {formatEth(b.profit, 4)}
                 </td>
               </tr>
             ))}

--- a/dashboard/components/EconomicsChart.tsx
+++ b/dashboard/components/EconomicsChart.tsx
@@ -98,7 +98,7 @@ export const EconomicsChart: React.FC<EconomicsChartProps> = ({
             stroke="#666666"
             fontSize={12}
             domain={['auto', 'auto']}
-            tickFormatter={(v: number) => formatEth(v * 1e9, 3)}
+            tickFormatter={(v: number) => formatEth(v * 1e9, 4)}
             label={{
               value: 'ETH',
               angle: -90,
@@ -116,16 +116,16 @@ export const EconomicsChart: React.FC<EconomicsChartProps> = ({
             formatter={(value: number, name: string, { payload }: Payload<number, string>) => {
               if (name === 'Revenue')
                 return [
-                  `${formatEth(value * 1e9, 3)} ($${payload.revenueUsd.toFixed(3)})`,
+                  `${formatEth(value * 1e9, 4)} ($${payload.revenueUsd.toFixed(3)})`,
                   name,
                 ];
               if (name === 'Cost')
                 return [
-                  `${formatEth(value * 1e9, 3)} ($${payload.costUsd.toFixed(3)})`,
+                  `${formatEth(value * 1e9, 4)} ($${payload.costUsd.toFixed(3)})`,
                   name,
                 ];
               return [
-                `${formatEth(value * 1e9, 3)} ($${payload.profitUsd.toFixed(3)})`,
+                `${formatEth(value * 1e9, 4)} ($${payload.profitUsd.toFixed(3)})`,
                 name,
               ];
             }}

--- a/dashboard/components/FeeFlowChart.tsx
+++ b/dashboard/components/FeeFlowChart.tsx
@@ -190,13 +190,13 @@ export const FeeFlowChart: React.FC<FeeFlowChartProps> = ({
 
       // If the item already has a `wei` value, use it directly
       if (itemData?.wei != null) {
-        return `${formatEth(itemData.wei, 3)} (${usd})`;
+        return `${formatEth(itemData.wei, 4)} (${usd})`;
       }
 
       // Otherwise, attempt to derive `wei` from USD using the current ETH price
       if (ethPrice) {
         const wei = (value / ethPrice) * WEI_TO_ETH;
-        return `${formatEth(wei, 3)} (${usd})`;
+        return `${formatEth(wei, 4)} (${usd})`;
       }
 
       // Fallback (should rarely happen): return USD only
@@ -210,13 +210,13 @@ export const FeeFlowChart: React.FC<FeeFlowChartProps> = ({
     (value: number, itemData?: any) => {
       // If the item already has a `wei` value, use it directly
       if (itemData?.wei != null) {
-        return formatEth(itemData.wei, 3);
+        return formatEth(itemData.wei, 4);
       }
 
       // Otherwise, attempt to derive `wei` from USD using the current ETH price
       if (ethPrice) {
         const wei = (value / ethPrice) * WEI_TO_ETH;
-        return formatEth(wei, 3);
+        return formatEth(wei, 4);
       }
 
       // Fallback (should rarely happen): return USD only

--- a/dashboard/components/ProfitRankingTable.tsx
+++ b/dashboard/components/ProfitRankingTable.tsx
@@ -317,11 +317,11 @@ export const ProfitRankingTable: React.FC<ProfitRankingTableProps> = ({
                   }
                 >
                   {row.revenueEth != null
-                    ? formatEth(row.revenueEth * 1e9, 3)
+                    ? formatEth(row.revenueEth * 1e9, 4)
                     : 'N/A'}
                 </td>
                 <td className="px-2 py-1" title={`$${formatUsd(row.costUsd)}`}>
-                  {formatEth(row.costEth * 1e9, 3)}
+                  {formatEth(row.costEth * 1e9, 4)}
                 </td>
                 <td
                   className="px-2 py-1"
@@ -332,7 +332,7 @@ export const ProfitRankingTable: React.FC<ProfitRankingTableProps> = ({
                   }
                 >
                   {row.profitEth != null
-                    ? formatEth(row.profitEth * 1e9, 3)
+                    ? formatEth(row.profitEth * 1e9, 4)
                     : 'N/A'}
                 </td>
                 <td className="px-2 py-1">

--- a/dashboard/components/views/DashboardView.tsx
+++ b/dashboard/components/views/DashboardView.tsx
@@ -100,7 +100,7 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
     const costWei = ethPrice > 0 ? (costUsd / ethPrice) * 1e9 : null;
     const hardwareMetric: MetricData = {
       title: 'Hardware Costs',
-      value: costWei != null ? formatEth(costWei, 3) : 'N/A',
+      value: costWei != null ? formatEth(costWei, 4) : 'N/A',
       group: 'Network Economics',
     };
     const idx = metricsData.metrics.findIndex((m) => m.title === 'Prove Cost');
@@ -118,7 +118,7 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
         const newProfitWei = profitWei - costWei;
         list[profitIdx] = {
           ...list[profitIdx],
-          value: formatEth(newProfitWei, 3),
+          value: formatEth(newProfitWei, 4),
         };
       }
     }

--- a/dashboard/config/tableConfig.ts
+++ b/dashboard/config/tableConfig.ts
@@ -256,7 +256,7 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
     mapData: (data) =>
       (data as { block: number; cost: number }[]).map((d) => ({
         block: blockLink(d.block),
-        cost: formatEth(d.cost, 3),
+        cost: formatEth(d.cost, 4),
       })),
     urlKey: 'l1-data-cost',
     supportsPagination: true,
@@ -273,7 +273,7 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
     mapData: (data) =>
       (data as { batch: number; cost: number }[]).map((d) => ({
         batch: d.batch.toLocaleString(),
-        cost: formatEth(d.cost, 3),
+        cost: formatEth(d.cost, 4),
       })),
     urlKey: 'prove-cost',
     supportsPagination: true,

--- a/dashboard/utils/metricsCreator.ts
+++ b/dashboard/utils/metricsCreator.ts
@@ -116,28 +116,28 @@ export const createMetrics = (data: MetricInputData): MetricData[] => [
   },
   {
     title: 'Net Sequencer Profit',
-    value: data.profit != null ? formatEth(data.profit, 3) : 'N/A',
+    value: data.profit != null ? formatEth(data.profit, 4) : 'N/A',
     group: 'Network Economics',
     tooltip: 'Sequencer profit minus subsidy.',
   },
   {
     title: 'Priority Fee',
-    value: data.priorityFee != null ? formatEth(data.priorityFee, 3) : 'N/A',
+    value: data.priorityFee != null ? formatEth(data.priorityFee, 4) : 'N/A',
     group: 'Network Economics',
   },
   {
     title: 'Base Fee',
-    value: data.baseFee != null ? formatEth(data.baseFee, 3) : 'N/A',
+    value: data.baseFee != null ? formatEth(data.baseFee, 4) : 'N/A',
     group: 'Network Economics',
   },
   {
     title: 'Proposing Cost',
-    value: data.l1DataCost != null ? formatEth(data.l1DataCost, 3) : 'N/A',
+    value: data.l1DataCost != null ? formatEth(data.l1DataCost, 4) : 'N/A',
     group: 'Network Economics',
   },
   {
     title: 'Prove Cost',
-    value: data.proveCost != null ? formatEth(data.proveCost, 3) : 'N/A',
+    value: data.proveCost != null ? formatEth(data.proveCost, 4) : 'N/A',
     group: 'Network Economics',
   },
   {


### PR DESCRIPTION
## Summary
- show 4 decimal places for ETH amounts in the economics view
- update block and profit tables
- increase precision in economic charts and metrics

## Testing
- `VITE_NETWORK_NAME=Masaya NETWORK_NAME=Masaya just ci`

------
https://chatgpt.com/codex/tasks/task_b_68679b896b708328ae6c01a5b86eb6ee