### PR TITLE
Fix view param in table navigation

### DIFF
--- a/dashboard/hooks/useRouterNavigation.ts
+++ b/dashboard/hooks/useRouterNavigation.ts
@@ -29,11 +29,16 @@ export const useRouterNavigation = () => {
         });
       }
 
+      const view = searchParams.get('view');
+      if (view) {
+        queryParams.view = view;
+      }
+
       const queryString = createSearchParams(queryParams).toString();
       const path = `/table/${tableType}${queryString ? `?${queryString}` : ''}`;
       safeNavigate(navigate, path);
     },
-    [navigate],
+    [navigate, searchParams],
   );
 
   const navigateToSequencer = useCallback(


### PR DESCRIPTION
## Summary
- preserve current dashboard view when navigating to table views
- test view parameter preservation

## Testing
- `npm run check`
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_686f720f033c832888e6471fd488c0ca