### PR TITLE
Update NATS retry logic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@
 - Avoid lines with trailing whitespace (spaces or tabs)
 
 ## NATS Exactly-Once Configuration
-- Publishing uses `publish_event_with_retry()` with 3 retries and exponential backoff
+- Publishing uses `publish_event_with_retry()` with 10 retries and exponential backoff (first retry after 1s)
 - Each event includes a unique `Msg-Id` header based on `TaikoEvent::dedup_id()`
 - For production: configure NATS stream with `duplicate_window: Duration::from_secs(120)` and file storage
 - NATS JetStream provides exactly-once delivery using message ID deduplication

--- a/crates/driver/src/ingestor.rs
+++ b/crates/driver/src/ingestor.rs
@@ -118,7 +118,7 @@ impl IngestorDriver {
                 maybe_l1 = l1_stream.next() => {
                     if let Some(header) = maybe_l1 {
                         let event = TaikoEvent::L1Header(header);
-                        if let Err(e) = publish_event_with_retry(&self.jetstream, &event, 3).await {
+                        if let Err(e) = publish_event_with_retry(&self.jetstream, &event, 10).await {
                             tracing::error!(err = %e, "Failed to publish L1Header");
                         }
                     }
@@ -126,7 +126,7 @@ impl IngestorDriver {
                 maybe_l2 = l2_stream.next() => {
                     if let Some(header) = maybe_l2 {
                         let event = TaikoEvent::L2Header(header);
-                        if let Err(e) = publish_event_with_retry(&self.jetstream, &event, 3).await {
+                        if let Err(e) = publish_event_with_retry(&self.jetstream, &event, 10).await {
                             tracing::error!(err = %e, "Failed to publish L2Header");
                         }
                     }
@@ -135,7 +135,7 @@ impl IngestorDriver {
                     if let Some((batch, l1_tx_hash)) = maybe_batch {
                         let wrapper = BatchProposedWrapper::from((batch, l1_tx_hash));
                         let event = TaikoEvent::BatchProposed(wrapper);
-                        if let Err(e) = publish_event_with_retry(&self.jetstream, &event, 3).await {
+                        if let Err(e) = publish_event_with_retry(&self.jetstream, &event, 10).await {
                             tracing::error!(err = %e, "Failed to publish BatchProposed");
                         }
                     }
@@ -144,7 +144,7 @@ impl IngestorDriver {
                     if let Some(fi) = maybe_fi {
                         let wrapper = ForcedInclusionProcessedWrapper::from(fi);
                         let event = TaikoEvent::ForcedInclusionProcessed(wrapper);
-                        if let Err(e) = publish_event_with_retry(&self.jetstream, &event, 3).await {
+                        if let Err(e) = publish_event_with_retry(&self.jetstream, &event, 10).await {
                             tracing::error!(err = %e, "Failed to publish ForcedInclusionProcessed");
                         }
                     }
@@ -153,7 +153,7 @@ impl IngestorDriver {
                     if let Some((proved, l1_block_number, l1_tx_hash)) = maybe_proved {
                         let wrapper = BatchesProvedWrapper::from((proved, l1_block_number, l1_tx_hash));
                         let event = TaikoEvent::BatchesProved(wrapper);
-                        if let Err(e) = publish_event_with_retry(&self.jetstream, &event, 3).await {
+                        if let Err(e) = publish_event_with_retry(&self.jetstream, &event, 10).await {
                             tracing::error!(err = %e, "Failed to publish BatchesProved");
                         }
                     }
@@ -162,7 +162,7 @@ impl IngestorDriver {
                     if let Some((verified, l1_block_number, l1_tx_hash)) = maybe_verified {
                         let wrapper = BatchesVerifiedWrapper::from((verified, l1_block_number, l1_tx_hash));
                         let event = TaikoEvent::BatchesVerified(wrapper);
-                        if let Err(e) = publish_event_with_retry(&self.jetstream, &event, 3).await {
+                        if let Err(e) = publish_event_with_retry(&self.jetstream, &event, 10).await {
                             tracing::error!(err = %e, "Failed to publish BatchesVerified");
                         }
                     }

--- a/crates/nats-utils/src/lib.rs
+++ b/crates/nats-utils/src/lib.rs
@@ -71,7 +71,7 @@ pub async fn publish_event_with_retry(
                 }
 
                 retries += 1;
-                let delay = std::time::Duration::from_millis(100 * (1 << retries));
+                let delay = std::time::Duration::from_secs(1u64 << (retries - 1));
 
                 tracing::warn!(
                     dedup_id = %dedup_id,


### PR DESCRIPTION
## Summary
- use exponential backoff starting at 1s in `publish_event_with_retry`
- retry 10 times in the ingestor when publishing events
- document new retry behavior

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_687ce9a900e8832883725f77efe64f0f