### PR TITLE
Remove sequencer filter from dashboard

### DIFF
--- a/dashboard/components/DashboardHeader.tsx
+++ b/dashboard/components/DashboardHeader.tsx
@@ -36,9 +36,6 @@ interface DashboardHeaderProps {
   lastRefresh: number;
   onManualRefresh: () => void;
   isTimeRangeChanging?: boolean;
-  sequencers: string[];
-  selectedSequencer: string | null;
-  onSequencerChange: (seq: string | null) => void;
 }
 
 export const DashboardHeader: React.FC<DashboardHeaderProps> = ({
@@ -49,15 +46,11 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({
   lastRefresh,
   onManualRefresh,
   isTimeRangeChanging,
-  sequencers,
-  selectedSequencer,
-  onSequencerChange,
 }) => {
   const { navigateToDashboard, updateSearchParams } = useRouterNavigation();
   const { errorMessage } = useErrorHandler();
   const [searchParams] = useSearchParams();
   const viewParam = searchParams.get('view') ?? 'economics';
-  const isEconomicsView = viewParam === 'economics';
   React.useEffect(() => {
     if (errorMessage) {
       showToast(errorMessage);
@@ -120,13 +113,7 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({
           lastRefresh={lastRefresh}
           onRefresh={onManualRefresh}
         />
-        {!isEconomicsView && (
-          <SequencerSelector
-            sequencers={sequencers}
-            value={selectedSequencer}
-            onChange={onSequencerChange}
-          />
-        )}
+        {/* Sequencer filter removed */}
         {/* Dark mode toggle removed as per request */}
       </div>
     </header>
@@ -356,37 +343,3 @@ export const RefreshRateInput: React.FC<RefreshRateInputProps> = ({
   );
 };
 
-export interface SequencerSelectorProps {
-  sequencers: string[];
-  value: string | null;
-  onChange: (seq: string | null) => void;
-}
-
-export const SequencerSelector: React.FC<SequencerSelectorProps> = ({
-  sequencers,
-  value,
-  onChange,
-}) => {
-  const sorted = React.useMemo(
-    () =>
-      [...sequencers]
-        .filter((s) => s.toLowerCase() !== 'all sequencers')
-        .sort(),
-    [sequencers],
-  );
-
-  return (
-    <select
-      value={value ?? ''}
-      onChange={(e) => onChange(e.target.value || null)}
-      className="p-1 border border-gray-300 dark:border-gray-600 rounded-md text-sm"
-    >
-      <option value="">All Sequencers</option>
-      {sorted.map((s) => (
-        <option key={s} value={s}>
-          {s}
-        </option>
-      ))}
-    </select>
-  );
-};

--- a/dashboard/components/routes/DashboardRoute.tsx
+++ b/dashboard/components/routes/DashboardRoute.tsx
@@ -31,8 +31,6 @@ export const DashboardRoute: React.FC = () => {
     timeRange,
     setTimeRange,
     selectedSequencer,
-    setSelectedSequencer,
-    sequencerList,
     chartsData,
     metricsData,
     refreshTimer,
@@ -54,9 +52,6 @@ export const DashboardRoute: React.FC = () => {
         lastRefresh={refreshTimer.lastRefresh}
         onManualRefresh={handleManualRefresh}
         isTimeRangeChanging={isTimeRangeChanging}
-        sequencers={sequencerList}
-        selectedSequencer={selectedSequencer}
-        onSequencerChange={setSelectedSequencer}
       />
       <DashboardView
         timeRange={timeRange}

--- a/dashboard/components/routes/TableRoute.tsx
+++ b/dashboard/components/routes/TableRoute.tsx
@@ -18,7 +18,6 @@ interface DashboardContextType {
   timeRange: TimeRange;
   setTimeRange: (range: TimeRange) => void;
   selectedSequencer: string | null;
-  setSelectedSequencer: (seq: string | null) => void;
   sequencerList: string[];
   chartsData: ChartsData;
   metricsData: MetricsDataState;
@@ -36,8 +35,6 @@ export const TableRoute: React.FC = () => {
     timeRange,
     setTimeRange,
     selectedSequencer,
-    setSelectedSequencer,
-    sequencerList,
     chartsData,
     metricsData,
     refreshTimer,
@@ -298,9 +295,6 @@ export const TableRoute: React.FC = () => {
         onRefreshRateChange={refreshTimer.setRefreshRate}
         lastRefresh={refreshTimer.lastRefresh}
         onManualRefresh={handleManualRefresh}
-        sequencers={sequencerList}
-        selectedSequencer={selectedSequencer}
-        onSequencerChange={setSelectedSequencer}
       />
       <TableView
         tableView={tableView}

--- a/dashboard/tests/dashboardHeader.test.ts
+++ b/dashboard/tests/dashboardHeader.test.ts
@@ -25,9 +25,6 @@ describe('DashboardHeader', () => {
               onRefreshRateChange: () => { },
               lastRefresh: Date.now(),
               onManualRefresh: () => { },
-              sequencers: ['seq1', 'seq2'],
-              selectedSequencer: null,
-              onSequencerChange: () => { },
             }),
           ),
         ),
@@ -37,7 +34,6 @@ describe('DashboardHeader', () => {
     expect(html.includes('1h')).toBe(true);
     expect(html.includes('Refresh')).toBe(true);
     expect(html.includes('Status')).toBe(true);
-    expect(html.includes('All Sequencers')).toBe(true);
     expect(html.includes('Performance')).toBe(true);
     expect(html.includes('Economics')).toBe(true);
     expect(html.includes('Health')).toBe(true);
@@ -61,14 +57,11 @@ describe('DashboardHeader', () => {
               onRefreshRateChange: () => { },
               lastRefresh: Date.now(),
               onManualRefresh: () => { },
-              sequencers: ['seq1', 'seq2'],
-              selectedSequencer: null,
-              onSequencerChange: () => { },
             }),
           ),
         ),
       ),
     );
-    expect(html.includes('All Sequencers')).toBe(false);
+    expect(html.includes('Taikoscope Hekla')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- drop sequencer dropdown from dashboard header
- update dashboard routes for new header props
- fix related tests

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6867e70290ec83289b3564fe309d981c