### PR TITLE
Add tabbed views to dashboard

### DIFF
--- a/dashboard/components/DashboardHeader.tsx
+++ b/dashboard/components/DashboardHeader.tsx
@@ -6,6 +6,7 @@ import { isValidRefreshRate } from '../utils';
 import { isValidTimeRange, formatTimeRangeDisplay } from '../utils/timeRange';
 import { useRouterNavigation } from '../hooks/useRouterNavigation';
 import { useErrorHandler } from '../hooks/useErrorHandler';
+import { ViewTabs } from './ViewTabs';
 import { useSearchParams } from 'react-router-dom';
 import { showToast } from '../utils/toast';
 import { DayPicker } from 'react-day-picker';
@@ -53,10 +54,11 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({
   selectedSequencer,
   onSequencerChange,
 }) => {
-  const { navigateToDashboard, updateSearchParams } = useRouterNavigation();
+  const { navigateToDashboard } = useRouterNavigation();
   const { errorMessage } = useErrorHandler();
   const [searchParams] = useSearchParams();
-  const isEconomicsView = searchParams.get('view') === 'economics';
+  const viewParam = searchParams.get('view') || 'economics';
+  const isEconomicsView = viewParam === 'economics';
   React.useEffect(() => {
     if (errorMessage) {
       showToast(errorMessage);
@@ -78,20 +80,7 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({
         </h1>
       </div>
       <div className="flex flex-wrap items-center gap-2 mt-4 md:mt-0 justify-center md:justify-end">
-        <button
-          onClick={() => {
-            const params = new URLSearchParams(searchParams);
-            if (params.get('view') === 'economics') {
-              navigateToDashboard(true);
-              return;
-            }
-            updateSearchParams({ view: 'economics', table: null });
-          }}
-          className="px-2 py-1 text-sm border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700"
-          style={{ color: TAIKO_PINK }}
-        >
-          Economics
-        </button>
+        <ViewTabs />
         <a
           href="https://status.taiko.xyz/"
           target="_blank"

--- a/dashboard/components/ViewTabs.tsx
+++ b/dashboard/components/ViewTabs.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { useRouterNavigation } from '../hooks/useRouterNavigation';
+import { TAIKO_PINK } from '../theme';
+
+export const ViewTabs: React.FC = () => {
+  const { updateSearchParams, navigateToDashboard } = useRouterNavigation();
+  const [searchParams] = useSearchParams();
+  const view = searchParams.get('view') || 'economics';
+
+  const tabs: { label: string; value: string }[] = [
+    { label: 'Performance', value: 'performance' },
+    { label: 'Economics', value: 'economics' },
+    { label: 'Health', value: 'health' },
+  ];
+
+  return (
+    <div className="flex space-x-2">
+      {tabs.map((t) => (
+        <button
+          key={t.value}
+          onClick={() => {
+            if (t.value === 'economics' && view === 'economics') {
+              navigateToDashboard(true);
+              return;
+            }
+            updateSearchParams({ view: t.value, table: null });
+          }}
+          className={`px-2 py-1 text-sm border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700 ${view === t.value ? 'font-semibold' : ''}`}
+          style={{ color: TAIKO_PINK }}
+        >
+          {t.label}
+        </button>
+      ))}
+    </div>
+  );
+};

--- a/dashboard/hooks/useDataFetcher.ts
+++ b/dashboard/hooks/useDataFetcher.ts
@@ -39,7 +39,7 @@ export const useDataFetcher = ({
   const location = useLocation();
 
   // Memoize the specific value we need to prevent infinite re-renders
-  const viewParam = searchParams.get('view');
+  const viewParam = searchParams.get('view') || 'economics';
   const isTableRoute = location.pathname.startsWith('/table/');
   const isTableView = useMemo(
     () => tableView || viewParam === 'table' || isTableRoute,
@@ -79,13 +79,13 @@ export const useDataFetcher = ({
 
         profit:
           data.priorityFee != null &&
-            data.baseFee != null &&
-            data.l1DataCost != null &&
-            data.proveCost != null
+          data.baseFee != null &&
+          data.l1DataCost != null &&
+          data.proveCost != null
             ? data.priorityFee +
-            (data.baseFee * 0.75) -
-            data.l1DataCost -
-            data.proveCost
+              data.baseFee * 0.75 -
+              data.l1DataCost -
+              data.proveCost
             : null,
         l2Block: data.l2Block,
         l1Block: data.l1Block,

--- a/dashboard/hooks/useMetricsData.ts
+++ b/dashboard/hooks/useMetricsData.ts
@@ -11,7 +11,7 @@ export const useMetricsData = (): MetricsDataState => {
   const [searchParams] = useSearchParams();
 
   // Memoize the specific value we need to prevent infinite re-renders
-  const viewParam = searchParams.get('view');
+  const viewParam = searchParams.get('view') || 'economics';
   const isEconomicsView = useMemo(() => viewParam === 'economics', [viewParam]);
 
   return useMemo(

--- a/dashboard/tests/dashboardHeader.test.ts
+++ b/dashboard/tests/dashboardHeader.test.ts
@@ -20,14 +20,14 @@ describe('DashboardHeader', () => {
             null,
             React.createElement(DashboardHeader, {
               timeRange: '1h',
-              onTimeRangeChange: () => { },
+              onTimeRangeChange: () => {},
               refreshRate: 60000,
-              onRefreshRateChange: () => { },
+              onRefreshRateChange: () => {},
               lastRefresh: Date.now(),
-              onManualRefresh: () => { },
+              onManualRefresh: () => {},
               sequencers: ['seq1', 'seq2'],
               selectedSequencer: null,
-              onSequencerChange: () => { },
+              onSequencerChange: () => {},
             }),
           ),
         ),
@@ -37,8 +37,10 @@ describe('DashboardHeader', () => {
     expect(html.includes('1h')).toBe(true);
     expect(html.includes('Refresh')).toBe(true);
     expect(html.includes('Status')).toBe(true);
-    expect(html.includes('All Sequencers')).toBe(true);
+    expect(html.includes('All Sequencers')).toBe(false);
+    expect(html.includes('Performance')).toBe(true);
     expect(html.includes('Economics')).toBe(true);
+    expect(html.includes('Health')).toBe(true);
   });
 
   it('hides sequencer selector in economics view', () => {
@@ -54,14 +56,14 @@ describe('DashboardHeader', () => {
             { initialEntries: ['/?view=economics'] },
             React.createElement(DashboardHeader, {
               timeRange: '1h',
-              onTimeRangeChange: () => { },
+              onTimeRangeChange: () => {},
               refreshRate: 60000,
-              onRefreshRateChange: () => { },
+              onRefreshRateChange: () => {},
               lastRefresh: Date.now(),
-              onManualRefresh: () => { },
+              onManualRefresh: () => {},
               sequencers: ['seq1', 'seq2'],
               selectedSequencer: null,
-              onSequencerChange: () => { },
+              onSequencerChange: () => {},
             }),
           ),
         ),

--- a/dashboard/tests/navigationUtils.test.ts
+++ b/dashboard/tests/navigationUtils.test.ts
@@ -15,9 +15,10 @@ const navSpy = vi.fn();
 let currentSearch = '?range=1h';
 
 vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual<typeof import('react-router-dom')>(
-    'react-router-dom',
-  );
+  const actual =
+    await vi.importActual<typeof import('react-router-dom')>(
+      'react-router-dom',
+    );
   return {
     ...actual,
     useNavigate: () => navSpy,
@@ -98,8 +99,12 @@ describe('navigationUtils', () => {
       const params = new URLSearchParams('view=table');
       expect(validateSearchParams(params)).toBe(true);
 
-      const params2 = new URLSearchParams('view=economics');
-      expect(validateSearchParams(params2)).toBe(true);
+      const econ = new URLSearchParams('view=economics');
+      expect(validateSearchParams(econ)).toBe(true);
+      const perf = new URLSearchParams('view=performance');
+      expect(validateSearchParams(perf)).toBe(true);
+      const health = new URLSearchParams('view=health');
+      expect(validateSearchParams(health)).toBe(true);
     });
 
     it('should reject invalid view parameters', () => {
@@ -226,7 +231,10 @@ describe('navigationUtils', () => {
 
       renderToStaticMarkup(React.createElement(Wrapper));
       setFn('24h');
-      expect(navSpy).toHaveBeenCalledWith({ search: 'range=24h' }, { replace: true });
+      expect(navSpy).toHaveBeenCalledWith(
+        { search: 'range=24h' },
+        { replace: true },
+      );
       navSpy.mockClear();
 
       currentSearch = '?range=15m';

--- a/dashboard/utils/navigationUtils.ts
+++ b/dashboard/utils/navigationUtils.ts
@@ -83,7 +83,10 @@ export const validateSearchParams = (params: URLSearchParams): boolean => {
   try {
     // Check for reasonable parameter values
     const view = params.get('view');
-    if (view && !['table', 'economics'].includes(view)) {
+    if (
+      view &&
+      !['table', 'economics', 'performance', 'health'].includes(view)
+    ) {
       console.warn('Invalid view parameter:', view);
       return false;
     }
@@ -129,7 +132,7 @@ export const cleanSearchParams = (params: URLSearchParams): URLSearchParams => {
 
   try {
     const validators: Record<string, (v: string) => boolean> = {
-      view: (v) => ['table', 'economics'].includes(v),
+      view: (v) => ['table', 'economics', 'performance', 'health'].includes(v),
       page: (v) => /^\d+$/.test(v),
       start: (v) => /^\d+$/.test(v),
       end: (v) => /^\d+$/.test(v),


### PR DESCRIPTION
## Summary
- add ViewTabs component with Performance/Economics/Health tabs
- default dashboard view to economics
- update header to show tabs
- support new views in dashboard view logic
- validate new view types in navigation utils
- update tests for tabs

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6867dbb75d408328a708ce911cba1940