### PR TITLE
Fix ETH price caching

### DIFF
--- a/crates/api/src/routes/core.rs
+++ b/crates/api/src/routes/core.rs
@@ -664,15 +664,12 @@ pub async fn eth_price(
 ) -> Result<Json<EthPriceResponse>, ErrorResponse> {
     match state.eth_price().await {
         Ok(price) => Ok(Json(EthPriceResponse { price })),
-        Err(e) => {
-            tracing::error!(error = %e, "Failed to fetch ETH price");
-            Err(ErrorResponse::new(
-                "price-error",
-                "Failed to fetch ETH price",
-                StatusCode::SERVICE_UNAVAILABLE,
-                e.to_string(),
-            ))
-        }
+        Err(e) => Err(ErrorResponse::new(
+            "price-error",
+            "Failed to fetch ETH price",
+            StatusCode::SERVICE_UNAVAILABLE,
+            e.to_string(),
+        )),
     }
 }
 

--- a/dashboard/services/priceService.ts
+++ b/dashboard/services/priceService.ts
@@ -7,29 +7,21 @@ const CACHE_KEY = 'ethPrice';
 const API_URL = `${API_BASE}/eth-price`;
 
 export const getEthPrice = async (): Promise<number> => {
-  let res: Response;
   try {
-    res = await fetch(API_URL);
-  } catch {
-    showToast('Failed to fetch ETH price');
-    return 0;
-  }
-  if (!res.ok) {
-    showToast('Failed to fetch ETH price');
-    return 0;
-  }
+    const res = await fetch(API_URL);
+    if (!res.ok) {
+      throw new Error(res.statusText);
+    }
 
-  try {
     const data = await res.json();
     const price = data?.price;
     if (typeof price !== 'number') {
-      showToast('Failed to fetch ETH price');
-      return 0;
+      throw new Error('invalid response');
     }
     return price;
-  } catch {
+  } catch (e) {
     showToast('Failed to fetch ETH price');
-    return 0;
+    throw e instanceof Error ? e : new Error('Failed to fetch ETH price');
   }
 };
 
@@ -80,9 +72,7 @@ export const useEthPrice = () => {
     }
   }, [swr.data]);
 
-  const error =
-    swr.error ??
-    (swr.data === 0 ? new Error('ETH price unavailable') : undefined);
+  const error = swr.data === undefined ? swr.error : undefined;
 
   return { ...swr, error };
 };

--- a/dashboard/tests/priceService.test.ts
+++ b/dashboard/tests/priceService.test.ts
@@ -45,24 +45,21 @@ describe('getEthPrice', () => {
   it('handles fetch failure', async () => {
     globalThis.fetch = mockFetch(0, false);
     const spy = vi.spyOn(toast, 'showToast').mockImplementation(() => {});
-    const price = await getEthPrice();
-    expect(price).toBe(0);
+    await expect(getEthPrice()).rejects.toThrow();
     expect(spy).toHaveBeenCalled();
     spy.mockRestore();
   });
 
-  it('returns 0 on network error', async () => {
+  it('throws on network error', async () => {
     globalThis.fetch = mockFetchWithNetworkError();
     const spy = vi.spyOn(toast, 'showToast').mockImplementation(() => {});
-    const price = await getEthPrice();
-    expect(price).toBe(0);
+    await expect(getEthPrice()).rejects.toThrow();
     expect(spy).toHaveBeenCalled();
     spy.mockRestore();
   });
 
   it('handles invalid response format', async () => {
     globalThis.fetch = mockFetchWithInvalidResponse();
-    const price = await getEthPrice();
-    expect(price).toBe(0);
+    await expect(getEthPrice()).rejects.toThrow();
   });
 });


### PR DESCRIPTION
## Summary
- handle ETH price API errors by falling back to cached value
- stop double-logging failures
- throw errors from dashboard `getEthPrice` so SWR keeps stale data
- update tests accordingly

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6877a85b5cd48328977cf16154599360