### PR TITLE
Add separate L1 and L2 monitor thresholds

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -132,9 +132,13 @@ pub struct InstatusOpts {
     /// Instatus monitor poll interval in seconds
     #[clap(long, env = "INSTATUS_MONITOR_POLL_INTERVAL_SECS", default_value = "30")]
     pub monitor_poll_interval_secs: u64,
-    /// Instatus monitor threshold in seconds for detecting an outage
-    #[clap(long, env = "INSTATUS_MONITOR_THRESHOLD_SECS", default_value = "600")]
-    pub monitor_threshold_secs: u64,
+    /// Threshold in seconds for detecting missing `BatchProposed` events
+    #[clap(long, env = "INSTATUS_L1_MONITOR_THRESHOLD_SECS", default_value = "600")]
+    pub l1_monitor_threshold_secs: u64,
+
+    /// Threshold in seconds for detecting missing L2 head events
+    #[clap(long, env = "INSTATUS_L2_MONITOR_THRESHOLD_SECS", default_value = "600")]
+    pub l2_monitor_threshold_secs: u64,
 
     /// Batch proof timeout threshold in seconds (default 3 hours)
     #[clap(long, env = "BATCH_PROOF_TIMEOUT_SECS", default_value = "10800")]
@@ -304,7 +308,8 @@ mod tests {
         use std::env;
         unsafe {
             env::remove_var("INSTATUS_MONITOR_POLL_INTERVAL_SECS");
-            env::remove_var("INSTATUS_MONITOR_THRESHOLD_SECS");
+            env::remove_var("INSTATUS_L1_MONITOR_THRESHOLD_SECS");
+            env::remove_var("INSTATUS_L2_MONITOR_THRESHOLD_SECS");
             env::remove_var("BATCH_PROOF_TIMEOUT_SECS");
             env::remove_var("INSTATUS_MONITORS_ENABLED");
             env::remove_var("ALLOWED_ORIGINS");
@@ -316,7 +321,8 @@ mod tests {
         let opts = Opts::try_parse_from(args).expect("failed to parse opts");
 
         assert_eq!(opts.instatus.monitor_poll_interval_secs, 30);
-        assert_eq!(opts.instatus.monitor_threshold_secs, 600);
+        assert_eq!(opts.instatus.l1_monitor_threshold_secs, 600);
+        assert_eq!(opts.instatus.l2_monitor_threshold_secs, 600);
         assert_eq!(opts.instatus.batch_proof_timeout_secs, 10800);
         assert_eq!(opts.api.host, "127.0.0.1");
         assert_eq!(opts.api.port, 3000);
@@ -343,7 +349,8 @@ mod tests {
         // Clean up first to ensure clean state
         unsafe {
             env::remove_var("INSTATUS_MONITOR_POLL_INTERVAL_SECS");
-            env::remove_var("INSTATUS_MONITOR_THRESHOLD_SECS");
+            env::remove_var("INSTATUS_L1_MONITOR_THRESHOLD_SECS");
+            env::remove_var("INSTATUS_L2_MONITOR_THRESHOLD_SECS");
             env::remove_var("BATCH_PROOF_TIMEOUT_SECS");
             env::remove_var("INSTATUS_MONITORS_ENABLED");
             env::remove_var("ALLOWED_ORIGINS");
@@ -353,7 +360,8 @@ mod tests {
 
         unsafe {
             env::set_var("INSTATUS_MONITOR_POLL_INTERVAL_SECS", "42");
-            env::set_var("INSTATUS_MONITOR_THRESHOLD_SECS", "33");
+            env::set_var("INSTATUS_L1_MONITOR_THRESHOLD_SECS", "33");
+            env::set_var("INSTATUS_L2_MONITOR_THRESHOLD_SECS", "44");
             env::set_var("BATCH_PROOF_TIMEOUT_SECS", "99");
             env::set_var("INSTATUS_MONITORS_ENABLED", "false");
             env::set_var("ALLOWED_ORIGINS", "http://localhost:3000,http://localhost:5173");
@@ -367,7 +375,8 @@ mod tests {
         let opts = Opts::try_parse_from(&args).expect("failed to parse opts");
 
         assert_eq!(opts.instatus.monitor_poll_interval_secs, 42);
-        assert_eq!(opts.instatus.monitor_threshold_secs, 33);
+        assert_eq!(opts.instatus.l1_monitor_threshold_secs, 33);
+        assert_eq!(opts.instatus.l2_monitor_threshold_secs, 44);
         assert_eq!(opts.instatus.batch_proof_timeout_secs, 99);
         assert_eq!(opts.api.host, "127.0.0.1");
         assert_eq!(opts.api.port, 3000);
@@ -382,7 +391,8 @@ mod tests {
         // Clean up after test
         unsafe {
             env::remove_var("INSTATUS_MONITOR_POLL_INTERVAL_SECS");
-            env::remove_var("INSTATUS_MONITOR_THRESHOLD_SECS");
+            env::remove_var("INSTATUS_L1_MONITOR_THRESHOLD_SECS");
+            env::remove_var("INSTATUS_L2_MONITOR_THRESHOLD_SECS");
             env::remove_var("BATCH_PROOF_TIMEOUT_SECS");
             env::remove_var("INSTATUS_MONITORS_ENABLED");
             env::remove_var("ALLOWED_ORIGINS");

--- a/crates/driver/src/lib.rs
+++ b/crates/driver/src/lib.rs
@@ -50,7 +50,8 @@ pub struct Driver {
     instatus_public_api_component_id: String,
     instatus_monitors_enabled: bool,
     instatus_monitor_poll_interval_secs: u64,
-    instatus_monitor_threshold_secs: u64,
+    instatus_l1_monitor_threshold_secs: u64,
+    instatus_l2_monitor_threshold_secs: u64,
     batch_proof_timeout_secs: u64,
     last_proposed_l2_block: u64,
     last_l2_header: Option<(u64, Address)>,
@@ -150,7 +151,8 @@ impl Driver {
             instatus_public_api_component_id,
             instatus_monitors_enabled: opts.instatus.monitors_enabled,
             instatus_monitor_poll_interval_secs: opts.instatus.monitor_poll_interval_secs,
-            instatus_monitor_threshold_secs: opts.instatus.monitor_threshold_secs,
+            instatus_l1_monitor_threshold_secs: opts.instatus.l1_monitor_threshold_secs,
+            instatus_l2_monitor_threshold_secs: opts.instatus.l2_monitor_threshold_secs,
             batch_proof_timeout_secs: opts.instatus.batch_proof_timeout_secs,
             last_proposed_l2_block: 0,
             last_l2_header: None,
@@ -241,7 +243,7 @@ impl Driver {
             self.clickhouse_reader.clone(),
             self.incident_client.clone(),
             self.instatus_batch_submission_component_id.clone(),
-            Duration::from_secs(self.instatus_monitor_threshold_secs),
+            Duration::from_secs(self.instatus_l1_monitor_threshold_secs),
             Duration::from_secs(self.instatus_monitor_poll_interval_secs),
         )
         .spawn();
@@ -250,7 +252,7 @@ impl Driver {
             self.clickhouse_reader.clone(),
             self.incident_client.clone(),
             self.instatus_transaction_sequencing_component_id.clone(),
-            Duration::from_secs(self.instatus_monitor_threshold_secs),
+            Duration::from_secs(self.instatus_l2_monitor_threshold_secs),
             Duration::from_secs(self.instatus_monitor_poll_interval_secs),
         )
         .spawn();
@@ -684,7 +686,8 @@ mod tests {
                 public_api_component_id: "public".into(),
                 monitors_enabled: true,
                 monitor_poll_interval_secs: 30,
-                monitor_threshold_secs: 96,
+                l1_monitor_threshold_secs: 96,
+                l2_monitor_threshold_secs: 96,
                 batch_proof_timeout_secs: 999,
             },
             enable_db_writes: false,

--- a/crates/driver/src/processor.rs
+++ b/crates/driver/src/processor.rs
@@ -38,7 +38,8 @@ pub struct ProcessorDriver {
     instatus_public_api_component_id: String,
     instatus_monitors_enabled: bool,
     instatus_monitor_poll_interval_secs: u64,
-    instatus_monitor_threshold_secs: u64,
+    instatus_l1_monitor_threshold_secs: u64,
+    instatus_l2_monitor_threshold_secs: u64,
     batch_proof_timeout_secs: u64,
     public_rpc_url: Option<Url>,
     nats_stream_config: config::NatsStreamOpts,
@@ -159,7 +160,8 @@ impl ProcessorDriver {
             instatus_public_api_component_id,
             instatus_monitors_enabled: opts.instatus.monitors_enabled,
             instatus_monitor_poll_interval_secs: opts.instatus.monitor_poll_interval_secs,
-            instatus_monitor_threshold_secs: opts.instatus.monitor_threshold_secs,
+            instatus_l1_monitor_threshold_secs: opts.instatus.l1_monitor_threshold_secs,
+            instatus_l2_monitor_threshold_secs: opts.instatus.l2_monitor_threshold_secs,
             batch_proof_timeout_secs: opts.instatus.batch_proof_timeout_secs,
             public_rpc_url: opts.rpc.public_url,
             nats_stream_config: opts.nats_stream,
@@ -666,7 +668,7 @@ impl ProcessorDriver {
                 reader.clone(),
                 self.incident_client.clone(),
                 self.instatus_batch_submission_component_id.clone(),
-                Duration::from_secs(self.instatus_monitor_threshold_secs),
+                Duration::from_secs(self.instatus_l1_monitor_threshold_secs),
                 Duration::from_secs(self.instatus_monitor_poll_interval_secs),
             )
             .spawn();
@@ -675,7 +677,7 @@ impl ProcessorDriver {
                 reader.clone(),
                 self.incident_client.clone(),
                 self.instatus_transaction_sequencing_component_id.clone(),
-                Duration::from_secs(self.instatus_monitor_threshold_secs),
+                Duration::from_secs(self.instatus_l2_monitor_threshold_secs),
                 Duration::from_secs(self.instatus_monitor_poll_interval_secs),
             )
             .spawn();


### PR DESCRIPTION
## Summary
- add `INSTATUS_L1_MONITOR_THRESHOLD_SECS` and `INSTATUS_L2_MONITOR_THRESHOLD_SECS`
- use new options in driver implementations
- update tests

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_687f6f542e3c8328bc424d674eb9ee34