### PR TITLE
Reorder dashboard tabs

### DIFF
--- a/dashboard/components/DashboardHeader.tsx
+++ b/dashboard/components/DashboardHeader.tsx
@@ -75,8 +75,8 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({
       <div className="flex flex-wrap items-center gap-2 mt-4 md:mt-0 justify-center md:justify-end">
         <div className="flex gap-2">
           {[
-            { view: 'performance', label: 'Performance' },
             { view: 'economics', label: 'Economics' },
+            { view: 'performance', label: 'Performance' },
             { view: 'health', label: 'Health' },
           ].map((tab) => (
             <button


### PR DESCRIPTION
## Summary
- update dashboard header to display Economics tab first

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6867ed3b2b18832897d9edb0bcdc7050