### PR TITLE
Add lightweight preconf data endpoint

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -22,6 +22,7 @@ use utoipa::OpenApi;
     paths(
         routes::core::l2_head_block,
         routes::core::l1_head_block,
+        routes::core::preconf_data,
         routes::table::reorgs,
         routes::table::slashings,
         routes::table::forced_inclusions,

--- a/crates/api/src/routes/mod.rs
+++ b/crates/api/src/routes/mod.rs
@@ -18,6 +18,7 @@ pub fn router(state: ApiState) -> Router {
     let api_routes = Router::new()
         .route("/l2-head-block", get(l2_head_block))
         .route("/l1-head-block", get(l1_head_block))
+        .route("/preconf-data", get(preconf_data))
         .route("/reorgs", get(reorgs))
         .route("/slashings", get(slashings))
         .route("/forced-inclusions", get(forced_inclusions))

--- a/dashboard/hooks/useBlockData.ts
+++ b/dashboard/hooks/useBlockData.ts
@@ -1,5 +1,9 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { fetchDashboardData } from '../services/apiService';
+import {
+  fetchPreconfData,
+  fetchL1HeadNumber,
+  fetchL2HeadNumber,
+} from '../services/apiService';
 import { MetricData, BlockDataState } from '../types';
 import { TAIKOSCAN_BASE } from '../utils';
 
@@ -13,15 +17,19 @@ export const useBlockData = (timeRange: TimeRange): BlockDataState => {
 
   const updateBlockHeads = useCallback(async () => {
     try {
-      const res = await fetchDashboardData(timeRange);
-      if (res.data?.l1_head_block != null) {
-        setL1HeadBlock(res.data.l1_head_block.toLocaleString());
+      const [l1Res, l2Res, preconfRes] = await Promise.all([
+        fetchL1HeadNumber(),
+        fetchL2HeadNumber(),
+        fetchPreconfData(timeRange),
+      ]);
+      if (l1Res.data != null) {
+        setL1HeadBlock(l1Res.data.toLocaleString());
       }
-      if (res.data?.l2_head_block != null) {
-        setL2HeadBlock(res.data.l2_head_block.toLocaleString());
+      if (l2Res.data != null) {
+        setL2HeadBlock(l2Res.data.toLocaleString());
       }
-      if (res.data?.preconf_data?.candidates) {
-        setCandidates(res.data.preconf_data.candidates);
+      if (preconfRes.data?.candidates) {
+        setCandidates(preconfRes.data.candidates);
       }
     } catch (error) {
       console.error('Failed to update block heads:', error);

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -339,11 +339,12 @@ export interface PreconfData {
 }
 
 export const fetchPreconfData = async (
-  range: TimeRange = '1h',
+  _range: TimeRange = '1h',
 ): Promise<RequestResult<PreconfData>> => {
-  const res = await fetchDashboardData(range);
+  const url = `${API_BASE}/preconf-data`;
+  const res = await fetchJson<PreconfData>(url);
   return {
-    data: res.data?.preconf_data ?? null,
+    data: res.data ?? null,
     badRequest: res.badRequest,
     error: res.error,
   };

--- a/dashboard/tests/apiService.test.ts
+++ b/dashboard/tests/apiService.test.ts
@@ -58,7 +58,7 @@ describe('apiService', () => {
   });
 
   it('fetches active sequencer addresses from preconf', async () => {
-    globalThis.fetch = mockFetch({ preconf_data: { candidates: ['a', 'b'] } });
+    globalThis.fetch = mockFetch({ candidates: ['a', 'b'] });
     const gateways = await fetchActiveSequencerAddresses('1h');
     expect(gateways.data).toStrictEqual(['a', 'b']);
   });

--- a/dashboard/tests/app.integration.test.ts
+++ b/dashboard/tests/app.integration.test.ts
@@ -60,6 +60,11 @@ const responses: Record<string, Record<string, unknown>> = {
   [`/v1/avg-prove-time?${q1h}`]: { avg_prove_time_ms: 1500 },
   [`/v1/l2-block-cadence?${q1h}`]: { l2_block_cadence_ms: 60000 },
   [`/v1/batch-posting-cadence?${q1h}`]: { batch_posting_cadence_ms: 120000 },
+  '/v1/preconf-data': {
+    candidates: ['gw1', 'gw2'],
+    current_operator: '0xaaa',
+    next_operator: '0xbbb',
+  },
   [`/v1/dashboard-data?${q1h}`]: {
     preconf_data: {
       candidates: ['gw1', 'gw2'],

--- a/dashboard/tests/profitRankingTable.test.ts
+++ b/dashboard/tests/profitRankingTable.test.ts
@@ -47,11 +47,11 @@ describe('ProfitRankingTable', () => {
               },
             ],
             batches: [
-              { sequencer: '0xseqA', batch_id: 1, revenue: 1e9, prove_cost: 0 },
-              { sequencer: '0xseqB', batch_id: 2, revenue: 0.5e9, prove_cost: 0 },
+              { sequencer: '0xseqA', batch_id: 1, revenue: 1e9, prove_cost: 0 } as any,
+              { sequencer: '0xseqB', batch_id: 2, revenue: 0.5e9, prove_cost: 0 } as any,
             ],
           },
-        } as RequestResult<L2FeesComponentsResponse>,
+        } as unknown as RequestResult<L2FeesComponentsResponse>,
       } as unknown as ReturnType<typeof swr.default>);
 
     vi.spyOn(api, 'fetchSequencerDistribution').mockResolvedValue({
@@ -85,8 +85,8 @@ describe('ProfitRankingTable', () => {
           },
         ],
         batches: [
-          { sequencer: '0xseqA', batch_id: 1, revenue: 1e9, prove_cost: 0 },
-          { sequencer: '0xseqB', batch_id: 2, revenue: 0.5e9, prove_cost: 0 },
+          { sequencer: '0xseqA', batch_id: 1, revenue: 1e9, prove_cost: 0 } as any,
+          { sequencer: '0xseqB', batch_id: 2, revenue: 0.5e9, prove_cost: 0 } as any,
         ],
       },
       badRequest: false,
@@ -141,10 +141,10 @@ describe('ProfitRankingTable', () => {
               },
             ],
             batches: [
-              { sequencer: '0xseqA', batch_id: 1, revenue: 1e9, prove_cost: 1e7 },
+              { sequencer: '0xseqA', batch_id: 1, revenue: 1e9, prove_cost: 1e7 } as any,
             ],
           },
-        } as RequestResult<L2FeesComponentsResponse>,
+        } as unknown as RequestResult<L2FeesComponentsResponse>,
       } as unknown as ReturnType<typeof swr.default>);
 
     vi.spyOn(api, 'fetchSequencerDistribution').mockResolvedValue({
@@ -168,7 +168,7 @@ describe('ProfitRankingTable', () => {
           },
         ],
         batches: [
-          { sequencer: '0xseqA', batch_id: 1, revenue: 1e9, prove_cost: 1e7 },
+          { sequencer: '0xseqA', batch_id: 1, revenue: 1e9, prove_cost: 1e7 } as any,
         ],
       },
       badRequest: false,


### PR DESCRIPTION
## Summary
- add `/preconf-data` API route
- expose preconf data in OpenAPI spec
- use new preconf endpoint in dashboard block data hook
- update TypeScript API service and tests

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_687654af90908328b254c8d63be1b68b