### PR TITLE
Add off refresh option

### DIFF
--- a/dashboard/components/DashboardHeader.tsx
+++ b/dashboard/components/DashboardHeader.tsx
@@ -305,6 +305,7 @@ export const RefreshRateInput: React.FC<RefreshRateInputProps> = ({
   onRefreshRateChange,
 }) => {
   const options = [
+    { label: 'Off', value: 0 },
     { label: '5 min', value: 5 * 60_000 },
     { label: '10 min', value: 10 * 60_000 },
     { label: '1h', value: 60 * 60_000 },
@@ -329,7 +330,7 @@ export const RefreshRateInput: React.FC<RefreshRateInputProps> = ({
         id="refreshRate"
         value={refreshRate}
         onChange={handleChange}
-        className="p-1 border border-gray-300 dark:border-gray-600 rounded-md text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
+        className="p-1 border border-gray-300 dark:border-gray-600 rounded-md text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-center"
       >
         {options.map(({ label, value }) => (
           <option key={value} value={value}>

--- a/dashboard/hooks/useDataFetcher.ts
+++ b/dashboard/hooks/useDataFetcher.ts
@@ -156,7 +156,8 @@ export const useDataFetcher = ({
   };
 
   const { data, mutate, isLoading, isValidating } = useSWR(fetchKey, fetcher, {
-    refreshInterval: Math.max(refreshRate, 300_000),
+    refreshInterval:
+      refreshRate === 0 ? 0 : Math.max(refreshRate, 300_000),
     revalidateOnFocus: false,
     refreshWhenHidden: false,
     onError: () => {

--- a/dashboard/tests/utils.more.test.ts
+++ b/dashboard/tests/utils.more.test.ts
@@ -74,14 +74,14 @@ describe('utils additional', () => {
   });
 
   it('validates refresh rate positively', () => {
-    expect(isValidRefreshRate(300_000)).toBe(true);
+    expect(isValidRefreshRate(0)).toBe(true);
   });
 
   it('loads refresh rate when localStorage is missing', () => {
     const prev = (globalThis as { localStorage?: Storage }).localStorage;
     // Ensure localStorage is undefined
     delete (globalThis as { localStorage?: Storage }).localStorage;
-    expect(loadRefreshRate()).toBe(3_600_000);
+    expect(loadRefreshRate()).toBe(0);
     if (prev !== undefined)
       (globalThis as { localStorage?: Storage }).localStorage = prev;
   });

--- a/dashboard/tests/utils.test.ts
+++ b/dashboard/tests/utils.test.ts
@@ -172,14 +172,15 @@ describe('utils', () => {
       length: 0,
     } as Storage;
 
-    expect(loadRefreshRate()).toBe(3_600_000);
-    saveRefreshRate(3_600_000);
-    expect(store.refreshRate).toBe('3600000');
+    expect(loadRefreshRate()).toBe(0);
+    saveRefreshRate(0);
+    expect(store.refreshRate).toBe('0');
     store.refreshRate = '2000';
-    expect(loadRefreshRate()).toBe(3_600_000);
+    expect(loadRefreshRate()).toBe(0);
   });
 
   it('validates refresh rate', () => {
+    expect(isValidRefreshRate(0)).toBe(true);
     expect(isValidRefreshRate(300_000)).toBe(true);
     expect(isValidRefreshRate(1000)).toBe(false);
     expect(isValidRefreshRate(-1)).toBe(false);

--- a/dashboard/utils.ts
+++ b/dashboard/utils.ts
@@ -247,18 +247,18 @@ export const bytesToHex = (bytes: number[]): string =>
   `0x${bytes.map((b) => b.toString(16).padStart(2, '0')).join('')}`;
 
 export const loadRefreshRate = (): number => {
-  if (typeof localStorage === 'undefined') return 3_600_000;
+  if (typeof localStorage === 'undefined') return 0;
   try {
     const stored = localStorage.getItem('refreshRate');
     const value = stored ? parseInt(stored, 10) : NaN;
-    if (!Number.isFinite(value) || value < 300_000) {
+    if (!Number.isFinite(value) || value < 0 || (value > 0 && value < 300_000)) {
       localStorage.removeItem('refreshRate');
-      return 3_600_000;
+      return 0;
     }
     return value;
   } catch (err) {
     console.error('Failed to access localStorage:', err);
-    return 3_600_000;
+    return 0;
   }
 };
 
@@ -272,4 +272,4 @@ export const saveRefreshRate = (rate: number): void => {
 };
 
 export const isValidRefreshRate = (rate: number): boolean =>
-  Number.isFinite(rate) && rate >= 300_000;
+  Number.isFinite(rate) && (rate === 0 || rate >= 300_000);


### PR DESCRIPTION
## Summary
- add Off refresh rate and use it as default
- center text in refresh rate dropdown
- allow 0 refresh interval in data fetcher
- update refresh rate tests

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_686f84f3b4608328bb700b207b88224b