### PR TITLE
Remove hardware metric from economics view

### DIFF
--- a/dashboard/components/views/DashboardView.tsx
+++ b/dashboard/components/views/DashboardView.tsx
@@ -107,15 +107,7 @@ export const DashboardView: React.FC<DashboardViewProps> = ({
       hours,
     );
     const costWei = ethPrice > 0 ? (costUsd / ethPrice) * 1e9 : null;
-    const hardwareMetric: MetricData = {
-      title: 'Hardware Costs',
-      value: costWei != null ? formatEth(costWei, 4) : 'N/A',
-      group: 'Network Economics',
-    };
-    const idx = metricsData.metrics.findIndex((m) => m.title === 'Prove Cost');
     const list = [...metricsData.metrics];
-    if (idx >= 0) list.splice(idx + 1, 0, hardwareMetric);
-    else list.push(hardwareMetric);
 
     if (costWei != null) {
       const profitIdx = list.findIndex(


### PR DESCRIPTION
## Summary
- remove the Hardware Costs metric from economics dashboard

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_687df6cd85b483289b9fc0e1ad3df121