### PR TITLE
Fix tooltip for Avg Blobs chart

### DIFF
--- a/dashboard/components/BlobsPerBatchChart.tsx
+++ b/dashboard/components/BlobsPerBatchChart.tsx
@@ -65,12 +65,9 @@ const BlobsPerBatchChartComponent: React.FC<BlobsPerBatchChartProps> = ({
           }}
         />
         <Tooltip
-          labelFormatter={(label: number, payload) => {
+          labelFormatter={(_label: number, payload) => {
             const batch = payload?.[0]?.payload?.batch as number;
-            if (batch && label) {
-              return `Block ${label.toLocaleString()} (Batch ${batch.toLocaleString()})`;
-            }
-            return label ? `Block ${label.toLocaleString()}` : 'Unknown';
+            return batch ? `Batch ${batch.toLocaleString()}` : 'Unknown';
           }}
           formatter={(value: number) => [value.toLocaleString(), 'blobs']}
           contentStyle={{


### PR DESCRIPTION
## Summary
- show only the batch in the Avg Blobs per Batch chart tooltip

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6867ba0f1b10832894577e0efb7188d2