### PR TITLE
Add failed proposal metrics

### DIFF
--- a/crates/api-types/src/lib.rs
+++ b/crates/api-types/src/lib.rs
@@ -128,6 +128,28 @@ pub struct ReorgEventsResponse {
     pub events: Vec<L2ReorgEvent>,
 }
 
+/// Event where a sequencer failed to post its block and another proposer posted it
+#[derive(Debug, Serialize, ToSchema)]
+pub struct FailedProposalEvent {
+    /// L2 block number originally produced
+    pub l2_block_number: u64,
+    /// Address of the sequencer that produced the block
+    pub original_sequencer: String,
+    /// Address of the sequencer that posted the batch on L1
+    pub proposer: String,
+    /// L1 block number where the batch was posted
+    pub l1_block_number: u64,
+    /// Time the batch was posted
+    pub inserted_at: DateTime<Utc>,
+}
+
+/// Failed proposal events
+#[derive(Debug, Serialize, ToSchema)]
+pub struct FailedProposalEventsResponse {
+    /// Failed proposal events
+    pub events: Vec<FailedProposalEvent>,
+}
+
 /// Gateways that submitted batches in the requested range.
 #[derive(Debug, Serialize, ToSchema)]
 pub struct ActiveGatewaysResponse {
@@ -490,6 +512,8 @@ pub struct DashboardDataResponse {
     pub slashings: usize,
     /// Number of forced inclusion events in the selected range.
     pub forced_inclusions: usize,
+    /// Number of failed proposal events in the selected range.
+    pub failed_proposals: usize,
     /// Number of the most recent L2 block.
     pub l2_head_block: Option<u64>,
     /// Number of the most recent L1 block.

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -60,6 +60,7 @@ use utoipa::OpenApi;
             ReorgEventsResponse,
             SlashingEventsResponse,
             ForcedInclusionEventsResponse,
+            FailedProposalEventsResponse,
             BatchPostingTimesResponse,
             AvgBlobsPerBatchResponse,
             BatchBlobsResponse,

--- a/crates/api/src/routes/aggregated.rs
+++ b/crates/api/src/routes/aggregated.rs
@@ -449,6 +449,7 @@ pub async fn dashboard_data(
         reorgs,
         slashings,
         forced_inclusions,
+        failed_proposals,
         l2_head_block,
         l1_head_block,
     ) = tokio::try_join!(
@@ -461,6 +462,7 @@ pub async fn dashboard_data(
         state.client.get_l2_reorgs_since(since),
         state.client.get_slashing_events_since(since),
         state.client.get_forced_inclusions_since(since),
+        state.client.get_failed_proposals_since(since),
         state.client.get_last_l2_block_number(),
         state.client.get_last_l1_block_number()
     )
@@ -481,6 +483,7 @@ pub async fn dashboard_data(
         reorgs = reorgs.len(),
         slashings = slashings.len(),
         forced_inclusions = forced_inclusions.len(),
+        failed_proposals = failed_proposals.len(),
         "Returning dashboard data"
     );
 
@@ -494,6 +497,7 @@ pub async fn dashboard_data(
         l2_reorgs: reorgs.len(),
         slashings: slashings.len(),
         forced_inclusions: forced_inclusions.len(),
+        failed_proposals: failed_proposals.len(),
         l2_head_block,
         l1_head_block,
     }))

--- a/crates/api/src/routes/mod.rs
+++ b/crates/api/src/routes/mod.rs
@@ -21,6 +21,7 @@ pub fn router(state: ApiState) -> Router {
         .route("/reorgs", get(reorgs))
         .route("/slashings", get(slashings))
         .route("/forced-inclusions", get(forced_inclusions))
+        .route("/failed-proposals", get(failed_proposals))
         .route("/batch-posting-times", get(batch_posting_times))
         .route("/avg-blobs-per-batch", get(avg_blobs_per_batch))
         .route("/blobs-per-batch", get(blobs_per_batch))

--- a/crates/clickhouse/src/models.rs
+++ b/crates/clickhouse/src/models.rs
@@ -186,6 +186,21 @@ pub struct SlashingEventRow {
     pub validator_addr: AddressBytes,
 }
 
+/// Row representing a failed proposal where a block was posted by a different sequencer
+#[derive(Debug, Row, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+pub struct FailedProposalRow {
+    /// L2 block number originally produced
+    pub l2_block_number: u64,
+    /// Address of the sequencer that produced the block
+    pub original_sequencer: AddressBytes,
+    /// Address of the sequencer that posted the batch on L1
+    pub proposer: AddressBytes,
+    /// L1 block number where the batch was posted
+    pub l1_block_number: u64,
+    /// Time the batch was posted
+    pub inserted_at: DateTime<Utc>,
+}
+
 /// Row representing the number of blocks produced by a sequencer
 #[derive(Debug, Row, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SequencerDistributionRow {


### PR DESCRIPTION
## Summary
- track when a sequencer's L2 block is posted by a different proposer
- expose failed proposal events via new API endpoint
- include count of failed proposals in dashboard data

## Testing
- `just lint`
- `just test`
- `just check-dashboard`
- `just test-dashboard`
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_6874b9dc78708328914e25a6860388e0