### PR TITLE
Use block_number across API

### DIFF
--- a/crates/api-types/src/lib.rs
+++ b/crates/api-types/src/lib.rs
@@ -337,7 +337,7 @@ pub struct SequencerBlocksResponse {
 #[derive(Debug, Serialize, ToSchema)]
 pub struct BlockTransactionsItem {
     /// Block number.
-    pub block: u64,
+    pub block_number: u64,
     /// Number of transactions in the block.
     pub txs: u32,
     /// Timestamp of the block.
@@ -355,7 +355,7 @@ pub struct BlockTransactionsResponse {
 #[derive(Debug, Serialize, ToSchema)]
 pub struct BlockProfitItem {
     /// Block number.
-    pub block: u64,
+    pub block_number: u64,
     /// Profit in gwei (priority + base - L1 cost).
     pub profit: i128,
 }
@@ -429,7 +429,7 @@ pub struct BatchBlockItem {
     /// Batch ID
     pub batch: u64,
     /// L1 block number that included the batch
-    pub block: u64,
+    pub block_number: u64,
 }
 
 /// Mapping of batches to their corresponding L1 block number.

--- a/crates/api/src/routes/aggregated.rs
+++ b/crates/api/src/routes/aggregated.rs
@@ -228,7 +228,7 @@ pub async fn block_transactions_aggregated(
     let blocks: Vec<BlockTransactionsItem> = rows
         .into_iter()
         .map(|r| BlockTransactionsItem {
-            block: r.l2_block_number,
+            block_number: r.l2_block_number,
             txs: r.sum_tx,
             block_time: r.block_time,
         })

--- a/crates/api/src/routes/core.rs
+++ b/crates/api/src/routes/core.rs
@@ -605,7 +605,7 @@ pub async fn block_profits(
     let mut blocks: Vec<BlockProfitItem> = rows
         .into_iter()
         .map(|r| BlockProfitItem {
-            block: r.l2_block_number,
+            block_number: r.l2_block_number,
             profit: r.priority_fee as i128 + (r.base_fee as i128 * 75 / 100) -
                 r.l1_data_cost.unwrap_or(0) as i128,
         })

--- a/crates/api/src/routes/table.rs
+++ b/crates/api/src/routes/table.rs
@@ -472,7 +472,7 @@ pub async fn block_transactions(
             let blocks: Vec<BlockTransactionsItem> = rows
                 .into_iter()
                 .map(|r| BlockTransactionsItem {
-                    block: r.l2_block_number,
+                    block_number: r.l2_block_number,
                     txs: r.sum_tx,
                     block_time: r.block_time,
                 })
@@ -528,7 +528,7 @@ pub async fn block_transactions(
             let blocks: Vec<BlockTransactionsItem> = rows
                 .into_iter()
                 .map(|r| BlockTransactionsItem {
-                    block: r.l2_block_number,
+                    block_number: r.l2_block_number,
                     txs: r.sum_tx,
                     block_time: r.block_time,
                 })

--- a/dashboard/components/BlobsPerBatchChart.tsx
+++ b/dashboard/components/BlobsPerBatchChart.tsx
@@ -66,7 +66,7 @@ const BlobsPerBatchChartComponent: React.FC<BlobsPerBatchChartProps> = ({
         />
         <Tooltip
           labelFormatter={(label: number, payload) => {
-            const block = payload?.[0]?.payload?.block as number;
+            const block = payload?.[0]?.payload?.block_number as number;
             if (block && label) {
               return `Batch ${label.toLocaleString()} (Block ${block.toLocaleString()})`;
             }

--- a/dashboard/components/BlockTxChart.tsx
+++ b/dashboard/components/BlockTxChart.tsx
@@ -23,7 +23,7 @@ const BlockTxChartComponent: React.FC<BlockTxChartProps> = ({
 }) => {
   const isMobile = useIsMobile();
   const sortedData = useMemo(
-    () => (data ? [...data].sort((a, b) => a.block - b.block) : []),
+    () => (data ? [...data].sort((a, b) => a.block_number - b.block_number) : []),
     [data],
   );
   if (sortedData.length === 0) {
@@ -41,7 +41,7 @@ const BlockTxChartComponent: React.FC<BlockTxChartProps> = ({
       >
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis
-          dataKey="block"
+          dataKey="block_number"
           tickFormatter={(v: number) => v.toLocaleString()}
           stroke="#666666"
           fontSize={12}

--- a/dashboard/components/TpsChart.tsx
+++ b/dashboard/components/TpsChart.tsx
@@ -11,7 +11,7 @@ import {
 import { useIsMobile } from '../hooks/useIsMobile';
 
 export interface TpsData {
-  block: number;
+  block_number: number;
   tps: number;
 }
 
@@ -37,7 +37,7 @@ const TpsChartComponent: React.FC<TpsChartProps> = ({ data, lineColor }) => {
       >
         <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
         <XAxis
-          dataKey="block"
+          dataKey="block_number"
           tickFormatter={(v: number) => v.toLocaleString()}
           stroke="#666666"
           fontSize={12}

--- a/dashboard/config/tableConfig.ts
+++ b/dashboard/config/tableConfig.ts
@@ -153,7 +153,7 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
     ],
     mapData: (data) =>
       (data as Record<string, any>[]).map((d) => ({
-        block: blockLink(d.block as number),
+        block: blockLink(d.block_number as number),
         batch: d.batch.toLocaleString(),
         blobs: d.blobs.toLocaleString(),
       })),
@@ -189,12 +189,10 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
       { key: 'txs', label: 'Tx Count' },
     ],
     mapData: (data) =>
-      (data as { block: number; txs: number }[]).map(
-        (d) => ({
-          block: blockLink(d.block),
-          txs: d.txs.toLocaleString(),
-        }),
-      ),
+      (data as { block_number: number; txs: number }[]).map((d) => ({
+        block: blockLink(d.block_number),
+        txs: d.txs.toLocaleString(),
+      })),
     chart: (data) => {
       const BlockTxChart = React.lazy(() =>
         import('../components/BlockTxChart').then((m) => ({
@@ -250,8 +248,8 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
       { key: 'cost', label: 'Cost' },
     ],
     mapData: (data) =>
-      (data as { block: number; cost: number }[]).map((d) => ({
-        block: blockLink(d.block),
+      (data as { block_number: number; cost: number }[]).map((d) => ({
+        block: blockLink(d.block_number),
         cost: formatEth(d.cost, 4),
       })),
     urlKey: 'l1-data-cost',
@@ -288,8 +286,8 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
       { key: 'tps', label: 'TPS' },
     ],
     mapData: (data) =>
-      (data as { block: number; tps: number }[]).map((d) => ({
-        block: blockLink(d.block),
+      (data as { block_number: number; tps: number }[]).map((d) => ({
+        block: blockLink(d.block_number),
         tps: d.tps.toFixed(2),
       })),
     chart: (data) => {

--- a/dashboard/hooks/useTableActions.ts
+++ b/dashboard/hooks/useTableActions.ts
@@ -178,8 +178,8 @@ export const useTableActions = (
       const disablePrev = page === 0;
       const disableNext = txData.length < 50;
       const nextCursor =
-        txData.length > 0 ? txData[txData.length - 1].block : undefined;
-      const prevCursor = txData.length > 0 ? txData[0].block : undefined;
+        txData.length > 0 ? txData[txData.length - 1].block_number : undefined;
+      const prevCursor = txData.length > 0 ? txData[0].block_number : undefined;
 
       const refreshSeqDist = async () => {
         try {
@@ -208,7 +208,7 @@ export const useTableActions = (
                   ? {
                     ...prev.extraTable,
                     rows: (refreshTxRes.data || []).map((t) => ({
-                      block: blockLink(t.block),
+                      block: blockLink(t.block_number),
                       txs: t.txs,
                     })) as unknown as Record<
                       string,
@@ -266,7 +266,7 @@ export const useTableActions = (
             { key: 'txs', label: 'Tx Count' },
           ],
           rows: (txRes.data || []).map((t) => ({
-            block: blockLink(t.block),
+            block: blockLink(t.block_number),
             txs: t.txs,
           })) as unknown as Record<string, React.ReactNode | string | number>[],
           pagination: {

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -656,7 +656,7 @@ export const fetchSequencerBlocks = async (
 };
 
 export interface BlockTransaction {
-  block: number;
+  block_number: number;
   txs: number;
   blockTime: number;
 }
@@ -691,7 +691,7 @@ export const fetchBlockTransactions = async (
   }
   const res = await fetchJson<{
     blocks: {
-      block: number;
+      block_number: number;
       txs: number;
       block_time: string;
     }[];
@@ -699,7 +699,7 @@ export const fetchBlockTransactions = async (
   return {
     data: res.data?.blocks
       ? res.data.blocks.map((b) => ({
-        block: b.block,
+        block_number: b.block_number,
         txs: b.txs,
         blockTime: new Date(b.block_time).getTime(),
       }))
@@ -734,7 +734,7 @@ export const fetchBlockTransactionsAggregated = async (
     (address ? `&address=${address}` : '');
   const res = await fetchJson<{
     blocks: {
-      block: number;
+      block_number: number;
       txs: number;
       block_time: string;
     }[];
@@ -742,7 +742,7 @@ export const fetchBlockTransactionsAggregated = async (
   return {
     data: res.data?.blocks
       ? res.data.blocks.map((b) => ({
-        block: b.block,
+        block_number: b.block_number,
         txs: b.txs,
         blockTime: new Date(b.block_time).getTime(),
       }))
@@ -753,7 +753,7 @@ export const fetchBlockTransactionsAggregated = async (
 };
 
 export interface BatchBlobCount {
-  block: number;
+  block_number: number;
   batch: number;
   blobs: number;
 }
@@ -785,7 +785,7 @@ export const fetchBatchBlobCounts = async (
   return {
     data: res.data
       ? res.data.batches.map((b) => ({
-        block: b.l1_block_number ?? b.batch_id, // Fallback to batch_id for backward compatibility
+        block_number: b.l1_block_number ?? b.batch_id, // Fallback to batch_id for backward compatibility
         batch: b.batch_id,
         blobs: b.blob_count,
       }))
@@ -809,7 +809,7 @@ export const fetchBatchBlobCountsAggregated = async (
   return {
     data: res.data
       ? res.data.batches.map((b) => ({
-        block: b.l1_block_number ?? b.batch_id, // Fallback to batch_id for backward compatibility
+        block_number: b.l1_block_number ?? b.batch_id, // Fallback to batch_id for backward compatibility
         batch: b.batch_id,
         blobs: b.blob_count,
       }))
@@ -878,7 +878,7 @@ export const fetchL2Fees = async (
 };
 
 export interface FeeComponent {
-  block: number;
+  block_number: number;
   priority: number;
   base: number;
   l1Cost: number | null;
@@ -912,7 +912,7 @@ export const fetchFeeComponents = async (
   return {
     data: res.data
       ? res.data.blocks.map((b) => ({
-        block: b.l2_block_number,
+        block_number: b.l2_block_number,
         priority: b.priority_fee,
         base: b.base_fee,
         l1Cost: b.l1_data_cost ?? null,
@@ -961,7 +961,7 @@ export const fetchBatchFeeComponents = async (
 };
 
 export interface L1DataCostItem {
-  block: number;
+  block_number: number;
   cost: number;
 }
 
@@ -992,7 +992,7 @@ export const fetchL1DataCost = async (
   }>(url);
   return {
     data: res.data
-      ? res.data.blocks.map((b) => ({ block: b.l1_block_number, cost: b.cost }))
+      ? res.data.blocks.map((b) => ({ block_number: b.l1_block_number, cost: b.cost }))
       : null,
     badRequest: res.badRequest,
     error: res.error,
@@ -1020,7 +1020,7 @@ export const fetchL2Tps = async (
   limit = 50,
   startingAfter?: number,
   endingBefore?: number,
-): Promise<RequestResult<{ block: number; tps: number }[]>> => {
+): Promise<RequestResult<{ block_number: number; tps: number }[]>> => {
   let url = `${API_BASE}/l2-tps?`;
   if (startingAfter === undefined && endingBefore === undefined) {
     url += `${timeRangeToQuery(range)}&limit=${limit}`;
@@ -1044,7 +1044,7 @@ export const fetchL2Tps = async (
   }
 
   const data = res.data.blocks.map((b) => ({
-    block: b.l2_block_number,
+    block_number: b.l2_block_number,
     tps: b.tps,
   }));
 
@@ -1054,7 +1054,7 @@ export const fetchL2Tps = async (
 export const fetchL2TpsAggregated = async (
   range: TimeRange,
   address?: string,
-): Promise<RequestResult<{ block: number; tps: number }[]>> => {
+): Promise<RequestResult<{ block_number: number; tps: number }[]>> => {
   const url =
     `${API_BASE}/l2-tps?${timeRangeToQuery(range)}&aggregated` +
     (address ? `&address=${address}` : '');
@@ -1067,7 +1067,7 @@ export const fetchL2TpsAggregated = async (
   }
 
   const data = res.data.blocks.map((b) => ({
-    block: b.l2_block_number,
+    block_number: b.l2_block_number,
     tps: b.tps,
   }));
 
@@ -1075,7 +1075,7 @@ export const fetchL2TpsAggregated = async (
 };
 
 export interface BlockProfit {
-  block: number;
+  block_number: number;
   profit: number;
 }
 
@@ -1088,12 +1088,12 @@ export const fetchBlockProfits = async (
   const url =
     `${API_BASE}/block-profits?${timeRangeToQuery(range)}&order=${order}&limit=${limit}` +
     (address ? `&address=${address}` : '');
-  const res = await fetchJson<{ blocks: { block: number; profit: number }[] }>(
+  const res = await fetchJson<{ blocks: { block_number: number; profit: number }[] }>(
     url,
   );
   return {
     data: res.data
-      ? res.data.blocks.map((b) => ({ block: b.block, profit: b.profit }))
+      ? res.data.blocks.map((b) => ({ block_number: b.block_number, profit: b.profit }))
       : null,
     badRequest: res.badRequest,
     error: res.error,

--- a/dashboard/tests/apiService.test.ts
+++ b/dashboard/tests/apiService.test.ts
@@ -93,23 +93,23 @@ describe('apiService', () => {
 
   it('transforms block transactions', async () => {
     globalThis.fetch = mockFetch({
-      blocks: [{ block: 1, txs: 3, block_time: '1970-01-01T00:00:01Z' }],
+      blocks: [{ block_number: 1, txs: 3, block_time: '1970-01-01T00:00:01Z' }],
     });
     const txs = await fetchBlockTransactions('1h');
     expect(txs.error).toBeNull();
     expect(txs.data).toStrictEqual([
-      { block: 1, txs: 3, blockTime: new Date('1970-01-01T00:00:01Z').getTime() },
+      { block_number: 1, txs: 3, blockTime: new Date('1970-01-01T00:00:01Z').getTime() },
     ]);
   });
 
   it('transforms block transactions for 15m', async () => {
     globalThis.fetch = mockFetch({
-      blocks: [{ block: 1, txs: 3, block_time: '1970-01-01T00:00:01Z' }],
+      blocks: [{ block_number: 1, txs: 3, block_time: '1970-01-01T00:00:01Z' }],
     });
     const txs = await fetchBlockTransactions('15m');
     expect(txs.error).toBeNull();
     expect(txs.data).toStrictEqual([
-      { block: 1, txs: 3, blockTime: new Date('1970-01-01T00:00:01Z').getTime() },
+      { block_number: 1, txs: 3, blockTime: new Date('1970-01-01T00:00:01Z').getTime() },
     ]);
   });
 

--- a/dashboard/tests/l1DataCostMap.test.ts
+++ b/dashboard/tests/l1DataCostMap.test.ts
@@ -5,7 +5,7 @@ describe('l1-data-cost mapData', () => {
   const mapData = TABLE_CONFIGS['l1-data-cost'].mapData!;
 
   it('formats block number as link and cost as ETH', () => {
-    const rows = mapData([{ block: 100, cost: 42e9 }]);
+    const rows = mapData([{ block_number: 100, cost: 42e9 }]);
 
     // value should be React element from blockLink
     expect(typeof rows[0].block).toBe('object');

--- a/tests/api_integration.rs
+++ b/tests/api_integration.rs
@@ -364,7 +364,7 @@ async fn block_profits_integration() {
     .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
     let body: serde_json::Value = resp.json().await.unwrap();
-    assert_eq!(body, serde_json::json!({ "blocks": [ { "block": 1, "profit": 12 } ] }));
+    assert_eq!(body, serde_json::json!({ "blocks": [ { "block_number": 1, "profit": 12 } ] }));
 
     let resp = reqwest::get(
         format!("http://{addr}/{API_VERSION}/block-profits?created[gte]=0&created[lte]=3600000&limit=1&order=asc"),
@@ -373,7 +373,7 @@ async fn block_profits_integration() {
     .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
     let body: serde_json::Value = resp.json().await.unwrap();
-    assert_eq!(body, serde_json::json!({ "blocks": [ { "block": 2, "profit": -6 } ] }));
+    assert_eq!(body, serde_json::json!({ "blocks": [ { "block_number": 2, "profit": -6 } ] }));
 
     server.abort();
 }

--- a/tests/pagination.rs
+++ b/tests/pagination.rs
@@ -425,7 +425,7 @@ async fn block_transactions_endpoint_supports_block_range() {
     let expected = serde_json::json!({
         "blocks": [
             {
-                "block": 5,
+                "block_number": 5,
                 "txs": 3,
                 "block_time": Utc.timestamp_opt(1000, 0).single().unwrap().to_rfc3339()
             }


### PR DESCRIPTION
## Summary
- refactor API types and routes to consistently expose `block_number`
- update dashboard API service, components, and table config for new field
- adjust TypeScript tests to reflect renamed data
- update Rust tests for new API responses

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_686fbeb9177c8328b592ad4d1911bf8b