### PR TITLE
Refresh ETH price in background

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -763,6 +763,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
+ "tokio-util",
  "tower",
  "tower-http 0.5.2",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ tokio = { version = "1.46.1", features = ["macros", "rt-multi-thread", "sync"] }
 tokio-retry = "0.3.0"
 tokio-stream = "0.1.17"
 tokio-tungstenite = "0.26"
+tokio-util = "0.7.15"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter", "fmt"] }
 url = { version = "2.5.4", features = ["serde"] }

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -27,6 +27,7 @@ utoipa.workspace = true
 utoipa-swagger-ui.workspace = true
 network = { path = "../network" }
 reqwest.workspace = true
+tokio-util.workspace = true
 
 [dev-dependencies]
 tower = "0.5"

--- a/crates/api/src/routes/core.rs
+++ b/crates/api/src/routes/core.rs
@@ -631,17 +631,15 @@ pub async fn block_profits(
 pub async fn eth_price(
     State(state): State<ApiState>,
 ) -> Result<Json<EthPriceResponse>, ErrorResponse> {
-    match state.eth_price().await {
-        Ok(price) => Ok(Json(EthPriceResponse { price })),
-        Err(e) => {
-            tracing::error!(error = %e, "Failed to fetch ETH price");
-            Err(ErrorResponse::new(
-                "price-error",
-                "Failed to fetch ETH price",
-                StatusCode::SERVICE_UNAVAILABLE,
-                e.to_string(),
-            ))
-        }
+    if let Some(price) = state.cached_eth_price().await {
+        Ok(Json(EthPriceResponse { price }))
+    } else {
+        Err(ErrorResponse::new(
+            "price-error",
+            "Failed to fetch ETH price",
+            StatusCode::SERVICE_UNAVAILABLE,
+            "price not available".to_owned(),
+        ))
     }
 }
 


### PR DESCRIPTION
## Summary
- update workspace dependencies
- spawn background task in `ApiState` to refresh the ETH price
- stop the task when the state is dropped
- serve the cached price from the `/eth-price` endpoint

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_687645293bc883289077fa482ba962ad