### PR TITLE
fix: restore dark text color in light mode

### DIFF
--- a/dashboard/index.css
+++ b/dashboard/index.css
@@ -1,8 +1,7 @@
 @import 'tailwindcss';
 
 @layer base {
-  html,
-  body {
+  html {
     @apply text-gray-900 dark:text-gray-100;
   }
 }


### PR DESCRIPTION
## Summary
- ensure global text color is dark in light mode and light in dark mode

## Testing
- `npm run lint:whitespace`
- `npm run check`
- `just ci`


------
https://chatgpt.com/codex/tasks/task_b_6890b9397a5083288664c4cd5e20515a