### PR TITLE
Refactor reorg models

### DIFF
--- a/crates/api/src/routes/table.rs
+++ b/crates/api/src/routes/table.rs
@@ -64,15 +64,12 @@ pub async fn reorgs(
     };
     let events: Vec<L2ReorgEvent> = rows
         .into_iter()
-        .filter_map(|e| {
-            let inserted_at = e.inserted_at?;
-            Some(L2ReorgEvent {
-                l2_block_number: e.l2_block_number,
-                depth: e.depth,
-                old_sequencer: format!("0x{}", encode(e.old_sequencer)),
-                new_sequencer: format!("0x{}", encode(e.new_sequencer)),
-                inserted_at,
-            })
+        .map(|e| L2ReorgEvent {
+            l2_block_number: e.l2_block_number,
+            depth: e.depth,
+            old_sequencer: format!("0x{}", encode(e.old_sequencer)),
+            new_sequencer: format!("0x{}", encode(e.new_sequencer)),
+            inserted_at: e.inserted_at,
         })
         .collect();
     tracing::info!(count = events.len(), "Returning reorg events");

--- a/crates/clickhouse/src/models.rs
+++ b/crates/clickhouse/src/models.rs
@@ -156,7 +156,7 @@ pub struct L2ReorgRow {
     pub new_sequencer: AddressBytes,
     /// Time the reorg was recorded.
     /// This is populated when reading from the database.
-    pub inserted_at: Option<DateTime<Utc>>,
+    pub inserted_at: DateTime<Utc>,
 }
 
 /// Forced inclusion processed row

--- a/crates/clickhouse/src/reader/client.rs
+++ b/crates/clickhouse/src/reader/client.rs
@@ -507,7 +507,7 @@ impl ClickhouseReader {
                     depth: r.depth,
                     old_sequencer: r.old_sequencer,
                     new_sequencer: r.new_sequencer,
-                    inserted_at: Some(ts),
+                    inserted_at: ts,
                 })
             })
             .collect())
@@ -563,7 +563,7 @@ impl ClickhouseReader {
                     depth: r.depth,
                     old_sequencer: r.old_sequencer,
                     new_sequencer: r.new_sequencer,
-                    inserted_at: Some(ts),
+                    inserted_at: ts,
                 })
             })
             .collect())

--- a/crates/messages/src/models.rs
+++ b/crates/messages/src/models.rs
@@ -149,7 +149,7 @@ pub struct L2ReorgRow {
     pub new_sequencer: AddressBytes,
     /// Time the reorg was recorded.
     /// This is populated when reading from the database.
-    pub inserted_at: Option<DateTime<Utc>>,
+    pub inserted_at: DateTime<Utc>,
 }
 
 /// Forced inclusion processed row


### PR DESCRIPTION
## Summary
- remove `Option` from `inserted_at` in reorg models
- adjust reader and API code for new type

## Testing
- `just lint`
- `just test`
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_686b6fbd8f708328b26e55bf25e625eb