### PR TITLE
Add bucketed l2 block times query

### DIFF
--- a/crates/api/src/routes/aggregated.rs
+++ b/crates/api/src/routes/aggregated.rs
@@ -2,10 +2,9 @@
 
 use crate::{
     helpers::{
-        aggregate_blobs_per_batch, aggregate_block_transactions, aggregate_l2_block_times,
-        aggregate_l2_fee_components, aggregate_l2_gas_used, aggregate_l2_tps,
-        aggregate_prove_times, aggregate_verify_times, blobs_bucket_size, bucket_size_from_range,
-        prove_bucket_size, verify_bucket_size,
+        aggregate_blobs_per_batch, aggregate_block_transactions, aggregate_l2_fee_components,
+        aggregate_l2_gas_used, aggregate_l2_tps, aggregate_prove_times, aggregate_verify_times,
+        blobs_bucket_size, bucket_size_from_range, prove_bucket_size, verify_bucket_size,
     },
     state::{ApiState, MAX_BLOCK_TRANSACTIONS_LIMIT},
     validation::{
@@ -65,15 +64,14 @@ pub async fn l2_block_times_aggregated(
     } else {
         None
     };
-    let blocks = match state.client.get_l2_block_times(address, time_range).await {
+    let bucket = bucket_size_from_range(&time_range);
+    let blocks = match state.client.get_l2_block_times(address, time_range, Some(bucket)).await {
         Ok(rows) => rows,
         Err(e) => {
             tracing::error!(error = %e, "Failed to get L2 block times");
             return Err(ErrorResponse::database_error());
         }
     };
-    let bucket = bucket_size_from_range(&time_range);
-    let blocks = aggregate_l2_block_times(blocks, bucket);
     tracing::info!(count = blocks.len(), "Returning aggregated L2 block times");
     Ok(Json(L2BlockTimesResponse { blocks }))
 }


### PR DESCRIPTION
## Summary
- add optional bucket param to `get_l2_block_times`
- aggregate in DB when bucket provided
- call bucketed query from aggregated route

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_686d0a00d094832895c9625f2ffdf2e3