### PR TITLE
fix(dashboard): ensure chart text readable in light mode

### DIFF
--- a/dashboard/index.css
+++ b/dashboard/index.css
@@ -12,7 +12,15 @@ select:hover {
   cursor: pointer;
 }
 
-/* Ensure chart text is readable in dark mode */
+/* Ensure chart text is readable in both light and dark modes */
+.recharts-layer text {
+  fill: #0f172a;
+}
+
+.recharts-default-tooltip {
+  color: #0f172a;
+}
+
 .dark .recharts-layer text {
   fill: #ffffff;
 }


### PR DESCRIPTION
## Summary
- fix chart text and tooltip colors to use dark text in light mode

## Testing
- `just lint-dashboard`
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_6890b9397a5083288664c4cd5e20515a