### PR TITLE
Set dashboard refresh default to 1h

### DIFF
--- a/dashboard/components/DashboardHeader.tsx
+++ b/dashboard/components/DashboardHeader.tsx
@@ -305,7 +305,7 @@ export const RefreshRateInput: React.FC<RefreshRateInputProps> = ({
   onRefreshRateChange,
 }) => {
   const options = [
-    { label: '60s', value: 60_000 },
+    { label: '1h', value: 60 * 60_000 },
     { label: '5 min', value: 5 * 60_000 },
     { label: '10 min', value: 10 * 60_000 },
   ];

--- a/dashboard/hooks/useDataFetcher.ts
+++ b/dashboard/hooks/useDataFetcher.ts
@@ -156,7 +156,7 @@ export const useDataFetcher = ({
   };
 
   const { data, mutate, isLoading, isValidating } = useSWR(fetchKey, fetcher, {
-    refreshInterval: Math.max(refreshRate, 60000),
+    refreshInterval: Math.max(refreshRate, 3_600_000),
     revalidateOnFocus: false,
     refreshWhenHidden: false,
     onError: () => {

--- a/dashboard/tests/dashboardHeader.test.ts
+++ b/dashboard/tests/dashboardHeader.test.ts
@@ -21,7 +21,7 @@ describe('DashboardHeader', () => {
             React.createElement(DashboardHeader, {
               timeRange: '1h',
               onTimeRangeChange: () => { },
-              refreshRate: 60000,
+              refreshRate: 3_600_000,
               onRefreshRateChange: () => { },
               lastRefresh: Date.now(),
               onManualRefresh: () => { },
@@ -53,7 +53,7 @@ describe('DashboardHeader', () => {
             React.createElement(DashboardHeader, {
               timeRange: '1h',
               onTimeRangeChange: () => { },
-              refreshRate: 60000,
+              refreshRate: 3_600_000,
               onRefreshRateChange: () => { },
               lastRefresh: Date.now(),
               onManualRefresh: () => { },

--- a/dashboard/tests/utils.more.test.ts
+++ b/dashboard/tests/utils.more.test.ts
@@ -74,14 +74,14 @@ describe('utils additional', () => {
   });
 
   it('validates refresh rate positively', () => {
-    expect(isValidRefreshRate(60000)).toBe(true);
+    expect(isValidRefreshRate(3_600_000)).toBe(true);
   });
 
   it('loads refresh rate when localStorage is missing', () => {
     const prev = (globalThis as { localStorage?: Storage }).localStorage;
     // Ensure localStorage is undefined
     delete (globalThis as { localStorage?: Storage }).localStorage;
-    expect(loadRefreshRate()).toBe(600000);
+    expect(loadRefreshRate()).toBe(3_600_000);
     if (prev !== undefined)
       (globalThis as { localStorage?: Storage }).localStorage = prev;
   });

--- a/dashboard/tests/utils.test.ts
+++ b/dashboard/tests/utils.test.ts
@@ -172,11 +172,11 @@ describe('utils', () => {
       length: 0,
     } as Storage;
 
-    expect(loadRefreshRate()).toBe(600000);
-    saveRefreshRate(600000);
-    expect(store.refreshRate).toBe('600000');
+    expect(loadRefreshRate()).toBe(3_600_000);
+    saveRefreshRate(3_600_000);
+    expect(store.refreshRate).toBe('3600000');
     store.refreshRate = '2000';
-    expect(loadRefreshRate()).toBe(600000);
+    expect(loadRefreshRate()).toBe(3_600_000);
   });
 
   it('validates refresh rate', () => {

--- a/dashboard/utils.ts
+++ b/dashboard/utils.ts
@@ -247,18 +247,18 @@ export const bytesToHex = (bytes: number[]): string =>
   `0x${bytes.map((b) => b.toString(16).padStart(2, '0')).join('')}`;
 
 export const loadRefreshRate = (): number => {
-  if (typeof localStorage === 'undefined') return 600000;
+  if (typeof localStorage === 'undefined') return 3_600_000;
   try {
     const stored = localStorage.getItem('refreshRate');
     const value = stored ? parseInt(stored, 10) : NaN;
-    if (!Number.isFinite(value) || value < 60000) {
+    if (!Number.isFinite(value) || value < 3_600_000) {
       localStorage.removeItem('refreshRate');
-      return 600000;
+      return 3_600_000;
     }
     return value;
   } catch (err) {
     console.error('Failed to access localStorage:', err);
-    return 600000;
+    return 3_600_000;
   }
 };
 
@@ -272,4 +272,4 @@ export const saveRefreshRate = (rate: number): void => {
 };
 
 export const isValidRefreshRate = (rate: number): boolean =>
-  Number.isFinite(rate) && rate >= 60000;
+  Number.isFinite(rate) && rate >= 3_600_000;


### PR DESCRIPTION
## Summary
- switch dashboard refresh options to use `1h`
- default refresh rate to 1h in utils and enforce 1h minimum
- update hooks to respect the new refresh interval
- adjust tests for the new default

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_686e7aff4a9483288dce2100a3f851de