### PR TITLE
refactor: remove option from fee costs

### DIFF
--- a/crates/api-types/src/lib.rs
+++ b/crates/api-types/src/lib.rs
@@ -194,9 +194,9 @@ pub struct L2FeesResponse {
     /// Sum of base fees for the range.
     pub base_fee: Option<u128>,
     /// Total L1 data posting cost for the range.
-    pub l1_data_cost: Option<u128>,
+    pub l1_data_cost: u128,
     /// Total proving cost for the range.
-    pub prove_cost: Option<u128>,
+    pub prove_cost: u128,
     /// Fee breakdown for each sequencer.
     pub sequencers: Vec<SequencerFeeRow>,
 }
@@ -395,9 +395,9 @@ pub struct SequencerFeeRow {
     /// Sum of base fees for the sequencer.
     pub base_fee: u128,
     /// Total L1 data posting cost for the sequencer.
-    pub l1_data_cost: Option<u128>,
+    pub l1_data_cost: u128,
     /// Total proving cost for the sequencer.
-    pub prove_cost: Option<u128>,
+    pub prove_cost: u128,
 }
 
 /// Blob count per batch.

--- a/crates/api/src/routes/core.rs
+++ b/crates/api/src/routes/core.rs
@@ -730,15 +730,15 @@ pub async fn l2_fees(
             address: format!("0x{}", encode(r.sequencer)),
             priority_fee: r.priority_fee / WEI_PER_GWEI,
             base_fee: r.base_fee / WEI_PER_GWEI,
-            l1_data_cost: r.l1_data_cost.map(|v| v / WEI_PER_GWEI),
-            prove_cost: r.prove_cost.map(|v| v / WEI_PER_GWEI),
+            l1_data_cost: r.l1_data_cost.unwrap_or(0) / WEI_PER_GWEI,
+            prove_cost: r.prove_cost.unwrap_or(0) / WEI_PER_GWEI,
         })
         .collect();
 
     let priority_fee = priority_fee.map(|v| v / WEI_PER_GWEI);
     let base_fee = base_fee.map(|v| v / WEI_PER_GWEI);
-    let l1_data_cost = l1_data_cost.map(|v| v / WEI_PER_GWEI);
-    let prove_cost = prove_cost.map(|v| v / WEI_PER_GWEI);
+    let l1_data_cost = l1_data_cost.unwrap_or(0) / WEI_PER_GWEI;
+    let prove_cost = prove_cost.unwrap_or(0) / WEI_PER_GWEI;
 
     tracing::info!(count = sequencers.len(), "Returning L2 fees and breakdown");
     Ok(Json(L2FeesResponse { priority_fee, base_fee, l1_data_cost, prove_cost, sequencers }))
@@ -802,17 +802,17 @@ pub async fn batch_fees(
             address: format!("0x{}", encode(r.sequencer)),
             priority_fee: r.priority_fee / WEI_PER_GWEI,
             base_fee: r.base_fee / WEI_PER_GWEI,
-            l1_data_cost: r.l1_data_cost.map(|v| v / WEI_PER_GWEI),
-            prove_cost: r.prove_cost.map(|v| v / WEI_PER_GWEI),
+            l1_data_cost: r.l1_data_cost.unwrap_or(0) / WEI_PER_GWEI,
+            prove_cost: r.prove_cost.unwrap_or(0) / WEI_PER_GWEI,
         })
         .collect();
 
     let priority_fee = priority_fee.map(|v| v / WEI_PER_GWEI);
     let base_fee = base_fee.map(|v| v / WEI_PER_GWEI);
-    let l1_data_cost = l1_data_cost.map(|v| v / WEI_PER_GWEI);
+    let l1_data_cost = l1_data_cost.unwrap_or(0) / WEI_PER_GWEI;
 
     tracing::info!(count = sequencers.len(), "Returning batch fees and breakdown");
-    Ok(Json(L2FeesResponse { priority_fee, base_fee, l1_data_cost, prove_cost: None, sequencers }))
+    Ok(Json(L2FeesResponse { priority_fee, base_fee, l1_data_cost, prove_cost: 0, sequencers }))
 }
 
 #[utoipa::path(

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -855,15 +855,15 @@ export interface SequencerFee {
   address: string;
   priority_fee: number;
   base_fee: number;
-  l1_data_cost: number | null;
-  prove_cost: number | null;
+  l1_data_cost: number;
+  prove_cost: number;
 }
 
 export interface L2FeesResponse {
   priority_fee: number | null;
   base_fee: number | null;
-  l1_data_cost: number | null;
-  prove_cost: number | null;
+  l1_data_cost: number;
+  prove_cost: number;
   sequencers: SequencerFee[];
 }
 

--- a/dashboard/tests/app.integration.test.ts
+++ b/dashboard/tests/app.integration.test.ts
@@ -137,14 +137,14 @@ const responses: Record<string, Record<string, unknown>> = {
   [`/v1/l2-fees?${q1h}`]: {
     priority_fee: 600,
     base_fee: 400,
-    l1_data_cost: null,
+    l1_data_cost: 0,
     prove_cost: 5,
     sequencers: [],
   },
   [`/v1/l2-fees?${q15m}`]: {
     priority_fee: 600,
     base_fee: 400,
-    l1_data_cost: null,
+    l1_data_cost: 0,
     prove_cost: 5,
     sequencers: [],
   },
@@ -175,7 +175,7 @@ const responses: Record<string, Record<string, unknown>> = {
   [`/v1/l2-fees?${q24h}`]: {
     priority_fee: 1200,
     base_fee: 800,
-    l1_data_cost: null,
+    l1_data_cost: 0,
     prove_cost: 10,
     sequencers: [],
   },

--- a/dashboard/tests/dataFetcher.test.ts
+++ b/dashboard/tests/dataFetcher.test.ts
@@ -109,7 +109,7 @@ describe('dataFetcher', () => {
     expect(res.badRequestResults).toHaveLength(4);
   });
 
-  it('defaults economics costs to null when missing', async () => {
+  it('defaults economics costs to zero when missing', async () => {
     setAll({
       fetchL2Fees: ok({
         priority_fee: null,
@@ -126,8 +126,8 @@ describe('dataFetcher', () => {
     const res = await fetchEconomicsData('1h', null);
     expect(res.priorityFee).toBeNull();
     expect(res.baseFee).toBeNull();
-    expect(res.l1DataCost).toBeNull();
-    expect(res.proveCost).toBeNull();
+    expect(res.l1DataCost).toBe(0);
+    expect(res.proveCost).toBe(0);
 
     expect(res.badRequestResults).toHaveLength(4);
   });

--- a/dashboard/utils/dataFetcher.ts
+++ b/dashboard/utils/dataFetcher.ts
@@ -48,8 +48,8 @@ export interface MainDashboardData {
 export interface EconomicsData {
   priorityFee: number | null;
   baseFee: number | null;
-  l1DataCost: number | null;
-  proveCost: number | null;
+  l1DataCost: number;
+  proveCost: number;
   l2Block: number | null;
   l1Block: number | null;
   sequencerDist: SequencerDistributionDataItem[];
@@ -123,7 +123,7 @@ export const fetchMainDashboardData = async (
     blobsPerBatch: batchBlobCountsRes.data || [],
     priorityFee: data?.priority_fee ?? null,
     baseFee: data?.base_fee ?? null,
-    proveCost: data?.prove_cost ?? null,
+    proveCost: data?.prove_cost ?? 0,
 
     badRequestResults: allResults.slice(1),
   };
@@ -147,8 +147,8 @@ export const fetchEconomicsData = async (
   return {
     priorityFee: l2FeesRes.data?.priority_fee ?? null,
     baseFee: l2FeesRes.data?.base_fee ?? null,
-    l1DataCost: l2FeesRes.data?.l1_data_cost ?? null,
-    proveCost: l2FeesRes.data?.prove_cost ?? null,
+    l1DataCost: l2FeesRes.data?.l1_data_cost ?? 0,
+    proveCost: l2FeesRes.data?.prove_cost ?? 0,
 
     l2Block: l2BlockRes.data,
     l1Block: l1BlockRes.data,

--- a/tests/api_integration.rs
+++ b/tests/api_integration.rs
@@ -674,7 +674,7 @@ async fn batch_fees_integration() {
             "priority_fee": 10,
             "base_fee": 20,
             "l1_data_cost": 5,
-            "prove_cost": null,
+            "prove_cost": 0,
             "sequencers": [
                 {
                     "address": format!("0x{}", hex::encode([2u8; 20])),


### PR DESCRIPTION
## Summary
- make `l1_data_cost` and `prove_cost` required in API types
- default missing fee costs to zero in API routes
- update dashboard types and data fetcher
- adjust tests for new cost defaults

## Testing
- `just fmt`
- `just check-dashboard`
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6867e28d8c0883288f853d7b846eca33