### PR TITLE
Optimize L2 block time aggregation

### DIFF
--- a/crates/api/src/routes/aggregated.rs
+++ b/crates/api/src/routes/aggregated.rs
@@ -2,10 +2,9 @@
 
 use crate::{
     helpers::{
-        aggregate_blobs_per_batch, aggregate_block_transactions, aggregate_l2_block_times,
-        aggregate_l2_fee_components, aggregate_l2_gas_used, aggregate_l2_tps,
-        aggregate_prove_times, aggregate_verify_times, blobs_bucket_size, bucket_size_from_range,
-        prove_bucket_size, verify_bucket_size,
+        aggregate_blobs_per_batch, aggregate_block_transactions, aggregate_l2_fee_components,
+        aggregate_l2_gas_used, aggregate_l2_tps, aggregate_prove_times, aggregate_verify_times,
+        blobs_bucket_size, bucket_size_from_range, prove_bucket_size, verify_bucket_size,
     },
     state::{ApiState, MAX_BLOCK_TRANSACTIONS_LIMIT},
     validation::{
@@ -65,15 +64,15 @@ pub async fn l2_block_times_aggregated(
     } else {
         None
     };
-    let blocks = match state.client.get_l2_block_times(address, time_range).await {
+    let bucket = bucket_size_from_range(&time_range);
+    let blocks = match state.client.get_l2_block_times_aggregated(address, time_range, bucket).await
+    {
         Ok(rows) => rows,
         Err(e) => {
-            tracing::error!(error = %e, "Failed to get L2 block times");
+            tracing::error!(error = %e, "Failed to get aggregated L2 block times");
             return Err(ErrorResponse::database_error());
         }
     };
-    let bucket = bucket_size_from_range(&time_range);
-    let blocks = aggregate_l2_block_times(blocks, bucket);
     tracing::info!(count = blocks.len(), "Returning aggregated L2 block times");
     Ok(Json(L2BlockTimesResponse { blocks }))
 }

--- a/crates/clickhouse/src/reader/client.rs
+++ b/crates/clickhouse/src/reader/client.rs
@@ -8,10 +8,7 @@ use derive_more::Debug;
 use eyre::{Context, Result};
 use hex::encode;
 use serde::{Deserialize, Serialize};
-use std::{
-    collections::{BTreeSet, HashMap},
-    time::Instant,
-};
+use std::{collections::BTreeSet, time::Instant};
 use tracing::{debug, error};
 use url::Url;
 


### PR DESCRIPTION
## Summary
- add ClickHouse query for aggregated L2 block times
- update API to use SQL aggregation
- test aggregated query and endpoint

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_686be1dd926c832890ca6a8146996df5