### PR TITLE
Fix resolved time for incidents

### DIFF
--- a/crates/incident/src/base_monitor.rs
+++ b/crates/incident/src/base_monitor.rs
@@ -114,7 +114,7 @@ impl<K: Clone + Debug + Eq + std::hash::Hash> BaseMonitor<K> {
             components: vec![self.component_id.clone()],
             statuses: vec![ComponentStatus::operational(&self.component_id)],
             notify: true,
-            started: Some(Utc::now().to_rfc3339()),
+            resolved: Some(Utc::now().to_rfc3339()),
         }
     }
 
@@ -288,7 +288,7 @@ mod tests {
         assert_eq!(payload.components, vec!["comp1".to_owned()]);
         assert_eq!(payload.statuses, vec![ComponentStatus::operational("comp1")]);
         assert!(payload.notify);
-        assert!(payload.started.is_some());
+        assert!(payload.resolved.is_some());
     }
 
     #[tokio::test]

--- a/crates/incident/src/client.rs
+++ b/crates/incident/src/client.rs
@@ -187,14 +187,14 @@ mod tests {
             components: vec!["comp1".to_owned()],
             statuses: vec![ComponentStatus::operational("comp1")],
             notify: true,
-            started: Some("2025-05-12T07:48:00Z".to_owned()),
+            resolved: Some("2025-05-12T07:48:00Z".to_owned()),
         };
         let expected = json!({
             "status": "RESOLVED",
             "components": ["comp1"],
             "statuses": [{"id": "comp1", "status": "OPERATIONAL"}],
             "notify": true,
-            "started": "2025-05-12T07:48:00Z"
+            "resolved": "2025-05-12T07:48:00Z"
         });
         let actual = serde_json::to_value(&payload).unwrap();
         assert_eq!(actual, expected);
@@ -249,7 +249,7 @@ mod tests {
             components: vec!["comp1".into()],
             statuses: vec![ComponentStatus::operational("comp1")],
             notify: true,
-            started: Some("2025-05-12T07:48:00Z".to_owned()),
+            resolved: Some("2025-05-12T07:48:00Z".to_owned()),
         };
         client.resolve_incident("incident123", &payload).await.unwrap();
         mock.assert_async().await;
@@ -358,7 +358,7 @@ mod tests {
             components: vec!["comp1".into()],
             statuses: vec![ComponentStatus::operational("comp1")],
             notify: true,
-            started: None,
+            resolved: None,
         };
         let err = client.resolve_incident("incident123", &payload).await.unwrap_err();
         assert!(err.to_string().contains("500"));

--- a/crates/incident/src/monitor/mod.rs
+++ b/crates/incident/src/monitor/mod.rs
@@ -80,9 +80,9 @@ pub struct ResolveIncident {
     pub statuses: Vec<ComponentStatus>,
     /// Whether to notify subscribers
     pub notify: bool,
-    /// Incident start time in RFC3339 format
+    /// Time the incident was resolved in RFC3339 format
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub started: Option<String>,
+    pub resolved: Option<String>,
 }
 
 mod batch_proof_timeout;

--- a/crates/incident/src/monitor/public_rpc.rs
+++ b/crates/incident/src/monitor/public_rpc.rs
@@ -126,7 +126,7 @@ async fn resolve(client: &IncidentClient, component_id: &str, id: &str) {
         components: vec![component_id.to_owned()],
         statuses: vec![ComponentStatus::operational(component_id)],
         notify: true,
-        started: Some(Utc::now().to_rfc3339()),
+        resolved: Some(Utc::now().to_rfc3339()),
     };
     if let Err(e) = client.resolve_incident(id, &body).await {
         error!(error = %e, incident_id = %id, "failed to resolve incident");


### PR DESCRIPTION
## Summary
- record the resolution time in `ResolveIncident`
- update resolve payload creation and serialization tests
- replace old `started` field usage in public RPC monitor

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_687f5756fb8883289a2195d27b4124a5