### PR TITLE
Simplify economics profit computation

### DIFF
--- a/dashboard/hooks/useDataFetcher.ts
+++ b/dashboard/hooks/useDataFetcher.ts
@@ -9,6 +9,7 @@ import {
   fetchEconomicsData,
 } from '../utils/dataFetcher';
 import { createMetrics, type MetricInputData } from '../utils/metricsCreator';
+import { calculateNetProfit } from '../utils/profit';
 import { hasBadRequest, getErrorMessage } from '../utils/errorHandler';
 
 interface UseDataFetcherProps {
@@ -83,10 +84,12 @@ export const useDataFetcher = ({
             data.baseFee != null &&
             data.l1DataCost != null &&
             data.proveCost != null
-            ? data.priorityFee +
-            (data.baseFee * 0.75) -
-            data.l1DataCost -
-            data.proveCost
+            ? calculateNetProfit({
+              priorityFee: data.priorityFee,
+              baseFee: data.baseFee,
+              l1DataCost: data.l1DataCost,
+              proveCost: data.proveCost,
+            })
             : null,
         l2Block: data.l2Block,
         l1Block: data.l1Block,

--- a/dashboard/tests/profit.test.ts
+++ b/dashboard/tests/profit.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { calculateProfit } from '../utils/profit';
+import { calculateProfit, calculateNetProfit } from '../utils/profit';
 
 describe('calculateProfit', () => {
   it('computes positive profit', () => {
@@ -36,5 +36,15 @@ describe('calculateProfit', () => {
     expect(res.revenueUsd).toBeCloseTo(0);
     expect(res.costUsd).toBeCloseTo(55);
     expect(res.profitUsd).toBeCloseTo(-55);
+  });
+
+  it('calculates net profit in gwei', () => {
+    const profit = calculateNetProfit({
+      priorityFee: 10,
+      baseFee: 20,
+      l1DataCost: 5,
+      proveCost: 5,
+    });
+    expect(profit).toBeCloseTo(10 + 20 * 0.75 - 5 - 5);
   });
 });

--- a/dashboard/utils/profit.ts
+++ b/dashboard/utils/profit.ts
@@ -44,3 +44,27 @@ export const calculateProfit = ({
     profitUsd,
   };
 };
+
+export interface NetProfitParams {
+  priorityFee?: number | null;
+  baseFee?: number | null;
+  l1DataCost?: number | null;
+  proveCost?: number | null;
+}
+
+/**
+ * Calculate net profit in gwei without hardware costs.
+ */
+export const calculateNetProfit = ({
+  priorityFee = 0,
+  baseFee = 0,
+  l1DataCost = 0,
+  proveCost = 0,
+}: NetProfitParams): number => {
+  return (
+    (priorityFee ?? 0) +
+    (baseFee ?? 0) * 0.75 -
+    (l1DataCost ?? 0) -
+    (proveCost ?? 0)
+  );
+};


### PR DESCRIPTION
## Summary
- add `calculateNetProfit` helper
- reuse helper in data fetcher
- cover new helper with tests

## Testing
- `npm run lint:whitespace`
- `npm run check`
- `npm run test`
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_686d03cfc3888328b3edfef19c43f40c