### PR TITLE
Remove sequencer distribution fetch from economics data

### DIFF
--- a/dashboard/tests/dataFetcher.test.ts
+++ b/dashboard/tests/dataFetcher.test.ts
@@ -90,9 +90,6 @@ describe('dataFetcher', () => {
       }),
       fetchL2HeadBlock: ok(2),
       fetchL1HeadBlock: ok(3),
-      fetchSequencerDistribution: ok([
-        { name: 'foo', address: '0xfoo', value: 1, tps: null },
-      ]),
     });
 
     const res = await fetchEconomicsData('1h', null);
@@ -103,8 +100,8 @@ describe('dataFetcher', () => {
     expect(res.l1DataCost).toBe(4);
     expect(res.proveCost).toBe(5);
 
-    expect(res.sequencerDist[0].name).toBe('foo');
-    expect(res.badRequestResults).toHaveLength(4);
+    expect(res.sequencerDist).toEqual([]);
+    expect(res.badRequestResults).toHaveLength(3);
   });
 
   it('defaults economics costs to zero when missing', async () => {
@@ -118,7 +115,6 @@ describe('dataFetcher', () => {
       }),
       fetchL2HeadBlock: ok(null),
       fetchL1HeadBlock: ok(null),
-      fetchSequencerDistribution: ok(null),
     });
 
     const res = await fetchEconomicsData('1h', null);
@@ -127,7 +123,7 @@ describe('dataFetcher', () => {
     expect(res.l1DataCost).toBe(0);
     expect(res.proveCost).toBe(0);
 
-    expect(res.badRequestResults).toHaveLength(4);
+    expect(res.badRequestResults).toHaveLength(3);
   });
 
   it('resets isTimeRangeChanging on fetch error', async () => {


### PR DESCRIPTION
## Summary
- remove `fetchSequencerDistribution` API call from economics data
- derive sequencer list from `fetchL2Fees` instead
- update tests to reflect changed behaviour

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6877a91b59f8832885bf05dc837eae35