### PR TITLE
Align JetStream stream names

### DIFF
--- a/crates/nats-utils/src/lib.rs
+++ b/crates/nats-utils/src/lib.rs
@@ -7,7 +7,7 @@ pub async fn publish_event(client: &async_nats::Client, event: &TaikoEvent) -> e
     let js = async_nats::jetstream::new(client.clone());
     let _stream = js
         .get_or_create_stream(async_nats::jetstream::stream::Config {
-            name: "taiko_events".to_owned(),
+            name: "taiko".to_owned(),
             subjects: vec!["taiko.events".to_owned()],
             ..Default::default()
         })


### PR DESCRIPTION
## Summary
- use stream name `taiko` when publishing NATS events

## Testing
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_68763025e92c8328bf1875d556a969f3