### PR TITLE
Add JetStream deduplication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1793,6 +1793,7 @@ dependencies = [
  "futures",
  "http",
  "incident",
+ "lru",
  "messages",
  "nats-utils",
  "network",
@@ -2951,6 +2952,7 @@ dependencies = [
  "primitives",
  "serde",
  "serde_json",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ url = { version = "2.5.4", features = ["serde"] }
 tower-http = { version = "0.5.2", features = ["cors", "trace"] }
 tower = { version = "0.5.2", features = ["limit"] }
 dashmap = "6.1"
+lru = "0.13"
 utoipa = { version = "5.4", features = ["axum_extras"] }
 utoipa-swagger-ui = { version = "8.1", features = ["axum", "vendored"] }
 

--- a/crates/driver/Cargo.toml
+++ b/crates/driver/Cargo.toml
@@ -28,6 +28,7 @@ tracing.workspace = true
 url.workspace = true
 async-nats.workspace = true
 serde_json.workspace = true
+lru.workspace = true
 
 [dev-dependencies]
 url.workspace = true

--- a/crates/nats-utils/Cargo.toml
+++ b/crates/nats-utils/Cargo.toml
@@ -15,6 +15,7 @@ serde.workspace = true
 serde_json.workspace = true
 bincode.workspace = true
 eyre.workspace = true
+tracing.workspace = true
 
 [lints]
 workspace = true

--- a/crates/nats-utils/src/lib.rs
+++ b/crates/nats-utils/src/lib.rs
@@ -4,6 +4,8 @@ pub use messages::TaikoEvent;
 
 // Placeholder for publishing an event to NATS JetStream
 pub async fn publish_event(client: &async_nats::Client, event: &TaikoEvent) -> eyre::Result<()> {
+    use async_nats::jetstream::context::Publish;
+
     let js = async_nats::jetstream::new(client.clone());
     let _stream = js
         .get_or_create_stream(async_nats::jetstream::stream::Config {
@@ -12,8 +14,20 @@ pub async fn publish_event(client: &async_nats::Client, event: &TaikoEvent) -> e
             ..Default::default()
         })
         .await?;
+
     let payload = serde_json::to_vec(event)?;
-    js.publish("taiko.events", payload.into()).await?;
+    let ack = js
+        .send_publish(
+            "taiko.events",
+            Publish::build().payload(payload.into()).message_id(event.dedup_id()),
+        )
+        .await?
+        .await?;
+
+    if ack.duplicate {
+        tracing::debug!(msg_id = %event.dedup_id(), "Duplicate event skipped");
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- set `Nats-Msg-Id` header when publishing events
- drop duplicate events in processor
- add `lru` dependency

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6876303742988328b6668a0cd6af5f1e