### PR TITLE
Add pagination filters to block range queries

### DIFF
--- a/crates/api/src/routes/table.rs
+++ b/crates/api/src/routes/table.rs
@@ -119,23 +119,24 @@ pub async fn l2_tps(
     };
     let end_block = params.block_range.block_lt.or(params.block_range.block_lte);
 
-    let mut blocks = match state.client.get_l2_tps_block_range(None, start_block, end_block).await {
+    let blocks = match state
+        .client
+        .get_l2_tps_block_range(
+            None,
+            start_block,
+            end_block,
+            limit,
+            params.starting_after,
+            params.ending_before,
+        )
+        .await
+    {
         Ok(rows) => rows,
         Err(e) => {
             tracing::error!("Failed to get L2 TPS: {}", e);
             return Err(ErrorResponse::database_error());
         }
     };
-    if let Some(start) = params.starting_after {
-        blocks.retain(|b| b.l2_block_number < start);
-    }
-    if let Some(end) = params.ending_before {
-        blocks.retain(|b| b.l2_block_number > end);
-    }
-    blocks.sort_by(|a, b| b.l2_block_number.cmp(&a.l2_block_number));
-    if blocks.len() > limit as usize {
-        blocks.truncate(limit as usize);
-    }
     tracing::info!(count = blocks.len(), "Returning L2 TPS");
     Ok(Json(L2TpsResponse { blocks }))
 }
@@ -182,25 +183,24 @@ pub async fn l2_block_times(
     };
     let end_block = params.block_range.block_lt.or(params.block_range.block_lte);
 
-    let mut rows =
-        match state.client.get_l2_block_times_block_range(None, start_block, end_block).await {
-            Ok(r) => r,
-            Err(e) => {
-                tracing::error!(error = %e, "Failed to get L2 block times");
-                return Err(ErrorResponse::database_error());
-            }
-        };
-
-    if let Some(start) = params.starting_after {
-        rows.retain(|b| b.l2_block_number < start);
-    }
-    if let Some(end) = params.ending_before {
-        rows.retain(|b| b.l2_block_number > end);
-    }
-    rows.sort_by(|a, b| b.l2_block_number.cmp(&a.l2_block_number));
-    if rows.len() > limit as usize {
-        rows.truncate(limit as usize);
-    }
+    let rows = match state
+        .client
+        .get_l2_block_times_block_range(
+            None,
+            start_block,
+            end_block,
+            limit,
+            params.starting_after,
+            params.ending_before,
+        )
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::error!(error = %e, "Failed to get L2 block times");
+            return Err(ErrorResponse::database_error());
+        }
+    };
 
     tracing::info!(count = rows.len(), "Returning table L2 block times");
     Ok(Json(L2BlockTimesResponse { blocks: rows }))
@@ -248,25 +248,24 @@ pub async fn l2_gas_used(
     };
     let end_block = params.block_range.block_lt.or(params.block_range.block_lte);
 
-    let mut rows =
-        match state.client.get_l2_gas_used_block_range(None, start_block, end_block).await {
-            Ok(r) => r,
-            Err(e) => {
-                tracing::error!("Failed to get L2 gas used: {}", e);
-                return Err(ErrorResponse::database_error());
-            }
-        };
-
-    if let Some(start) = params.starting_after {
-        rows.retain(|b| b.l2_block_number < start);
-    }
-    if let Some(end) = params.ending_before {
-        rows.retain(|b| b.l2_block_number > end);
-    }
-    rows.sort_by(|a, b| b.l2_block_number.cmp(&a.l2_block_number));
-    if rows.len() > limit as usize {
-        rows.truncate(limit as usize);
-    }
+    let rows = match state
+        .client
+        .get_l2_gas_used_block_range(
+            None,
+            start_block,
+            end_block,
+            limit,
+            params.starting_after,
+            params.ending_before,
+        )
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::error!("Failed to get L2 gas used: {}", e);
+            return Err(ErrorResponse::database_error());
+        }
+    };
 
     tracing::info!(count = rows.len(), "Returning table L2 gas used");
     Ok(Json(L2GasUsedResponse { blocks: rows }))
@@ -314,25 +313,24 @@ pub async fn block_transactions(
     };
     let end_block = params.block_range.block_lt.or(params.block_range.block_lte);
 
-    let mut rows =
-        match state.client.get_block_transactions_block_range(start_block, end_block, None).await {
-            Ok(r) => r,
-            Err(e) => {
-                tracing::error!(error = %e, "Failed to get block transactions");
-                return Err(ErrorResponse::database_error());
-            }
-        };
-
-    if let Some(start) = params.starting_after {
-        rows.retain(|b| b.l2_block_number < start);
-    }
-    if let Some(end) = params.ending_before {
-        rows.retain(|b| b.l2_block_number > end);
-    }
-    rows.sort_by(|a, b| b.l2_block_number.cmp(&a.l2_block_number));
-    if rows.len() > limit as usize {
-        rows.truncate(limit as usize);
-    }
+    let rows = match state
+        .client
+        .get_block_transactions_block_range(
+            start_block,
+            end_block,
+            None,
+            limit,
+            params.starting_after,
+            params.ending_before,
+        )
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::error!(error = %e, "Failed to get block transactions");
+            return Err(ErrorResponse::database_error());
+        }
+    };
 
     let blocks: Vec<BlockTransactionsItem> = rows
         .into_iter()

--- a/crates/clickhouse/src/reader/client.rs
+++ b/crates/clickhouse/src/reader/client.rs
@@ -710,6 +710,9 @@ impl ClickhouseReader {
         start_block: Option<u64>,
         end_block: Option<u64>,
         sequencer: Option<AddressBytes>,
+        limit: u64,
+        starting_after: Option<u64>,
+        ending_before: Option<u64>,
     ) -> Result<Vec<BlockTransactionRow>> {
         #[derive(Row, Deserialize)]
         struct RawRow {
@@ -739,7 +742,16 @@ impl ClickhouseReader {
             query.push_str(&format!(" AND sequencer = unhex('{}')", encode(addr)));
         }
 
-        query.push_str(" ORDER BY l2_block_number ASC");
+        if let Some(start) = starting_after {
+            query.push_str(&format!(" AND l2_block_number < {}", start));
+        }
+
+        if let Some(end) = ending_before {
+            query.push_str(&format!(" AND l2_block_number > {}", end));
+        }
+
+        query.push_str(" ORDER BY l2_block_number DESC");
+        query.push_str(&format!(" LIMIT {}", limit));
 
         let rows = self.execute::<RawRow>(&query).await?;
         Ok(rows
@@ -1470,6 +1482,9 @@ impl ClickhouseReader {
         sequencer: Option<AddressBytes>,
         start_block: Option<u64>,
         end_block: Option<u64>,
+        limit: u64,
+        starting_after: Option<u64>,
+        ending_before: Option<u64>,
     ) -> Result<Vec<L2BlockTimeRow>> {
         #[derive(Row, Deserialize)]
         struct RawRow {
@@ -1504,7 +1519,16 @@ impl ClickhouseReader {
             query.push_str(&format!(" AND sequencer = unhex('{}')", encode(addr)));
         }
 
-        query.push_str(" ORDER BY l2_block_number ASC");
+        if let Some(start) = starting_after {
+            query.push_str(&format!(" AND l2_block_number < {}", start));
+        }
+
+        if let Some(end) = ending_before {
+            query.push_str(&format!(" AND l2_block_number > {}", end));
+        }
+
+        query.push_str(" ORDER BY l2_block_number DESC");
+        query.push_str(&format!(" LIMIT {}", limit));
 
         let rows = self.execute::<RawRow>(&query).await?;
         Ok(rows
@@ -1609,6 +1633,9 @@ impl ClickhouseReader {
         sequencer: Option<AddressBytes>,
         start_block: Option<u64>,
         end_block: Option<u64>,
+        limit: u64,
+        starting_after: Option<u64>,
+        ending_before: Option<u64>,
     ) -> Result<Vec<L2GasUsedRow>> {
         #[derive(Row, Deserialize)]
         struct RawRow {
@@ -1637,7 +1664,16 @@ impl ClickhouseReader {
             query.push_str(&format!(" AND sequencer = unhex('{}')", encode(addr)));
         }
 
-        query.push_str(" ORDER BY l2_block_number ASC");
+        if let Some(start) = starting_after {
+            query.push_str(&format!(" AND l2_block_number < {}", start));
+        }
+
+        if let Some(end) = ending_before {
+            query.push_str(&format!(" AND l2_block_number > {}", end));
+        }
+
+        query.push_str(" ORDER BY l2_block_number DESC");
+        query.push_str(&format!(" LIMIT {}", limit));
 
         let rows = self.execute::<RawRow>(&query).await?;
         Ok(rows
@@ -2080,6 +2116,9 @@ impl ClickhouseReader {
         sequencer: Option<AddressBytes>,
         start_block: Option<u64>,
         end_block: Option<u64>,
+        limit: u64,
+        starting_after: Option<u64>,
+        ending_before: Option<u64>,
     ) -> Result<Vec<L2TpsRow>> {
         #[derive(Row, Deserialize)]
         struct RawRow {
@@ -2111,7 +2150,16 @@ impl ClickhouseReader {
             query.push_str(&format!(" AND sequencer = unhex('{}')", encode(addr)));
         }
 
-        query.push_str(" ORDER BY l2_block_number ASC");
+        if let Some(start) = starting_after {
+            query.push_str(&format!(" AND l2_block_number < {}", start));
+        }
+
+        if let Some(end) = ending_before {
+            query.push_str(&format!(" AND l2_block_number > {}", end));
+        }
+
+        query.push_str(" ORDER BY l2_block_number DESC");
+        query.push_str(&format!(" LIMIT {}", limit));
 
         let rows = self.execute::<RawRow>(&query).await?;
         Ok(rows

--- a/tests/pagination.rs
+++ b/tests/pagination.rs
@@ -76,6 +76,82 @@ async fn batch_posting_times_paginated_builds_query() {
 }
 
 #[tokio::test]
+async fn l2_tps_block_range_builds_query() {
+    let mock = Mock::new();
+    let ctl = mock.add(handlers::record_ddl());
+    let url = Url::parse(mock.url()).unwrap();
+    let reader = ClickhouseReader::new(url, "db".to_owned(), "user".into(), "pass".into()).unwrap();
+
+    let _ = reader
+        .get_l2_tps_block_range(None, Some(1), Some(10), 5, Some(8), Some(2))
+        .await;
+    let query = ctl.query().await;
+    assert!(query.contains("h.l2_block_number >= 1"));
+    assert!(query.contains("h.l2_block_number <= 10"));
+    assert!(query.contains("l2_block_number < 8"));
+    assert!(query.contains("l2_block_number > 2"));
+    assert!(query.contains("LIMIT 5"));
+    assert!(query.contains("ORDER BY l2_block_number DESC"));
+}
+
+#[tokio::test]
+async fn l2_block_times_block_range_builds_query() {
+    let mock = Mock::new();
+    let ctl = mock.add(handlers::record_ddl());
+    let url = Url::parse(mock.url()).unwrap();
+    let reader = ClickhouseReader::new(url, "db".to_owned(), "user".into(), "pass".into()).unwrap();
+
+    let _ = reader
+        .get_l2_block_times_block_range(None, Some(1), Some(10), 7, Some(9), Some(3))
+        .await;
+    let query = ctl.query().await;
+    assert!(query.contains("h.l2_block_number >= 1"));
+    assert!(query.contains("h.l2_block_number <= 10"));
+    assert!(query.contains("l2_block_number < 9"));
+    assert!(query.contains("l2_block_number > 3"));
+    assert!(query.contains("LIMIT 7"));
+    assert!(query.contains("ORDER BY l2_block_number DESC"));
+}
+
+#[tokio::test]
+async fn l2_gas_used_block_range_builds_query() {
+    let mock = Mock::new();
+    let ctl = mock.add(handlers::record_ddl());
+    let url = Url::parse(mock.url()).unwrap();
+    let reader = ClickhouseReader::new(url, "db".to_owned(), "user".into(), "pass".into()).unwrap();
+
+    let _ = reader
+        .get_l2_gas_used_block_range(None, Some(1), Some(10), 6, Some(8), Some(4))
+        .await;
+    let query = ctl.query().await;
+    assert!(query.contains("h.l2_block_number >= 1"));
+    assert!(query.contains("h.l2_block_number <= 10"));
+    assert!(query.contains("l2_block_number < 8"));
+    assert!(query.contains("l2_block_number > 4"));
+    assert!(query.contains("LIMIT 6"));
+    assert!(query.contains("ORDER BY l2_block_number DESC"));
+}
+
+#[tokio::test]
+async fn block_transactions_block_range_builds_query() {
+    let mock = Mock::new();
+    let ctl = mock.add(handlers::record_ddl());
+    let url = Url::parse(mock.url()).unwrap();
+    let reader = ClickhouseReader::new(url, "db".to_owned(), "user".into(), "pass".into()).unwrap();
+
+    let _ = reader
+        .get_block_transactions_block_range(Some(1), Some(10), None, 4, Some(9), Some(5))
+        .await;
+    let query = ctl.query().await;
+    assert!(query.contains("h.l2_block_number >= 1"));
+    assert!(query.contains("h.l2_block_number <= 10"));
+    assert!(query.contains("l2_block_number < 9"));
+    assert!(query.contains("l2_block_number > 5"));
+    assert!(query.contains("LIMIT 4"));
+    assert!(query.contains("ORDER BY l2_block_number DESC"));
+}
+
+#[tokio::test]
 async fn reorgs_endpoint_returns_items_with_pagination() {
     #[derive(Serialize, Row)]
     struct RawRow {
@@ -379,3 +455,4 @@ async fn block_range_overflow_returns_400() {
 
     server.abort();
 }
+


### PR DESCRIPTION
## Summary
- support `starting_after`, `ending_before` and `limit` in block range reader functions
- pass new parameters in table API routes
- verify generated SQL contains pagination filters for block range functions

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6867a8126d4c83289672225ee24a979a