### PR TITLE
Improve dashboard navigation

### DIFF
--- a/dashboard/components/DashboardHeader.tsx
+++ b/dashboard/components/DashboardHeader.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TimeRange } from '../types';
+import { TimeRange, DashboardViewType } from '../types';
 import { RefreshCountdown } from './RefreshCountdown';
 import { TAIKO_PINK } from '../theme';
 import { isValidRefreshRate } from '../utils';
@@ -56,7 +56,12 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({
   const { navigateToDashboard, updateSearchParams } = useRouterNavigation();
   const { errorMessage } = useErrorHandler();
   const [searchParams] = useSearchParams();
-  const isEconomicsView = searchParams.get('view') === 'economics';
+  const view =
+    (searchParams.get('view') as DashboardViewType | null) ?? 'economics';
+  const isEconomicsView = view === 'economics';
+  const handleViewChange = (v: DashboardViewType) => {
+    updateSearchParams({ view: v, table: null });
+  };
   React.useEffect(() => {
     if (errorMessage) {
       showToast(errorMessage);
@@ -78,20 +83,24 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({
         </h1>
       </div>
       <div className="flex flex-wrap items-center gap-2 mt-4 md:mt-0 justify-center md:justify-end">
-        <button
-          onClick={() => {
-            const params = new URLSearchParams(searchParams);
-            if (params.get('view') === 'economics') {
-              navigateToDashboard(true);
-              return;
-            }
-            updateSearchParams({ view: 'economics', table: null });
-          }}
-          className="px-2 py-1 text-sm border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700"
-          style={{ color: TAIKO_PINK }}
-        >
-          Economics
-        </button>
+        <div className="flex space-x-2">
+          {(['performance', 'economics', 'health'] as DashboardViewType[]).map(
+            (v) => (
+              <button
+                key={v}
+                onClick={() => handleViewChange(v)}
+                className={`px-2 py-1 text-sm border border-gray-300 dark:border-gray-600 rounded-md ${
+                  view === v
+                    ? 'bg-gray-200 dark:bg-gray-700'
+                    : 'bg-white dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700'
+                }`}
+                style={{ color: TAIKO_PINK }}
+              >
+                {v.charAt(0).toUpperCase() + v.slice(1)}
+              </button>
+            ),
+          )}
+        </div>
         <a
           href="https://status.taiko.xyz/"
           target="_blank"

--- a/dashboard/components/routes/TableRoute.tsx
+++ b/dashboard/components/routes/TableRoute.tsx
@@ -76,7 +76,7 @@ export const TableRoute: React.FC = () => {
     setMetrics: metricsData.setMetrics,
     setLoadingMetrics: metricsData.setLoadingMetrics,
     setErrorMessage: metricsData.setErrorMessage,
-    isEconomicsView: metricsData.isEconomicsView,
+    view: metricsData.view,
     refreshRate: refreshTimer.refreshRate,
     updateLastRefresh: refreshTimer.updateLastRefresh,
   });
@@ -125,7 +125,11 @@ export const TableRoute: React.FC = () => {
 
         let res;
         let aggRes;
-        if (tableType === 'reorgs' || tableType === 'prove-times' || tableType === 'verify-times') {
+        if (
+          tableType === 'reorgs' ||
+          tableType === 'prove-times' ||
+          tableType === 'verify-times'
+        ) {
           if (config.aggregatedFetcher) {
             [res, aggRes] = await Promise.all([
               config.fetcher(range, PAGE_LIMIT, startingAfter, endingBefore),
@@ -138,18 +142,39 @@ export const TableRoute: React.FC = () => {
           }
         } else if (config.supportsPagination) {
           // For paginated tables, determine if an address param is needed
-          const fetchLimit = tableType === 'l2-block-times' && startingAfter === undefined && endingBefore === undefined
-            ? PAGE_LIMIT + 1
-            : PAGE_LIMIT;
-          const needsAddress = ['l2-block-times', 'l2-gas-used', 'l2-tps', 'block-tx'].includes(tableType);
+          const fetchLimit =
+            tableType === 'l2-block-times' &&
+            startingAfter === undefined &&
+            endingBefore === undefined
+              ? PAGE_LIMIT + 1
+              : PAGE_LIMIT;
+          const needsAddress = [
+            'l2-block-times',
+            'l2-gas-used',
+            'l2-tps',
+            'block-tx',
+          ].includes(tableType);
           const addressParam = needsAddress
-            ? (selectedSequencer ? getSequencerAddress(selectedSequencer) : undefined)
+            ? selectedSequencer
+              ? getSequencerAddress(selectedSequencer)
+              : undefined
             : undefined;
           if (config.aggregatedFetcher) {
             [res, aggRes] = await Promise.all([
               needsAddress
-                ? config.fetcher(range, addressParam, fetchLimit, startingAfter, endingBefore)
-                : config.fetcher(range, fetchLimit, startingAfter, endingBefore),
+                ? config.fetcher(
+                    range,
+                    addressParam,
+                    fetchLimit,
+                    startingAfter,
+                    endingBefore,
+                  )
+                : config.fetcher(
+                    range,
+                    fetchLimit,
+                    startingAfter,
+                    endingBefore,
+                  ),
               needsAddress
                 ? config.aggregatedFetcher(range, addressParam)
                 : config.aggregatedFetcher(range),
@@ -157,16 +182,27 @@ export const TableRoute: React.FC = () => {
           } else {
             [res] = await Promise.all([
               needsAddress
-                ? config.fetcher(range, addressParam, fetchLimit, startingAfter, endingBefore)
-                : config.fetcher(range, fetchLimit, startingAfter, endingBefore),
+                ? config.fetcher(
+                    range,
+                    addressParam,
+                    fetchLimit,
+                    startingAfter,
+                    endingBefore,
+                  )
+                : config.fetcher(
+                    range,
+                    fetchLimit,
+                    startingAfter,
+                    endingBefore,
+                  ),
             ]);
           }
         } else {
           [res, aggRes] = await (config.aggregatedFetcher
             ? Promise.all([
-              config.fetcher(range, ...fetcherArgs),
-              config.aggregatedFetcher(range, ...fetcherArgs),
-            ])
+                config.fetcher(range, ...fetcherArgs),
+                config.aggregatedFetcher(range, ...fetcherArgs),
+              ])
             : Promise.all([config.fetcher(range, ...fetcherArgs)]));
         }
         if (currentFetchId !== fetchIdRef.current) return;
@@ -175,7 +211,8 @@ export const TableRoute: React.FC = () => {
 
         // For tables with aggregatedFetcher, use aggregated data on custom absolute time ranges
         const isCustomAbsoluteRange =
-          typeof currentTimeRange === 'string' && /^\d+-\d+$/.test(currentTimeRange);
+          typeof currentTimeRange === 'string' &&
+          /^\d+-\d+$/.test(currentTimeRange);
         if (config.aggregatedFetcher && isCustomAbsoluteRange) {
           data = chartData;
         }
@@ -198,7 +235,9 @@ export const TableRoute: React.FC = () => {
           );
         };
         const nextCursor =
-          originalData.length > 0 ? getCursor(originalData[originalData.length - 1]) : undefined;
+          originalData.length > 0
+            ? getCursor(originalData[originalData.length - 1])
+            : undefined;
         const prevCursor =
           originalData.length > 0 ? getCursor(originalData[0]) : undefined;
 
@@ -225,7 +264,10 @@ export const TableRoute: React.FC = () => {
             chart,
           };
           // Only show pagination controls when NOT in a custom range on l2-tps
-          if (config.supportsPagination && !(config.aggregatedFetcher && isCustomAbsoluteRange)) {
+          if (
+            config.supportsPagination &&
+            !(config.aggregatedFetcher && isCustomAbsoluteRange)
+          ) {
             const disablePrev = page === 0;
             const disableNext = originalData.length < PAGE_LIMIT;
             view.serverPagination = {
@@ -247,7 +289,8 @@ export const TableRoute: React.FC = () => {
                   params.delete('start');
                   params.delete('end');
                 } else {
-                  if (prevCursor !== undefined) params.set('end', String(prevCursor));
+                  if (prevCursor !== undefined)
+                    params.set('end', String(prevCursor));
                   params.delete('start');
                 }
                 setSearchParams(params);

--- a/dashboard/components/views/DashboardView.tsx
+++ b/dashboard/components/views/DashboardView.tsx
@@ -8,7 +8,12 @@ import { BlockProfitTables } from '../BlockProfitTables';
 import { FeeFlowChart } from '../FeeFlowChart';
 import { ChartCard } from '../ChartCard';
 import { TAIKO_PINK } from '../../theme';
-import { TimeRange, MetricData, ChartsData } from '../../types';
+import {
+  TimeRange,
+  MetricData,
+  ChartsData,
+  DashboardViewType,
+} from '../../types';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useEthPrice } from '../../services/priceService';
 import { rangeToHours } from '../../utils/timeRange';
@@ -84,7 +89,11 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
 }) => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const isEconomicsView = searchParams.get('view') === 'economics';
+  const view =
+    (searchParams.get('view') as DashboardViewType | null) ?? 'economics';
+  const isEconomicsView = view === 'economics';
+  const isPerformanceView = view === 'performance';
+  const isHealthView = view === 'health';
   // Default monthly costs in USD
   const [cloudCost, setCloudCost] = useState(0);
   const [proverCost, setProverCost] = useState(0);
@@ -96,7 +105,7 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
     const hours = rangeToHours(timeRange);
     const sequencerCount = chartsData.sequencerDistribution.length || 1;
     const costUsd =
-      ((cloudCost + proverCost) * sequencerCount) / HOURS_IN_MONTH * hours;
+      (((cloudCost + proverCost) * sequencerCount) / HOURS_IN_MONTH) * hours;
     const costWei = ethPrice > 0 ? (costUsd / ethPrice) * 1e9 : null;
     const hardwareMetric: MetricData = {
       title: 'Hardware Costs',
@@ -124,16 +133,31 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
     }
 
     return list;
-  }, [metricsData.metrics, isEconomicsView, cloudCost, proverCost, ethPrice, timeRange]);
+  }, [
+    metricsData.metrics,
+    isEconomicsView,
+    cloudCost,
+    proverCost,
+    ethPrice,
+    timeRange,
+  ]);
 
   const visibleMetrics = React.useMemo(
     () =>
       metricsWithHardware.filter((m) => {
         if (selectedSequencer && m.group === 'Sequencers') return false;
         if (isEconomicsView) return m.group === 'Network Economics';
-        return m.group !== 'Network Economics';
+        if (isPerformanceView) return m.group === 'Network Performance';
+        if (isHealthView) return m.group === 'Network Health';
+        return true;
       }),
-    [metricsWithHardware, selectedSequencer, isEconomicsView],
+    [
+      metricsWithHardware,
+      selectedSequencer,
+      isEconomicsView,
+      isPerformanceView,
+      isHealthView,
+    ],
   );
 
   const groupedMetrics = React.useMemo(
@@ -149,15 +173,15 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
 
   const groupOrder = isEconomicsView
     ? ['Network Economics']
-    : ['Network Performance', 'Network Health', 'Sequencers', 'Other'];
+    : isPerformanceView
+      ? ['Network Performance', 'Sequencers']
+      : ['Network Health', 'Sequencers'];
 
   const skeletonGroupCounts: Record<string, number> = isEconomicsView
     ? { 'Network Economics': 6 }
-    : {
-      'Network Performance': 3,
-      'Network Health': 5,
-      Sequencers: 3,
-    };
+    : isPerformanceView
+      ? { 'Network Performance': 3, Sequencers: 3 }
+      : { 'Network Health': 5, Sequencers: 3 };
 
   const displayGroupName = useCallback(
     (group: string): string => {
@@ -281,10 +305,12 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
       </ChartCard>,
     ];
 
-    const groups: Record<string, React.ReactNode[]> = {
-      'Network Performance': performance,
-      'Network Health': health,
-    };
+    const groups: Record<string, React.ReactNode[]> = {};
+    if (isPerformanceView) {
+      groups['Network Performance'] = performance;
+    } else if (isHealthView) {
+      groups['Network Health'] = health;
+    }
 
     if (!selectedSequencer) {
       groups['Sequencers'] = [
@@ -309,6 +335,8 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
     selectedSequencer,
     isLoadingData,
     isEconomicsView,
+    isPerformanceView,
+    isHealthView,
     onOpenTable,
     onOpenSequencerDistributionTable,
   ]);
@@ -356,7 +384,9 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
               totalSequencers={chartsData.sequencerDistribution.length}
             />
             <div className="mt-6">
-              <h3 className="text-lg font-semibold mb-2">PnL Trend per Batch</h3>
+              <h3 className="text-lg font-semibold mb-2">
+                PnL Trend per Batch
+              </h3>
               <EconomicsChart
                 timeRange={timeRange}
                 cloudCost={cloudCost}

--- a/dashboard/hooks/useDashboardController.ts
+++ b/dashboard/hooks/useDashboardController.ts
@@ -27,7 +27,6 @@ export const useDashboardController = () => {
   const { selectedSequencer, setSelectedSequencer, sequencerList } =
     useSequencerHandler({ blockData, metricsData });
 
-
   // Table actions
   const {
     tableView,
@@ -48,7 +47,7 @@ export const useDashboardController = () => {
       setMetrics: metricsData.setMetrics,
       setLoadingMetrics: metricsData.setLoadingMetrics,
       setErrorMessage: metricsData.setErrorMessage,
-      isEconomicsView: metricsData.isEconomicsView,
+      view: metricsData.view,
       refreshRate: refreshTimer.refreshRate,
       updateLastRefresh: refreshTimer.updateLastRefresh,
     });

--- a/dashboard/hooks/useDataFetcher.ts
+++ b/dashboard/hooks/useDataFetcher.ts
@@ -1,7 +1,12 @@
 import { useCallback, useEffect, useMemo } from 'react';
 import useSWR from 'swr';
 import { useSearchParams, useLocation } from 'react-router-dom';
-import { TimeRange, MetricData, ChartsDataUpdate } from '../types';
+import {
+  TimeRange,
+  MetricData,
+  ChartsDataUpdate,
+  DashboardViewType,
+} from '../types';
 import { TableViewState } from './useTableActions';
 import {
   fetchMainDashboardData,
@@ -18,7 +23,7 @@ interface UseDataFetcherProps {
   setMetrics: (metrics: MetricData[]) => void;
   setLoadingMetrics: (v: boolean) => void;
   setErrorMessage: (msg: string) => void;
-  isEconomicsView: boolean;
+  view: DashboardViewType;
   refreshRate: number;
   updateLastRefresh: () => void;
 }
@@ -31,7 +36,7 @@ export const useDataFetcher = ({
   setMetrics,
   setLoadingMetrics,
   setErrorMessage,
-  isEconomicsView,
+  view,
   refreshRate,
   updateLastRefresh,
 }: UseDataFetcherProps) => {
@@ -48,9 +53,10 @@ export const useDataFetcher = ({
 
   const selectedSequencerForFetch = selectedSequencer;
 
+  const isEconomicsView = view === 'economics';
   const fetchKey = isTableView
     ? null
-    : ['metrics', timeRange, selectedSequencerForFetch, isEconomicsView];
+    : ['metrics', timeRange, selectedSequencerForFetch, view];
 
   const fetcher = async () => {
     if (isEconomicsView) {
@@ -79,13 +85,13 @@ export const useDataFetcher = ({
 
         profit:
           data.priorityFee != null &&
-            data.baseFee != null &&
-            data.l1DataCost != null &&
-            data.proveCost != null
+          data.baseFee != null &&
+          data.l1DataCost != null &&
+          data.proveCost != null
             ? data.priorityFee +
-            (data.baseFee * 0.75) -
-            data.l1DataCost -
-            data.proveCost
+              data.baseFee * 0.75 -
+              data.l1DataCost -
+              data.proveCost
             : null,
         l2Block: data.l2Block,
         l1Block: data.l1Block,

--- a/dashboard/hooks/useMetricsData.ts
+++ b/dashboard/hooks/useMetricsData.ts
@@ -1,7 +1,7 @@
 import { useState, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { useErrorHandler } from './useErrorHandler';
-import type { MetricData, MetricsDataState } from '../types';
+import type { MetricData, MetricsDataState, DashboardViewType } from '../types';
 
 export const useMetricsData = (): MetricsDataState => {
   const [metrics, setMetrics] = useState<MetricData[]>([]);
@@ -11,8 +11,16 @@ export const useMetricsData = (): MetricsDataState => {
   const [searchParams] = useSearchParams();
 
   // Memoize the specific value we need to prevent infinite re-renders
-  const viewParam = searchParams.get('view');
-  const isEconomicsView = useMemo(() => viewParam === 'economics', [viewParam]);
+  const viewParam = searchParams.get('view') as DashboardViewType | null;
+  const view = useMemo<DashboardViewType>(
+    () =>
+      viewParam === 'performance' ||
+      viewParam === 'health' ||
+      viewParam === 'economics'
+        ? viewParam
+        : 'economics',
+    [viewParam],
+  );
 
   return useMemo(
     () => ({
@@ -22,8 +30,8 @@ export const useMetricsData = (): MetricsDataState => {
       setLoadingMetrics,
       errorMessage,
       setErrorMessage,
-      isEconomicsView,
+      view,
     }),
-    [metrics, loadingMetrics, errorMessage, isEconomicsView],
+    [metrics, loadingMetrics, errorMessage, view],
   );
 };

--- a/dashboard/tests/dashboardHeader.test.ts
+++ b/dashboard/tests/dashboardHeader.test.ts
@@ -20,14 +20,14 @@ describe('DashboardHeader', () => {
             null,
             React.createElement(DashboardHeader, {
               timeRange: '1h',
-              onTimeRangeChange: () => { },
+              onTimeRangeChange: () => {},
               refreshRate: 60000,
-              onRefreshRateChange: () => { },
+              onRefreshRateChange: () => {},
               lastRefresh: Date.now(),
-              onManualRefresh: () => { },
+              onManualRefresh: () => {},
               sequencers: ['seq1', 'seq2'],
               selectedSequencer: null,
-              onSequencerChange: () => { },
+              onSequencerChange: () => {},
             }),
           ),
         ),
@@ -37,8 +37,10 @@ describe('DashboardHeader', () => {
     expect(html.includes('1h')).toBe(true);
     expect(html.includes('Refresh')).toBe(true);
     expect(html.includes('Status')).toBe(true);
-    expect(html.includes('All Sequencers')).toBe(true);
+    expect(html.includes('All Sequencers')).toBe(false);
     expect(html.includes('Economics')).toBe(true);
+    expect(html.includes('Performance')).toBe(true);
+    expect(html.includes('Health')).toBe(true);
   });
 
   it('hides sequencer selector in economics view', () => {
@@ -54,14 +56,14 @@ describe('DashboardHeader', () => {
             { initialEntries: ['/?view=economics'] },
             React.createElement(DashboardHeader, {
               timeRange: '1h',
-              onTimeRangeChange: () => { },
+              onTimeRangeChange: () => {},
               refreshRate: 60000,
-              onRefreshRateChange: () => { },
+              onRefreshRateChange: () => {},
               lastRefresh: Date.now(),
-              onManualRefresh: () => { },
+              onManualRefresh: () => {},
               sequencers: ['seq1', 'seq2'],
               selectedSequencer: null,
-              onSequencerChange: () => { },
+              onSequencerChange: () => {},
             }),
           ),
         ),

--- a/dashboard/tests/navigationUtils.test.ts
+++ b/dashboard/tests/navigationUtils.test.ts
@@ -15,9 +15,10 @@ const navSpy = vi.fn();
 let currentSearch = '?range=1h';
 
 vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual<typeof import('react-router-dom')>(
-    'react-router-dom',
-  );
+  const actual =
+    await vi.importActual<typeof import('react-router-dom')>(
+      'react-router-dom',
+    );
   return {
     ...actual,
     useNavigate: () => navSpy,
@@ -100,6 +101,12 @@ describe('navigationUtils', () => {
 
       const params2 = new URLSearchParams('view=economics');
       expect(validateSearchParams(params2)).toBe(true);
+
+      const params3 = new URLSearchParams('view=performance');
+      expect(validateSearchParams(params3)).toBe(true);
+
+      const params4 = new URLSearchParams('view=health');
+      expect(validateSearchParams(params4)).toBe(true);
     });
 
     it('should reject invalid view parameters', () => {
@@ -165,10 +172,10 @@ describe('navigationUtils', () => {
     });
 
     it('should trim parameter values', () => {
-      const params = new URLSearchParams('view= table &sequencer= test ');
+      const params = new URLSearchParams('view= performance &sequencer= test ');
       const cleaned = cleanSearchParams(params);
 
-      expect(cleaned.get('view')).toBe('table');
+      expect(cleaned.get('view')).toBe('performance');
       expect(cleaned.get('sequencer')).toBe('test');
     });
 
@@ -226,7 +233,10 @@ describe('navigationUtils', () => {
 
       renderToStaticMarkup(React.createElement(Wrapper));
       setFn('24h');
-      expect(navSpy).toHaveBeenCalledWith({ search: 'range=24h' }, { replace: true });
+      expect(navSpy).toHaveBeenCalledWith(
+        { search: 'range=24h' },
+        { replace: true },
+      );
       navSpy.mockClear();
 
       currentSearch = '?range=15m';

--- a/dashboard/types.ts
+++ b/dashboard/types.ts
@@ -97,6 +97,8 @@ export interface ChartsData {
   updateChartsData: (data: ChartsDataUpdate) => void;
 }
 
+export type DashboardViewType = 'performance' | 'economics' | 'health';
+
 export interface MetricsDataState {
   metrics: MetricData[];
   setMetrics: (metrics: MetricData[]) => void;
@@ -104,7 +106,7 @@ export interface MetricsDataState {
   setLoadingMetrics: (v: boolean) => void;
   errorMessage: string;
   setErrorMessage: (msg: string) => void;
-  isEconomicsView: boolean;
+  view: DashboardViewType;
 }
 
 export interface BlockDataState {

--- a/dashboard/utils/navigationUtils.ts
+++ b/dashboard/utils/navigationUtils.ts
@@ -83,7 +83,10 @@ export const validateSearchParams = (params: URLSearchParams): boolean => {
   try {
     // Check for reasonable parameter values
     const view = params.get('view');
-    if (view && !['table', 'economics'].includes(view)) {
+    if (
+      view &&
+      !['table', 'economics', 'performance', 'health'].includes(view)
+    ) {
       console.warn('Invalid view parameter:', view);
       return false;
     }
@@ -129,7 +132,7 @@ export const cleanSearchParams = (params: URLSearchParams): URLSearchParams => {
 
   try {
     const validators: Record<string, (v: string) => boolean> = {
-      view: (v) => ['table', 'economics'].includes(v),
+      view: (v) => ['table', 'economics', 'performance', 'health'].includes(v),
       page: (v) => /^\d+$/.test(v),
       start: (v) => /^\d+$/.test(v),
       end: (v) => /^\d+$/.test(v),


### PR DESCRIPTION
## Summary
- add tabbed view buttons for Performance, Economics and Health
- default to the economics view when query param is missing
- adjust metrics filtering and charts for the selected view
- allow new views in navigation utils
- update tests for the new tabs

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6867dbb75d408328a708ce911cba1940