### PR TITLE
Optimize l2 fees endpoint

### DIFF
--- a/tests/api_integration.rs
+++ b/tests/api_integration.rs
@@ -538,9 +538,6 @@ async fn prove_cost_integration() {
 #[tokio::test]
 async fn l2_fees_integration() {
     let mock = Mock::new();
-    mock.add(handlers::provide(vec![TotalRow { total: 600 * WEI_PER_GWEI }]));
-    mock.add(handlers::provide(vec![TotalRow { total: 400 * WEI_PER_GWEI }]));
-    mock.add(handlers::provide(vec![TotalRow { total: 10 * WEI_PER_GWEI }]));
     mock.add(handlers::provide::<clickhouse_lib::SequencerFeeRow>(vec![
         clickhouse_lib::SequencerFeeRow {
             sequencer: AddressBytes([1u8; 20]),


### PR DESCRIPTION
## Summary
- avoid redundant queries in `l2_fees`
- compute fee totals from per-sequencer results
- adjust integration test

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6867f5332a3c8328829339cf96f136c2