### PR TITLE
Update dashboard default time range

### DIFF
--- a/dashboard/components/routes/TableRoute.tsx
+++ b/dashboard/components/routes/TableRoute.tsx
@@ -44,7 +44,7 @@ export const TableRoute: React.FC = () => {
   const handleTimeRangeChange = useCallback(
     (newRange: TimeRange) => {
       const newParams = new URLSearchParams(searchParams);
-      if (newRange === '1h') {
+      if (newRange === '24h') {
         newParams.delete('range');
       } else {
         newParams.set('range', newRange);

--- a/dashboard/hooks/useTimeRangeSync.ts
+++ b/dashboard/hooks/useTimeRangeSync.ts
@@ -3,7 +3,7 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { TimeRange } from '../types';
 import { isValidTimeRange } from '../utils/timeRange';
 
-const DEFAULT_TIME_RANGE: TimeRange = '1h';
+const DEFAULT_TIME_RANGE: TimeRange = '24h';
 
 /**
  * Hook that synchronizes time range state with URL parameters to prevent navigation loops

--- a/dashboard/tests/navigationUtils.test.ts
+++ b/dashboard/tests/navigationUtils.test.ts
@@ -232,12 +232,12 @@ describe('navigationUtils', () => {
 
       renderToStaticMarkup(React.createElement(Wrapper));
       setFn('24h');
-      expect(navSpy).toHaveBeenCalledWith({ search: 'range=24h' }, { replace: true });
+      expect(navSpy).toHaveBeenCalledWith({ search: '' }, { replace: true });
       navSpy.mockClear();
 
       currentSearch = '?range=15m';
       renderToStaticMarkup(React.createElement(Wrapper));
-      setFn('1h');
+      setFn('24h');
       expect(navSpy).toHaveBeenCalledWith({ search: '' }, { replace: true });
     });
   });

--- a/dashboard/tests/timeRange.test.ts
+++ b/dashboard/tests/timeRange.test.ts
@@ -14,8 +14,8 @@ describe('normalizeTimeRange', () => {
     expect(normalizeTimeRange('1000-2000', now)).toBe('1000-2000');
   });
 
-  it('trims whitespace and defaults to one hour for invalid input', () => {
+  it('trims whitespace and defaults to 24 hours for invalid input', () => {
     expect(normalizeTimeRange(' 1h ', now)).toBe(`${now - 3_600_000}-${now}`);
-    expect(normalizeTimeRange('foo', now)).toBe(`${now - 3_600_000}-${now}`);
+    expect(normalizeTimeRange('foo', now)).toBe(`${now - 86_400_000}-${now}`);
   });
 });

--- a/dashboard/utils/timeRange.ts
+++ b/dashboard/utils/timeRange.ts
@@ -36,16 +36,16 @@ export const rangeToHours = (range: string): number => {
   if (custom) {
     const start = parseInt(custom[1], 10);
     const end = parseInt(custom[2], 10);
-    if (isNaN(start) || isNaN(end) || end <= start) return 1;
+    if (isNaN(start) || isNaN(end) || end <= start) return 24;
     return (end - start) / 3_600_000;
   }
 
-  return 1;
+  return 24;
 };
 
 export const timeRangeToQuery = (range: string): string => {
   const now = Date.now();
-  let start = now - 3600_000;
+  let start = now - 86_400_000;
   let end = now;
 
   const trimmed = range.trim();
@@ -119,7 +119,7 @@ export const normalizeTimeRange = (
   range: string,
   now: number = Date.now(),
 ): string => {
-  let start = now - 3600_000;
+  let start = now - 86_400_000;
   let end = now;
 
   const trimmed = range.trim();


### PR DESCRIPTION
## Summary
- set default time range to `24h` in hooks and logic
- adjust helper functions to use 24 hour default
- update table route handling
- fix tests for new default

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_686d20e9301883289e66e7ebcc92d85c