### PR TITLE
Implement tab view for dashboard

### DIFF
--- a/dashboard/components/DashboardHeader.tsx
+++ b/dashboard/components/DashboardHeader.tsx
@@ -56,7 +56,8 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({
   const { navigateToDashboard, updateSearchParams } = useRouterNavigation();
   const { errorMessage } = useErrorHandler();
   const [searchParams] = useSearchParams();
-  const isEconomicsView = searchParams.get('view') === 'economics';
+  const viewParam = searchParams.get('view') ?? 'economics';
+  const isEconomicsView = viewParam === 'economics';
   React.useEffect(() => {
     if (errorMessage) {
       showToast(errorMessage);
@@ -78,20 +79,24 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({
         </h1>
       </div>
       <div className="flex flex-wrap items-center gap-2 mt-4 md:mt-0 justify-center md:justify-end">
-        <button
-          onClick={() => {
-            const params = new URLSearchParams(searchParams);
-            if (params.get('view') === 'economics') {
-              navigateToDashboard(true);
-              return;
-            }
-            updateSearchParams({ view: 'economics', table: null });
-          }}
-          className="px-2 py-1 text-sm border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700"
-          style={{ color: TAIKO_PINK }}
-        >
-          Economics
-        </button>
+        <div className="flex gap-2">
+          {[
+            { view: 'performance', label: 'Performance' },
+            { view: 'economics', label: 'Economics' },
+            { view: 'health', label: 'Health' },
+          ].map((tab) => (
+            <button
+              key={tab.view}
+              onClick={() =>
+                updateSearchParams({ view: tab.view, table: null })
+              }
+              className={`px-2 py-1 text-sm border border-gray-300 dark:border-gray-600 rounded-md ${viewParam === tab.view ? 'bg-gray-200 dark:bg-gray-700' : 'bg-white dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700'}`}
+              style={{ color: TAIKO_PINK }}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
         <a
           href="https://status.taiko.xyz/"
           target="_blank"

--- a/dashboard/components/views/DashboardView.tsx
+++ b/dashboard/components/views/DashboardView.tsx
@@ -135,9 +135,10 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
         if (selectedSequencer && m.group === 'Sequencers') return false;
         if (isEconomicsView) return m.group === 'Network Economics';
         if (isHealthView) return m.group === 'Network Health';
+        if (isPerformanceView) return m.group === 'Network Performance';
         return m.group !== 'Network Economics';
       }),
-    [metricsWithHardware, selectedSequencer, isEconomicsView, isHealthView],
+    [metricsWithHardware, selectedSequencer, isEconomicsView, isHealthView, isPerformanceView],
   );
 
   const groupedMetrics = React.useMemo(
@@ -162,10 +163,10 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
     : isHealthView
       ? { 'Network Health': 5 }
       : {
-          'Network Performance': 3,
-          'Network Health': 5,
-          Sequencers: 3,
-        };
+        'Network Performance': 3,
+        'Network Health': 5,
+        Sequencers: 3,
+      };
 
   const displayGroupName = useCallback(
     (group: string): string => {

--- a/dashboard/hooks/useMetricsData.ts
+++ b/dashboard/hooks/useMetricsData.ts
@@ -11,7 +11,7 @@ export const useMetricsData = (): MetricsDataState => {
   const [searchParams] = useSearchParams();
 
   // Memoize the specific value we need to prevent infinite re-renders
-  const viewParam = searchParams.get('view');
+  const viewParam = searchParams.get('view') ?? 'economics';
   const isEconomicsView = useMemo(() => viewParam === 'economics', [viewParam]);
 
   return useMemo(

--- a/dashboard/tests/dashboardHeader.test.ts
+++ b/dashboard/tests/dashboardHeader.test.ts
@@ -17,7 +17,7 @@ describe('DashboardHeader', () => {
           null,
           React.createElement(
             MemoryRouter,
-            null,
+            { initialEntries: ['/?view=performance'] },
             React.createElement(DashboardHeader, {
               timeRange: '1h',
               onTimeRangeChange: () => { },
@@ -38,7 +38,9 @@ describe('DashboardHeader', () => {
     expect(html.includes('Refresh')).toBe(true);
     expect(html.includes('Status')).toBe(true);
     expect(html.includes('All Sequencers')).toBe(true);
+    expect(html.includes('Performance')).toBe(true);
     expect(html.includes('Economics')).toBe(true);
+    expect(html.includes('Health')).toBe(true);
   });
 
   it('hides sequencer selector in economics view', () => {

--- a/dashboard/tests/navigationUtils.test.ts
+++ b/dashboard/tests/navigationUtils.test.ts
@@ -100,6 +100,12 @@ describe('navigationUtils', () => {
 
       const params2 = new URLSearchParams('view=economics');
       expect(validateSearchParams(params2)).toBe(true);
+
+      const params3 = new URLSearchParams('view=performance');
+      expect(validateSearchParams(params3)).toBe(true);
+
+      const params4 = new URLSearchParams('view=health');
+      expect(validateSearchParams(params4)).toBe(true);
     });
 
     it('should reject invalid view parameters', () => {

--- a/dashboard/utils/navigationUtils.ts
+++ b/dashboard/utils/navigationUtils.ts
@@ -83,7 +83,7 @@ export const validateSearchParams = (params: URLSearchParams): boolean => {
   try {
     // Check for reasonable parameter values
     const view = params.get('view');
-    if (view && !['table', 'economics'].includes(view)) {
+    if (view && !['table', 'performance', 'economics', 'health'].includes(view)) {
       console.warn('Invalid view parameter:', view);
       return false;
     }
@@ -129,7 +129,7 @@ export const cleanSearchParams = (params: URLSearchParams): URLSearchParams => {
 
   try {
     const validators: Record<string, (v: string) => boolean> = {
-      view: (v) => ['table', 'economics'].includes(v),
+      view: (v) => ['table', 'performance', 'economics', 'health'].includes(v),
       page: (v) => /^\d+$/.test(v),
       start: (v) => /^\d+$/.test(v),
       end: (v) => /^\d+$/.test(v),


### PR DESCRIPTION
## Summary
- switch dashboard to tabbed navigation with Performance, Economics, Health
- support new view types in navigation utils
- default dashboard view to economics
- update tests for new behaviour

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6867dbb75d408328a708ce911cba1940