### PR TITLE
Update pagination tests for mutually exclusive params

### DIFF
--- a/tests/api_integration.rs
+++ b/tests/api_integration.rs
@@ -694,7 +694,7 @@ async fn l1_data_cost_paginated() {
     wait_for_server(addr).await;
 
     let resp = reqwest::get(format!(
-        "http://{addr}/{API_VERSION}/l1-data-cost?starting_after=0&ending_before=2&limit=1"
+        "http://{addr}/{API_VERSION}/l1-data-cost?starting_after=0&limit=1"
     ))
     .await
     .unwrap();
@@ -706,6 +706,27 @@ async fn l1_data_cost_paginated() {
             "blocks": [ { "l1_block_number": 1, "cost": 789 } ]
         })
     );
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn l1_data_cost_pagination_both_params_returns_400() {
+    let mock = Mock::new();
+
+    let url = Url::parse(mock.url()).unwrap();
+    let client =
+        ClickhouseReader::new(url, "test-db".to_owned(), "user".into(), "pass".into()).unwrap();
+
+    let (addr, server) = spawn_server(client).await;
+    wait_for_server(addr).await;
+
+    let resp = reqwest::get(format!(
+        "http://{addr}/{API_VERSION}/l1-data-cost?starting_after=0&ending_before=10&limit=1"
+    ))
+    .await
+    .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
 
     server.abort();
 }

--- a/tests/pagination.rs
+++ b/tests/pagination.rs
@@ -165,14 +165,14 @@ async fn reorgs_endpoint_returns_items_with_pagination() {
     let mock = Mock::new();
     mock.add(handlers::provide(vec![
         RawRow {
-            l2_block_number: 9,
+            l2_block_number: 12,
             depth: 1,
             old_sequencer: AddressBytes::from(Address::repeat_byte(1)),
             new_sequencer: AddressBytes::from(Address::repeat_byte(2)),
             ts: 1000,
         },
         RawRow {
-            l2_block_number: 8,
+            l2_block_number: 11,
             depth: 2,
             old_sequencer: AddressBytes::from(Address::repeat_byte(3)),
             new_sequencer: AddressBytes::from(Address::repeat_byte(4)),
@@ -197,14 +197,14 @@ async fn reorgs_endpoint_returns_items_with_pagination() {
     let expected = serde_json::json!({
         "events": [
             {
-                "l2_block_number": 8,
+                "l2_block_number": 11,
                 "depth": 2,
                 "old_sequencer": "0x0303030303030303030303030303030303030303",
                 "new_sequencer": "0x0404040404040404040404040404040404040404",
                 "inserted_at": Utc.timestamp_millis_opt(2000).single().unwrap().to_rfc3339()
             },
             {
-                "l2_block_number": 9,
+                "l2_block_number": 12,
                 "depth": 1,
                 "old_sequencer": "0x0101010101010101010101010101010101010101",
                 "new_sequencer": "0x0202020202020202020202020202020202020202",


### PR DESCRIPTION
## Summary
- update pagination-related integration tests to avoid using both `starting_after` and `ending_before`
- ensure requests providing both parameters now return 400

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6867a801ddc483289c112a9350b610c9