### PR TITLE
Improve connection error messages

### DIFF
--- a/crates/clickhouse/src/writer.rs
+++ b/crates/clickhouse/src/writer.rs
@@ -226,7 +226,7 @@ impl ClickhouseWriter {
             .query(&format!("CREATE DATABASE IF NOT EXISTS {}", self.db_name))
             .execute()
             .await
-            .wrap_err_with(|| format!("Failed to create database {}", self.db_name))?;
+            .wrap_err_with(|| format!("Failed to init database {}", self.db_name))?;
 
         if reset {
             for view in VIEWS {

--- a/crates/clickhouse/src/writer.rs
+++ b/crates/clickhouse/src/writer.rs
@@ -225,7 +225,8 @@ impl ClickhouseWriter {
         self.base
             .query(&format!("CREATE DATABASE IF NOT EXISTS {}", self.db_name))
             .execute()
-            .await?;
+            .await
+            .wrap_err_with(|| format!("Failed to create database {}", self.db_name))?;
 
         if reset {
             for view in VIEWS {

--- a/crates/driver/src/ingestor.rs
+++ b/crates/driver/src/ingestor.rs
@@ -1,6 +1,6 @@
 //! Taikoscope Ingestor Driver
 
-use eyre::Result;
+use eyre::{Context, Result};
 use tokio_stream::StreamExt;
 use tracing::info;
 
@@ -37,7 +37,9 @@ impl IngestorDriver {
         )
         .await?;
 
-        let nats_client = async_nats::connect(&opts.nats_url).await?;
+        let nats_client = async_nats::connect(&opts.nats_url)
+            .await
+            .wrap_err_with(|| format!("failed to connect to NATS at {}", opts.nats_url))?;
         info!("Connected to NATS server at {}", opts.nats_url);
 
         let jetstream = async_nats::jetstream::new(nats_client);

--- a/crates/driver/src/processor.rs
+++ b/crates/driver/src/processor.rs
@@ -6,7 +6,7 @@ use alloy_primitives::{Address, B256};
 use clickhouse::{AddressBytes, ClickhouseReader, ClickhouseWriter, HashBytes, L2HeadEvent};
 use config::Opts;
 use extractor::{Extractor, ReorgDetector};
-use eyre::Result;
+use eyre::{Context, Result};
 use incident::{
     BatchProofTimeoutMonitor, InstatusL1Monitor, InstatusMonitor, Monitor,
     client::Client as IncidentClient,
@@ -61,7 +61,9 @@ impl ProcessorDriver {
             info!("Instatus monitors disabled; no incidents will be reported");
         }
 
-        let nats_client = async_nats::connect(&opts.nats_url).await?;
+        let nats_client = async_nats::connect(&opts.nats_url)
+            .await
+            .wrap_err_with(|| format!("failed to connect to NATS at {}", opts.nats_url))?;
         info!("Connected to NATS server at {}", opts.nats_url);
 
         // Initialize extractor for L2 block statistics and transaction cost analysis


### PR DESCRIPTION
## Summary
- clarify connection errors when connecting to NATS
- add context to ClickHouse DB initialization

## Testing
- `just fmt`
- `just lint`
- `just test`
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_687f845527c083289baed49af49ab383