### PR TITLE
Implement DB-side aggregation for API metrics

### DIFF
--- a/crates/api/src/routes/core.rs
+++ b/crates/api/src/routes/core.rs
@@ -546,10 +546,11 @@ pub async fn block_profits(
         None
     };
 
-    let rows = state.client.get_l2_fee_components(address, time_range).await.map_err(|e| {
-        tracing::error!(error = %e, "Failed to get fee components");
-        ErrorResponse::database_error()
-    })?;
+    let rows =
+        state.client.get_l2_fee_components(address, time_range, None).await.map_err(|e| {
+            tracing::error!(error = %e, "Failed to get fee components");
+            ErrorResponse::database_error()
+        })?;
 
     let mut blocks: Vec<BlockProfitItem> = rows
         .into_iter()
@@ -717,10 +718,11 @@ pub async fn l2_fee_components(
         None
     };
 
-    let blocks = state.client.get_l2_fee_components(address, time_range).await.map_err(|e| {
-        tracing::error!(error = %e, "Failed to get fee components");
-        ErrorResponse::database_error()
-    })?;
+    let blocks =
+        state.client.get_l2_fee_components(address, time_range, None).await.map_err(|e| {
+            tracing::error!(error = %e, "Failed to get fee components");
+            ErrorResponse::database_error()
+        })?;
 
     let blocks: Vec<BlockFeeComponentRow> = blocks
         .into_iter()

--- a/crates/clickhouse/src/reader/tests.rs
+++ b/crates/clickhouse/src/reader/tests.rs
@@ -26,7 +26,7 @@ async fn fee_components_returns_expected_rows() {
     let url = url::Url::parse(mock.url()).unwrap();
     let reader = ClickhouseReader::new(url, "db".to_owned(), "user".into(), "pass".into()).unwrap();
 
-    let rows = reader.get_l2_fee_components(None, TimeRange::LastHour).await.unwrap();
+    let rows = reader.get_l2_fee_components(None, TimeRange::LastHour, None).await.unwrap();
 
     assert_eq!(
         rows,


### PR DESCRIPTION
## Summary
- add optional bucket params to Clickhouse reader methods
- aggregate metrics directly in SQL queries
- update aggregated API routes to use DB-side aggregation

## Testing
- `just ci` *(fails: build terminated)*


------
https://chatgpt.com/codex/tasks/task_b_686cc94297b48328b0c0ad94c31dc6ef