### PR TITLE
Remove sequencer from block transaction output

### DIFF
--- a/crates/api-types/src/lib.rs
+++ b/crates/api-types/src/lib.rs
@@ -333,15 +333,13 @@ pub struct SequencerBlocksResponse {
     pub sequencers: Vec<SequencerBlocksItem>,
 }
 
-/// Transaction count for a block and its sequencer.
+/// Transaction count for a block.
 #[derive(Debug, Serialize, ToSchema)]
 pub struct BlockTransactionsItem {
     /// Block number.
     pub block: u64,
     /// Number of transactions in the block.
     pub txs: u32,
-    /// Address of the sequencer that proposed the block.
-    pub sequencer: String,
     /// Timestamp of the block.
     pub block_time: DateTime<Utc>,
 }

--- a/crates/api/src/routes/aggregated.rs
+++ b/crates/api/src/routes/aggregated.rs
@@ -230,7 +230,6 @@ pub async fn block_transactions_aggregated(
         .map(|r| BlockTransactionsItem {
             block: r.l2_block_number,
             txs: r.sum_tx,
-            sequencer: format!("0x{}", encode(r.sequencer)),
             block_time: r.block_time,
         })
         .collect();

--- a/crates/api/src/routes/table.rs
+++ b/crates/api/src/routes/table.rs
@@ -344,7 +344,6 @@ pub async fn block_transactions(
         .map(|r| BlockTransactionsItem {
             block: r.l2_block_number,
             txs: r.sum_tx,
-            sequencer: format!("0x{}", encode(r.sequencer)),
             block_time: r.block_time,
         })
         .collect();


### PR DESCRIPTION
## Summary
- remove `sequencer` field from `BlockTransactionsItem`
- drop sequencer from block transaction mappings

## Testing
- `just lint`
- `just lint-dashboard`
- `just test`
- `just check-dashboard`
- `just test-dashboard`


------
https://chatgpt.com/codex/tasks/task_b_686f71006d888328ad0c1c521ee93725