### PR TITLE
fix(dashboard): improve chart text visibility in dark mode

### DIFF
--- a/dashboard/components/FeeFlowChart.tsx
+++ b/dashboard/components/FeeFlowChart.tsx
@@ -172,7 +172,7 @@ export const FeeFlowChart: React.FC<FeeFlowChartProps> = ({
 }) => {
   const { theme } = useTheme();
   const textColor =
-    theme === 'dark' ? '#e2e8f0' : lightTheme.foreground;
+    theme === 'dark' ? '#ffffff' : lightTheme.foreground;
   const { data: feeRes } = useSWR(['l2FeesFlow', timeRange, address], () =>
     fetchL2FeesComponents(timeRange),
   );

--- a/dashboard/index.css
+++ b/dashboard/index.css
@@ -11,3 +11,9 @@ button:disabled {
 select:hover {
   cursor: pointer;
 }
+
+/* Ensure chart text remains legible in dark mode */
+.dark .recharts-text,
+.dark .recharts-text tspan {
+  fill: #ffffff !important;
+}


### PR DESCRIPTION
## Summary
- ensure Recharts labels render in white when using dark theme
- set FeeFlowChart node text to white for better contrast

## Testing
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_6890b22fcab48328a546d5e600c5c04b