### PR TITLE
Fix sequencer fee attribution

### DIFF
--- a/crates/clickhouse/src/reader/client.rs
+++ b/crates/clickhouse/src/reader/client.rs
@@ -2726,41 +2726,30 @@ impl ClickhouseReader {
 
     /// Get aggregated L2 fees grouped by sequencer for the given range
     pub async fn get_l2_fees_by_sequencer(&self, range: TimeRange) -> Result<Vec<SequencerFeeRow>> {
-        // Pre-aggregate at batch level to prevent fan-out from block-level joins
         let query = format!(
-            "WITH eligible_batches AS ( \
-            SELECT b.batch_id, b.proposer_addr \
-            FROM {db}.batches b \
-            INNER JOIN {db}.l1_head_events l1 ON b.l1_block_number = l1.l1_block_number \
-            WHERE l1.block_ts >= toUnixTimestamp(now64() - INTERVAL {interval}) \
-        ), \
-        fees_per_batch AS ( \
-            SELECT \
-                bb.batch_id, \
-                sum(h.sum_priority_fee) as priority_fee, \
-                sum(h.sum_base_fee) as base_fee \
-            FROM {db}.batch_blocks bb \
-            INNER JOIN {db}.l2_head_events h ON bb.l2_block_number = h.l2_block_number \
-            WHERE bb.batch_id IN (SELECT batch_id FROM eligible_batches) \
-              AND h.l2_block_number NOT IN ( \
-                  SELECT l2_block_number FROM {db}.l2_reorgs \
-              ) \
-            GROUP BY bb.batch_id \
-        ) \
-        SELECT \
-            eb.proposer_addr as sequencer, \
-            coalesce(sum(fpb.priority_fee), toUInt128(0)) as priority_fee, \
-            coalesce(sum(fpb.base_fee), toUInt128(0)) as base_fee, \
-            toNullable(sum(dc.cost)) as l1_data_cost, \
-            toNullable(sum(pc.cost)) as prove_cost \
-        FROM eligible_batches eb \
-        LEFT JOIN fees_per_batch fpb ON eb.batch_id = fpb.batch_id \
-        LEFT JOIN {db}.l1_data_costs dc ON eb.batch_id = dc.batch_id \
-        LEFT JOIN {db}.prove_costs pc ON eb.batch_id = pc.batch_id \
-        GROUP BY eb.proposer_addr \
-        ORDER BY priority_fee DESC",
-            db = self.db_name,
+            "SELECT h.sequencer, \
+                    sum(h.sum_priority_fee) AS priority_fee, \
+                    sum(h.sum_base_fee) AS base_fee, \
+                    toNullable(sum(if(b.batch_size > 0, intDiv(dc.cost, b.batch_size), NULL))) AS l1_data_cost, \
+                    toNullable(sum(if(b.batch_size > 0, intDiv(pc.cost, b.batch_size), NULL))) AS prove_cost \
+             FROM {db}.batch_blocks bb \
+             INNER JOIN {db}.batches b \
+               ON bb.batch_id = b.batch_id \
+             INNER JOIN {db}.l1_head_events l1 \
+               ON b.l1_block_number = l1.l1_block_number \
+             LEFT JOIN {db}.l2_head_events h \
+               ON bb.l2_block_number = h.l2_block_number \
+             LEFT JOIN {db}.l1_data_costs dc \
+               ON b.batch_id = dc.batch_id \
+             LEFT JOIN {db}.prove_costs pc \
+               ON b.batch_id = pc.batch_id \
+             WHERE l1.block_ts >= toUnixTimestamp(now64() - INTERVAL {interval}) \
+               AND {filter} \
+             GROUP BY h.sequencer \
+             ORDER BY priority_fee DESC",
             interval = range.interval(),
+            filter = self.reorg_filter("h"),
+            db = self.db_name,
         );
 
         self.execute(&query).await


### PR DESCRIPTION
## Summary
- attribute L2 fees to the sequencer that produced the blocks
- update spacing test to match new query

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_686fc69c86fc8328bbf6fb8cd670b461