### PR TITLE
Refine buckets for blob chart

### DIFF
--- a/crates/api/src/helpers/aggregation.rs
+++ b/crates/api/src/helpers/aggregation.rs
@@ -47,6 +47,15 @@ pub const fn verify_bucket_size(range: &TimeRange) -> u64 {
     if size == 0 { 1 } else { size }
 }
 
+/// Determine bucket size for blobs-per-batch aggregation. Uses a slightly
+/// smaller bucket than [`bucket_size_from_range`] so that charts show more
+/// detail without overwhelming the client.
+pub const fn blobs_bucket_size(range: &TimeRange) -> u64 {
+    let base = bucket_size_from_range(range);
+    let size = base / 5;
+    if size == 0 { 1 } else { size }
+}
+
 /// Aggregate L2 block times by bucket size
 pub fn aggregate_l2_block_times(rows: Vec<L2BlockTimeRow>, bucket: u64) -> Vec<L2BlockTimeRow> {
     let bucket = bucket.max(1);
@@ -426,6 +435,12 @@ mod tests {
     fn test_verify_bucket_size_smaller() {
         let range = TimeRange::Custom(6 * 3600); // 6 hours
         assert_eq!(verify_bucket_size(&range), 1); // base 5 / 25 = 0 -> 1
+    }
+
+    #[test]
+    fn test_blobs_bucket_size_smaller() {
+        let range = TimeRange::Custom(12 * 3600); // 12 hours
+        assert_eq!(blobs_bucket_size(&range), 2); // base 10 / 5 = 2
     }
 
     // Tests for aggregate_l2_block_times

--- a/crates/api/src/routes/aggregated.rs
+++ b/crates/api/src/routes/aggregated.rs
@@ -4,8 +4,8 @@ use crate::{
     helpers::{
         aggregate_batch_fee_components, aggregate_blobs_per_batch, aggregate_block_transactions,
         aggregate_l2_block_times, aggregate_l2_fee_components, aggregate_l2_gas_used,
-        aggregate_l2_tps, aggregate_prove_times, aggregate_verify_times, bucket_size_from_range,
-        prove_bucket_size, verify_bucket_size,
+        aggregate_l2_tps, aggregate_prove_times, aggregate_verify_times, blobs_bucket_size,
+        bucket_size_from_range, prove_bucket_size, verify_bucket_size,
     },
     state::{ApiState, MAX_BLOCK_TRANSACTIONS_LIMIT},
     validation::{
@@ -913,7 +913,7 @@ pub async fn blobs_per_batch_aggregated(
         }
     };
 
-    let bucket = bucket_size_from_range(&time_range);
+    let bucket = blobs_bucket_size(&time_range);
     let batches = aggregate_blobs_per_batch(batches, bucket);
     tracing::info!(count = batches.len(), "Returning aggregated blobs per batch");
     Ok(Json(AvgBatchBlobsResponse { batches }))


### PR DESCRIPTION
## Summary
- compute a specific bucket size for blobs per batch aggregation
- use that bucket size in the endpoint
- add unit test

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6867b0353d088328bc54372f07994813