### PR TITLE
Fix reorg table time range

### DIFF
--- a/crates/api/src/routes/table.rs
+++ b/crates/api/src/routes/table.rs
@@ -4,8 +4,8 @@ use crate::{
     state::{ApiState, MAX_TABLE_LIMIT},
     validation::{
         BlockPaginatedQuery, PaginatedQuery, has_block_range_params, has_time_range_params,
-        resolve_time_range_since, validate_block_range, validate_pagination,
-        validate_range_exclusivity, validate_time_range,
+        resolve_time_range_bounds, resolve_time_range_since, validate_block_range,
+        validate_pagination, validate_range_exclusivity, validate_time_range,
     },
 };
 use api_types::*;
@@ -50,10 +50,10 @@ pub async fn reorgs(
     let has_slot_range = params.starting_after.is_some() || params.ending_before.is_some();
     validate_range_exclusivity(has_time_range, has_slot_range)?;
 
-    let since = resolve_time_range_since(&params.common.range, &params.common.time_range);
+    let (since, until) = resolve_time_range_bounds(&params.common.range, &params.common.time_range);
     let rows = match state
         .client
-        .get_l2_reorgs_paginated(since, limit, params.starting_after, params.ending_before)
+        .get_l2_reorgs_paginated(since, until, limit, params.starting_after, params.ending_before)
         .await
     {
         Ok(rows) => rows,

--- a/crates/api/src/validation.rs
+++ b/crates/api/src/validation.rs
@@ -334,6 +334,29 @@ pub fn resolve_time_range_since(
     now - range_duration(range)
 }
 
+/// Resolve time range to start and end `DateTime` values
+pub fn resolve_time_range_bounds(
+    range: &Option<String>,
+    time_params: &TimeRangeParams,
+) -> (DateTime<Utc>, DateTime<Utc>) {
+    let now = Utc::now();
+
+    let start = time_params
+        .created_gt
+        .map(|v| v + 1)
+        .or(time_params.created_gte)
+        .and_then(|ms| Utc.timestamp_millis_opt(ms as i64).single())
+        .unwrap_or_else(|| now - range_duration(range));
+
+    let end = time_params
+        .created_lt
+        .or(time_params.created_lte)
+        .and_then(|ms| Utc.timestamp_millis_opt(ms as i64).single())
+        .unwrap_or(now);
+
+    (start, end)
+}
+
 /// Custom deserializer that converts a URL-encoded form value into a `u64`.
 /// This accepts both bare numbers (e.g. `1750000`) and quoted numbers (e.g.
 /// `"1750000"`) to be tolerant of over-encoded clients.

--- a/crates/clickhouse/src/reader/client.rs
+++ b/crates/clickhouse/src/reader/client.rs
@@ -518,6 +518,7 @@ impl ClickhouseReader {
     pub async fn get_l2_reorgs_paginated(
         &self,
         since: DateTime<Utc>,
+        until: DateTime<Utc>,
         limit: u64,
         starting_after: Option<u64>,
         ending_before: Option<u64>,
@@ -535,9 +536,11 @@ impl ClickhouseReader {
             "SELECT l2_block_number, depth, old_sequencer, new_sequencer, \
                     toUInt64(toUnixTimestamp64Milli(inserted_at)) AS ts \
              FROM {db}.l2_reorgs \
-             WHERE inserted_at > toDateTime64({since}, 3)",
+             WHERE inserted_at > toDateTime64({since}, 3) \
+               AND inserted_at <= toDateTime64({until}, 3)",
             db = self.db_name,
             since = since.timestamp_millis() as f64 / 1000.0,
+            until = until.timestamp_millis() as f64 / 1000.0,
         );
 
         if let Some(start) = starting_after {

--- a/tests/pagination.rs
+++ b/tests/pagination.rs
@@ -51,8 +51,11 @@ async fn l2_reorgs_paginated_builds_query() {
     let reader = ClickhouseReader::new(url, "db".to_owned(), "user".into(), "pass".into()).unwrap();
 
     let since = Utc.timestamp_opt(0, 0).single().unwrap();
-    let _ = reader.get_l2_reorgs_paginated(since, 5, Some(100), Some(50)).await;
+    let until = Utc.timestamp_opt(1, 0).single().unwrap();
+    let _ = reader.get_l2_reorgs_paginated(since, until, 5, Some(100), Some(50)).await;
     let query = ctl.query().await;
+    assert!(query.contains("inserted_at > toDateTime64(0"));
+    assert!(query.contains("inserted_at <= toDateTime64(1"));
     assert!(query.contains("l2_block_number < 100"));
     assert!(query.contains("l2_block_number > 50"));
     assert!(query.contains("LIMIT 5"));


### PR DESCRIPTION
## Summary
- support `created[lte]` for reorg table queries
- validate custom time range bounds when building reorg table queries
- test new upper bound handling

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6867b9a9f7a48328bf3e7fd92d85b7a8