### PR TITLE
Fix hardware cost scaling across dashboard

### DIFF
--- a/dashboard/components/BlockProfitTables.tsx
+++ b/dashboard/components/BlockProfitTables.tsx
@@ -12,6 +12,8 @@ interface BlockProfitTablesProps {
   cloudCost: number;
   proverCost: number;
   address?: string;
+  /** Total number of sequencers for scaling network-wide costs */
+  totalSequencers?: number;
 }
 
 const formatUsd = (value: number): string => {
@@ -28,6 +30,7 @@ export const BlockProfitTables: React.FC<BlockProfitTablesProps> = ({
   cloudCost,
   proverCost,
   address,
+  totalSequencers,
 }) => {
   const { data: ethPrice = 0 } = useEthPrice();
   const { data: feeRes } = useSWR(
@@ -39,8 +42,9 @@ export const BlockProfitTables: React.FC<BlockProfitTablesProps> = ({
   const HOURS_IN_MONTH = 30 * 24;
   const hours = rangeToHours(timeRange);
 
+  const seqCount = address ? 1 : Math.max(1, totalSequencers ?? 1);
   const operationalCostPerBatchUsd = batchCount > 0
-    ? ((cloudCost + proverCost) / HOURS_IN_MONTH) * (hours / batchCount)
+    ? ((cloudCost + proverCost) * seqCount) / HOURS_IN_MONTH * (hours / batchCount)
     : 0;
 
   const profits = batchData.map((b) => {

--- a/dashboard/components/CostChart.tsx
+++ b/dashboard/components/CostChart.tsx
@@ -21,6 +21,8 @@ interface CostChartProps {
   cloudCost: number;
   proverCost: number;
   address?: string;
+  /** Total number of sequencers for scaling network-wide costs */
+  totalSequencers?: number;
 }
 
 export const CostChart: React.FC<CostChartProps> = ({
@@ -28,6 +30,7 @@ export const CostChart: React.FC<CostChartProps> = ({
   cloudCost,
   proverCost,
   address,
+  totalSequencers,
 }) => {
   const { data: feeRes } = useSWR(
     ['batchFeeComponents', timeRange, address],
@@ -46,7 +49,8 @@ export const CostChart: React.FC<CostChartProps> = ({
 
   const hours = rangeToHours(timeRange);
   const HOURS_IN_MONTH = 30 * 24;
-  const baseCostUsd = ((cloudCost + proverCost) / HOURS_IN_MONTH) * hours;
+  const seqCount = address ? 1 : Math.max(1, totalSequencers ?? 1);
+  const baseCostUsd = ((cloudCost + proverCost) * seqCount) / HOURS_IN_MONTH * hours;
   const baseCostEth = ethPrice ? baseCostUsd / ethPrice : 0;
   const baseCostPerBatchEth = baseCostEth / feeData.length;
 

--- a/dashboard/components/EconomicsChart.tsx
+++ b/dashboard/components/EconomicsChart.tsx
@@ -21,6 +21,8 @@ interface EconomicsChartProps {
   cloudCost: number;
   proverCost: number;
   address?: string;
+  /** Total number of sequencers for scaling network-wide costs */
+  totalSequencers?: number;
 }
 
 export const EconomicsChart: React.FC<EconomicsChartProps> = ({
@@ -28,6 +30,7 @@ export const EconomicsChart: React.FC<EconomicsChartProps> = ({
   cloudCost,
   proverCost,
   address,
+  totalSequencers,
 }) => {
   const { data: feeRes } = useSWR(
     ['batchFeeComponents', timeRange, address],
@@ -46,7 +49,8 @@ export const EconomicsChart: React.FC<EconomicsChartProps> = ({
 
   const hours = rangeToHours(timeRange);
   const HOURS_IN_MONTH = 30 * 24;
-  const baseCostUsd = ((cloudCost + proverCost) / HOURS_IN_MONTH) * hours;
+  const seqCount = address ? 1 : Math.max(1, totalSequencers ?? 1);
+  const baseCostUsd = ((cloudCost + proverCost) * seqCount) / HOURS_IN_MONTH * hours;
   const baseCostPerBatchUsd = baseCostUsd / feeData.length;
   const baseCostPerBatchEth = ethPrice ? baseCostPerBatchUsd / ethPrice : 0;
 

--- a/dashboard/components/FeeFlowChart.tsx
+++ b/dashboard/components/FeeFlowChart.tsx
@@ -272,8 +272,10 @@ export const FeeFlowChart: React.FC<FeeFlowChartProps> = ({
   // Scale operational costs to the selected time range
   const hours = rangeToHours(timeRange);
   const sequencerCount = Math.max(1, totalSequencers ?? sequencerFees.length);
-  // Compute total hardware cost for the range, then derive per-sequencer share
-  const totalHardwareCost = safeValue(((cloudCost + proverCost) / MONTH_HOURS) * hours);
+  // Compute network-wide hardware cost for the range then derive per-sequencer share
+  const totalHardwareCost = safeValue(
+    ((cloudCost + proverCost) * sequencerCount) / MONTH_HOURS * hours,
+  );
   const hardwareCostPerSeq = safeValue(totalHardwareCost / sequencerCount);
 
   const seqData = sequencerFees.map((f) => {

--- a/dashboard/components/ProfitabilityChart.tsx
+++ b/dashboard/components/ProfitabilityChart.tsx
@@ -22,6 +22,8 @@ interface ProfitabilityChartProps {
   cloudCost: number;
   proverCost: number;
   address?: string;
+  /** Total number of sequencers for scaling network-wide costs */
+  totalSequencers?: number;
 }
 
 export const ProfitabilityChart: React.FC<ProfitabilityChartProps> = ({
@@ -29,6 +31,7 @@ export const ProfitabilityChart: React.FC<ProfitabilityChartProps> = ({
   cloudCost,
   proverCost,
   address,
+  totalSequencers,
 }) => {
   const { data: feeRes } = useSWR(
     ['batchFeeComponents', timeRange, address],
@@ -47,8 +50,9 @@ export const ProfitabilityChart: React.FC<ProfitabilityChartProps> = ({
 
   const hours = rangeToHours(timeRange);
   const HOURS_IN_MONTH = 30 * 24;
+  const seqCount = address ? 1 : Math.max(1, totalSequencers ?? 1);
   const costPerBatchUsd =
-    ((cloudCost + proverCost) / HOURS_IN_MONTH) * (hours / feeData.length);
+    ((cloudCost + proverCost) * seqCount) / HOURS_IN_MONTH * (hours / feeData.length);
 
   const data = feeData.map((b) => {
     const { profitEth, profitUsd } = calculateProfit({

--- a/dashboard/components/views/DashboardView.tsx
+++ b/dashboard/components/views/DashboardView.tsx
@@ -362,6 +362,7 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
                 cloudCost={cloudCost}
                 proverCost={proverCost}
                 address={selectedSequencer || undefined}
+                totalSequencers={chartsData.sequencerDistribution.length}
               />
             </div>
             <ProfitRankingTable
@@ -374,6 +375,7 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
               cloudCost={cloudCost}
               proverCost={proverCost}
               address={selectedSequencer || undefined}
+              totalSequencers={chartsData.sequencerDistribution.length}
             />
           </>
         )}


### PR DESCRIPTION
## Summary
- multiply cloud/prover costs by sequencer count in FeeFlowChart
- allow charts to compute network totals based on sequencer count
- wire DashboardView to pass sequencer count

## Testing
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_6867cc3b59b8832895bcf6d5ce8b7f71