### PR TITLE
Expose reorg range

### DIFF
--- a/crates/api-types/src/lib.rs
+++ b/crates/api-types/src/lib.rs
@@ -107,8 +107,10 @@ pub struct ForcedInclusionEventsResponse {
 /// Single L2 reorg event with sequencer addresses.
 #[derive(Debug, Serialize, ToSchema)]
 pub struct L2ReorgEvent {
+    /// Block number that was replaced.
+    pub from_block_number: u64,
     /// Block number that became the new head.
-    pub l2_block_number: u64,
+    pub to_block_number: u64,
     /// Number of blocks replaced by the reorg.
     pub depth: u16,
     /// Address of the sequencer that produced the replaced block.

--- a/crates/api/src/routes/table.rs
+++ b/crates/api/src/routes/table.rs
@@ -69,12 +69,16 @@ pub async fn reorgs(
     };
     let events: Vec<L2ReorgEvent> = rows
         .into_iter()
-        .map(|e| L2ReorgEvent {
-            l2_block_number: e.l2_block_number,
-            depth: e.depth,
-            old_sequencer: format!("0x{}", encode(e.old_sequencer)),
-            new_sequencer: format!("0x{}", encode(e.new_sequencer)),
-            inserted_at: e.inserted_at,
+        .map(|e| {
+            let from_block_number = e.l2_block_number + u64::from(e.depth);
+            L2ReorgEvent {
+                from_block_number,
+                to_block_number: e.l2_block_number,
+                depth: e.depth,
+                old_sequencer: format!("0x{}", encode(e.old_sequencer)),
+                new_sequencer: format!("0x{}", encode(e.new_sequencer)),
+                inserted_at: e.inserted_at,
+            }
         })
         .collect();
     tracing::info!(count = events.len(), "Returning reorg events");

--- a/dashboard/config/tableConfig.ts
+++ b/dashboard/config/tableConfig.ts
@@ -75,7 +75,8 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
     fetcher: fetchL2ReorgEvents,
     columns: [
       { key: 'timestamp', label: 'Time' },
-      { key: 'l2_block_number', label: 'L2 Block Number' },
+      { key: 'from_block_number', label: 'From Block' },
+      { key: 'to_block_number', label: 'To Block' },
       { key: 'depth', label: 'Depth' },
       { key: 'old_sequencer', label: 'Old Sequencer' },
       { key: 'new_sequencer', label: 'New Sequencer' },
@@ -83,7 +84,8 @@ export const TABLE_CONFIGS: Record<string, TableConfig> = {
     mapData: (data) =>
       (data as L2ReorgEvent[]).map((e) => ({
         timestamp: formatDateTime(e.timestamp),
-        l2_block_number: blockLink(e.l2_block_number),
+        from_block_number: blockLink(e.from_block_number),
+        to_block_number: blockLink(e.to_block_number),
         depth: e.depth.toLocaleString(),
         old_sequencer: getSequencerName(e.old_sequencer),
         new_sequencer: getSequencerName(e.new_sequencer),

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -182,7 +182,8 @@ export const fetchL2ReorgEvents = async (
   }
   const res = await fetchJson<{
     events: {
-      l2_block_number: number;
+      from_block_number: number;
+      to_block_number: number;
       depth: number;
       old_sequencer: string;
       new_sequencer: string;
@@ -192,7 +193,8 @@ export const fetchL2ReorgEvents = async (
   return {
     data: res.data?.events
       ? res.data.events.map((e) => ({
-        l2_block_number: e.l2_block_number,
+        from_block_number: e.from_block_number,
+        to_block_number: e.to_block_number,
         depth: e.depth,
         old_sequencer: e.old_sequencer,
         new_sequencer: e.new_sequencer,

--- a/dashboard/tests/app.integration.test.ts
+++ b/dashboard/tests/app.integration.test.ts
@@ -69,7 +69,7 @@ const responses: Record<string, Record<string, unknown>> = {
   },
   [`/v1/reorgs?${q1h}`]: {
     events: [
-      { l2_block_number: 10, depth: 1, inserted_at: '1970-01-01T00:00:00Z' },
+      { from_block_number: 11, to_block_number: 10, depth: 1, inserted_at: '1970-01-01T00:00:00Z' },
     ],
   },
   [`/v1/slashings?${q1h}`]: {
@@ -78,7 +78,7 @@ const responses: Record<string, Record<string, unknown>> = {
   [`/v1/forced-inclusions?${q1h}`]: { events: [{ blob_hash: [3, 4] }] },
   [`/v1/reorgs?${q15m}`]: {
     events: [
-      { l2_block_number: 10, depth: 1, inserted_at: '1970-01-01T00:00:00Z' },
+      { from_block_number: 11, to_block_number: 10, depth: 1, inserted_at: '1970-01-01T00:00:00Z' },
     ],
   },
   [`/v1/slashings?${q15m}`]: {

--- a/dashboard/types.ts
+++ b/dashboard/types.ts
@@ -27,7 +27,8 @@ export interface MetricData {
 }
 
 export interface L2ReorgEvent {
-  l2_block_number: number;
+  from_block_number: number;
+  to_block_number: number;
   depth: number;
   old_sequencer: string;
   new_sequencer: string;

--- a/tests/pagination.rs
+++ b/tests/pagination.rs
@@ -200,14 +200,16 @@ async fn reorgs_endpoint_returns_items_with_pagination() {
     let expected = serde_json::json!({
         "events": [
             {
-                "l2_block_number": 8,
+                "from_block_number": 10,
+                "to_block_number": 8,
                 "depth": 2,
                 "old_sequencer": "0x0303030303030303030303030303030303030303",
                 "new_sequencer": "0x0404040404040404040404040404040404040404",
                 "inserted_at": Utc.timestamp_millis_opt(2000).single().unwrap().to_rfc3339()
             },
             {
-                "l2_block_number": 9,
+                "from_block_number": 10,
+                "to_block_number": 9,
                 "depth": 1,
                 "old_sequencer": "0x0101010101010101010101010101010101010101",
                 "new_sequencer": "0x0202020202020202020202020202020202020202",


### PR DESCRIPTION
## Summary
- include from/to block numbers in reorg event schema
- return from/to numbers from `/reorgs` endpoint
- display reorg range on dashboard tables
- update dashboard services and tests
- adapt pagination test for new fields

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6871255b9ad48328beb0f4647c2ceedf