### PR TITLE
feat: expose batch prove cost directly

### DIFF
--- a/crates/api-types/src/lib.rs
+++ b/crates/api-types/src/lib.rs
@@ -305,8 +305,8 @@ pub struct BatchFeeComponentRow {
     pub base_fee: u128,
     /// L1 data posting cost associated with the batch, if available
     pub l1_data_cost: Option<u128>,
-    /// Prover cost amortized across batches in the selected range
-    pub amortized_prove_cost: Option<u128>,
+    /// Prover cost for the batch, if available
+    pub prove_cost: Option<u128>,
 }
 
 /// Fee components for each batch

--- a/crates/api/src/helpers/aggregation.rs
+++ b/crates/api/src/helpers/aggregation.rs
@@ -144,7 +144,7 @@ pub fn aggregate_batch_fee_components(
                 any_l1 = true;
             }
 
-            if let Some(prove_cost) = r.amortized_prove_cost {
+            if let Some(prove_cost) = r.prove_cost {
                 sum_prove += prove_cost;
                 any_prove = true;
             }
@@ -171,7 +171,7 @@ pub fn aggregate_batch_fee_components(
             priority_fee: sum_priority,
             base_fee: sum_base,
             l1_data_cost: any_l1.then_some(sum_l1),
-            amortized_prove_cost: any_prove.then_some(sum_prove),
+            prove_cost: any_prove.then_some(sum_prove),
         });
     }
 
@@ -301,7 +301,7 @@ mod tests {
             priority_fee,
             base_fee,
             l1_data_cost: l1_cost,
-            amortized_prove_cost: prove_cost,
+            prove_cost,
         }
     }
 
@@ -475,7 +475,7 @@ mod tests {
         assert_eq!(result[0].priority_fee, 1000);
         assert_eq!(result[0].base_fee, 2000);
         assert_eq!(result[0].l1_data_cost, Some(500));
-        assert_eq!(result[0].amortized_prove_cost, Some(300));
+        assert_eq!(result[0].prove_cost, Some(300));
     }
 
     #[test]
@@ -508,7 +508,7 @@ mod tests {
         assert_eq!(result[0].priority_fee, 2500); // 1000 + 1500
         assert_eq!(result[0].base_fee, 4500); // 2000 + 2500
         assert_eq!(result[0].l1_data_cost, Some(1100)); // 500 + 600
-        assert_eq!(result[0].amortized_prove_cost, Some(700)); // 300 + 400
+        assert_eq!(result[0].prove_cost, Some(700)); // 300 + 400
         assert_eq!(result[0].l1_block_number, 101); // Last value
         assert_eq!(result[0].l1_tx_hash, "0x1"); // Last value
         assert_eq!(result[0].sequencer, "seq2"); // Last value
@@ -542,7 +542,7 @@ mod tests {
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].l1_data_cost, Some(600)); // any=true due to second row
-        assert_eq!(result[0].amortized_prove_cost, Some(300)); // any=true due to first row
+        assert_eq!(result[0].prove_cost, Some(300)); // any=true due to first row
     }
 
     // Tests for aggregate_l2_tps

--- a/crates/api/src/routes/core.rs
+++ b/crates/api/src/routes/core.rs
@@ -756,7 +756,7 @@ pub async fn l2_fees_components(
 
     let time_range = resolve_time_range_enum(&params.time_range);
 
-    let (sequencer_fees, batch_components, prove_total) = state
+    let (sequencer_fees, batch_components) = state
         .client
         .get_l2_fees_and_components(None, time_range)
         .await
@@ -767,11 +767,6 @@ pub async fn l2_fees_components(
     let base_fee = sequencer_fees.iter().map(|s| s.base_fee).sum::<u128>();
     let l1_data_cost = sequencer_fees.iter().map(|s| s.l1_data_cost).sum::<u128>();
     let prove_cost = sequencer_fees.iter().map(|s| s.prove_cost).sum::<u128>();
-
-    // Calculate amortized prove cost
-    let count = batch_components.len() as u128;
-    let amortized_prove =
-        if count > 0 { prove_total.map(|c| wei_to_gwei(c / count)) } else { None };
 
     // Convert sequencer fees to gwei
     let sequencers: Vec<SequencerFeeRow> = sequencer_fees
@@ -796,7 +791,7 @@ pub async fn l2_fees_components(
             priority_fee: wei_to_gwei(r.priority_fee),
             base_fee: wei_to_gwei(r.base_fee),
             l1_data_cost: wei_to_gwei_opt(r.l1_data_cost),
-            amortized_prove_cost: amortized_prove,
+            prove_cost: wei_to_gwei_opt(r.prove_cost),
         })
         .collect();
 

--- a/crates/clickhouse/src/models.rs
+++ b/crates/clickhouse/src/models.rs
@@ -416,6 +416,8 @@ pub struct BatchFeeComponentRow {
     pub base_fee: u128,
     /// L1 data posting cost associated with the batch, if available
     pub l1_data_cost: Option<u128>,
+    /// Prover cost associated with the batch, if available
+    pub prove_cost: Option<u128>,
 }
 
 /// Row representing the transactions per second for an L2 block

--- a/crates/clickhouse/src/reader/client.rs
+++ b/crates/clickhouse/src/reader/client.rs
@@ -2476,7 +2476,7 @@ impl ClickhouseReader {
                 sum(h.sum_priority_fee) AS priority_fee,
                 sum(h.sum_base_fee) AS base_fee,
                 toNullable(max(dc.cost)) AS l1_data_cost,
-                pc.cost AS prove_cost
+                toNullable(max(pc.cost)) AS prove_cost
             FROM
                 recent_batches rb
             INNER JOIN
@@ -2496,7 +2496,7 @@ impl ClickhouseReader {
                 )
                 AND {filter}
             GROUP BY
-                rb.batch_id, rb.l1_block_number, rb.l1_tx_hash, rb.proposer_addr, pc.cost
+                rb.batch_id, rb.l1_block_number, rb.l1_tx_hash, rb.proposer_addr
             ORDER BY
                 rb.batch_id ASC",
             interval = range.interval(),

--- a/crates/clickhouse/src/reader/client.rs
+++ b/crates/clickhouse/src/reader/client.rs
@@ -2433,6 +2433,7 @@ impl ClickhouseReader {
             priority_fee: u128,
             base_fee: u128,
             l1_data_cost: Option<u128>,
+            prove_cost: Option<u128>,
         }
 
         let mut query = format!(
@@ -2474,7 +2475,8 @@ impl ClickhouseReader {
                 rb.proposer_addr AS proposer,
                 sum(h.sum_priority_fee) AS priority_fee,
                 sum(h.sum_base_fee) AS base_fee,
-                toNullable(max(dc.cost)) AS l1_data_cost
+                toNullable(max(dc.cost)) AS l1_data_cost,
+                pc.cost AS prove_cost
             FROM
                 recent_batches rb
             INNER JOIN
@@ -2483,6 +2485,8 @@ impl ClickhouseReader {
                 {db}.l2_head_events h ON bb.l2_block_number = h.l2_block_number
             LEFT JOIN
                 {db}.l1_data_costs dc ON rb.batch_id = dc.batch_id AND rb.l1_block_number = dc.l1_block_number
+            LEFT JOIN
+                {db}.prove_costs pc ON rb.batch_id = pc.batch_id
             WHERE
                 bb.batch_id IN (
                     SELECT DISTINCT b2.batch_id
@@ -2492,7 +2496,7 @@ impl ClickhouseReader {
                 )
                 AND {filter}
             GROUP BY
-                rb.batch_id, rb.l1_block_number, rb.l1_tx_hash, rb.proposer_addr
+                rb.batch_id, rb.l1_block_number, rb.l1_tx_hash, rb.proposer_addr, pc.cost
             ORDER BY
                 rb.batch_id ASC",
             interval = range.interval(),
@@ -2511,6 +2515,7 @@ impl ClickhouseReader {
                 priority_fee: r.priority_fee,
                 base_fee: r.base_fee,
                 l1_data_cost: r.l1_data_cost,
+                prove_cost: r.prove_cost,
             })
             .collect())
     }
@@ -3157,13 +3162,12 @@ impl ClickhouseReader {
         &self,
         proposer: Option<AddressBytes>,
         range: TimeRange,
-    ) -> Result<(Vec<SequencerFeeRow>, Vec<BatchFeeComponentRow>, Option<u128>)> {
-        // Fetch all three concurrently
-        let (sequencer_fees, batch_components, prove_total) = try_join!(
+    ) -> Result<(Vec<SequencerFeeRow>, Vec<BatchFeeComponentRow>)> {
+        // Fetch both concurrently
+        let (sequencer_fees, batch_components) = try_join!(
             self.get_l2_fees_by_sequencer(range),
-            self.get_batch_fee_components(proposer, range),
-            self.get_total_prove_cost(proposer, range)
+            self.get_batch_fee_components(proposer, range)
         )?;
-        Ok((sequencer_fees, batch_components, prove_total))
+        Ok((sequencer_fees, batch_components))
     }
 }

--- a/crates/clickhouse/src/reader/tests.rs
+++ b/crates/clickhouse/src/reader/tests.rs
@@ -140,6 +140,7 @@ struct BatchFeeRow {
     priority_fee: u128,
     base_fee: u128,
     l1_data_cost: Option<u128>,
+    prove_cost: Option<u128>,
 }
 
 #[tokio::test]
@@ -153,6 +154,7 @@ async fn batch_fee_components_returns_expected_rows() {
         priority_fee: 10,
         base_fee: 20,
         l1_data_cost: Some(5),
+        prove_cost: Some(3),
     }]));
 
     let url = url::Url::parse(mock.url()).unwrap();
@@ -170,6 +172,7 @@ async fn batch_fee_components_returns_expected_rows() {
             priority_fee: 10,
             base_fee: 20,
             l1_data_cost: Some(5),
+            prove_cost: Some(3),
         }]
     );
 }
@@ -186,6 +189,7 @@ async fn batch_total_fee_helpers_return_expected_values() {
             priority_fee: 10,
             base_fee: 20,
             l1_data_cost: Some(5),
+            prove_cost: Some(3),
         }]));
     }
 

--- a/crates/messages/src/models.rs
+++ b/crates/messages/src/models.rs
@@ -368,8 +368,8 @@ pub struct BatchFeeComponentRow {
     pub base_fee: u128,
     /// L1 data posting cost associated with the batch, if available
     pub l1_data_cost: Option<u128>,
-    /// Prover cost amortized across batches in the selected range
-    pub amortized_prove_cost: Option<u128>,
+    /// Prover cost associated with the batch, if available
+    pub prove_cost: Option<u128>,
     /// Verifier cost amortized across batches in the selected range
     pub amortized_verify_cost: Option<u128>,
 }

--- a/dashboard/components/BlockProfitTables.tsx
+++ b/dashboard/components/BlockProfitTables.tsx
@@ -48,7 +48,7 @@ export const BlockProfitTables: React.FC<BlockProfitTablesProps> = ({
         priority: b.priority_fee,
         base: b.base_fee,
         l1Cost: b.l1_data_cost,
-        amortizedProveCost: b.amortized_prove_cost,
+        proveCost: b.prove_cost,
       })) ?? [];
   const batchCount = batchData.length;
   const HOURS_IN_MONTH = 30 * 24;
@@ -64,7 +64,7 @@ export const BlockProfitTables: React.FC<BlockProfitTablesProps> = ({
       priorityFee: b.priority,
       baseFee: b.base,
       l1DataCost: b.l1Cost ?? 0,
-      proveCost: b.amortizedProveCost ?? 0,
+      proveCost: b.proveCost ?? 0,
 
       hardwareCostUsd: operationalCostPerBatchUsd,
       ethPrice,

--- a/dashboard/components/CostChart.tsx
+++ b/dashboard/components/CostChart.tsx
@@ -47,7 +47,7 @@ export const CostChart: React.FC<CostChartProps> = ({
         priority: b.priority_fee,
         base: b.base_fee,
         l1Cost: b.l1_data_cost,
-        amortizedProveCost: b.amortized_prove_cost,
+        proveCost: b.prove_cost,
       })) ?? null;
 
   if (!feeData || feeData.length === 0) {
@@ -67,7 +67,7 @@ export const CostChart: React.FC<CostChartProps> = ({
 
   const data = feeData.map((b) => {
     const l1CostEth = (b.l1Cost ?? 0) / 1e9;
-    const proveEth = (b.amortizedProveCost ?? 0) / 1e9;
+    const proveEth = (b.proveCost ?? 0) / 1e9;
     const verifyEth = 0;
     const costEth = baseCostPerBatchEth + proveEth + verifyEth + l1CostEth;
     const costUsd = costEth * ethPrice;

--- a/dashboard/components/EconomicsChart.tsx
+++ b/dashboard/components/EconomicsChart.tsx
@@ -46,7 +46,7 @@ export const EconomicsChart: React.FC<EconomicsChartProps> = ({
         priority: b.priority_fee,
         base: b.base_fee,
         l1Cost: b.l1_data_cost,
-        amortizedProveCost: b.amortized_prove_cost,
+        proveCost: b.prove_cost,
       })) ?? null;
   const { data: ethPrice = 0, error: ethPriceError } = useEthPrice();
 
@@ -67,7 +67,7 @@ export const EconomicsChart: React.FC<EconomicsChartProps> = ({
 
   const data = feeData.map((b) => {
     const revenueEth = (b.priority + b.base) / 1e9;
-    const proveEth = (b.amortizedProveCost ?? 0) / 1e9;
+    const proveEth = (b.proveCost ?? 0) / 1e9;
     const verifyEth = 0;
     const costEth = baseCostPerBatchEth + proveEth + verifyEth + (b.l1Cost ?? 0) / 1e9;
     const profitEth = revenueEth - costEth;

--- a/dashboard/components/IncomeChart.tsx
+++ b/dashboard/components/IncomeChart.tsx
@@ -38,7 +38,7 @@ export const RevenueChart: React.FC<RevenueChartProps> = ({
         priority: b.priority_fee,
         base: b.base_fee,
         l1Cost: b.l1_data_cost,
-        amortizedProveCost: b.amortized_prove_cost,
+        proveCost: b.prove_cost,
       })) ?? null;
   const { data: ethPrice = 0, error: ethPriceError } = useEthPrice();
 

--- a/dashboard/components/ProfitabilityChart.tsx
+++ b/dashboard/components/ProfitabilityChart.tsx
@@ -47,7 +47,7 @@ export const ProfitabilityChart: React.FC<ProfitabilityChartProps> = ({
         priority: b.priority_fee,
         base: b.base_fee,
         l1Cost: b.l1_data_cost,
-        amortizedProveCost: b.amortized_prove_cost,
+        proveCost: b.prove_cost,
       })) ?? null;
   const { data: ethPrice = 0, error: ethPriceError } = useEthPrice();
 
@@ -70,7 +70,7 @@ export const ProfitabilityChart: React.FC<ProfitabilityChartProps> = ({
       priorityFee: b.priority,
       baseFee: b.base,
       l1DataCost: b.l1Cost ?? 0,
-      proveCost: b.amortizedProveCost ?? 0,
+      proveCost: b.proveCost ?? 0,
 
       hardwareCostUsd: costPerBatchUsd,
       ethPrice,

--- a/dashboard/components/RevenueChart.tsx
+++ b/dashboard/components/RevenueChart.tsx
@@ -38,7 +38,7 @@ export const RevenueChart: React.FC<RevenueChartProps> = ({
         priority: b.priority_fee,
         base: b.base_fee,
         l1Cost: b.l1_data_cost,
-        amortizedProveCost: b.amortized_prove_cost,
+        proveCost: b.prove_cost,
       })) ?? null;
   const { data: ethPrice = 0, error: ethPriceError } = useEthPrice();
 

--- a/dashboard/services/apiService.ts
+++ b/dashboard/services/apiService.ts
@@ -945,7 +945,7 @@ export interface L2FeesComponentsResponse {
     priority_fee: number;
     base_fee: number;
     l1_data_cost: number | null;
-    amortized_prove_cost: number | null;
+    prove_cost: number | null;
   }[];
 }
 

--- a/dashboard/tests/blockProfitTables.test.ts
+++ b/dashboard/tests/blockProfitTables.test.ts
@@ -16,7 +16,7 @@ const feeData = [
     priority: 1e9,
     base: 1e9,
     l1Cost: 0,
-    amortizedProveCost: 0,
+    proveCost: 0,
 
   },
 ];

--- a/dashboard/tests/costChart.test.ts
+++ b/dashboard/tests/costChart.test.ts
@@ -14,7 +14,7 @@ const batchData = [{
   priority_fee: 100000000,
   base_fee: 200000000,
   l1_data_cost: 50000000,
-  amortized_prove_cost: 25000000,
+  prove_cost: 25000000,
 }];
 
 describe('CostChart', () => {

--- a/dashboard/tests/economicsChart.test.ts
+++ b/dashboard/tests/economicsChart.test.ts
@@ -14,7 +14,7 @@ const batchData = [{
   priority_fee: 100000000,
   base_fee: 200000000,
   l1_data_cost: 50000000,
-  amortized_prove_cost: 25000000,
+  prove_cost: 25000000,
 }];
 
 describe('EconomicsChart', () => {

--- a/dashboard/tests/incomeChart.test.ts
+++ b/dashboard/tests/incomeChart.test.ts
@@ -14,7 +14,7 @@ const batchData = [{
   priority_fee: 100000000,
   base_fee: 200000000,
   l1_data_cost: 50000000,
-  amortized_prove_cost: 25000000,
+  prove_cost: 25000000,
 }];
 
 describe('RevenueChart', () => {

--- a/dashboard/tests/profitabilityChart.test.ts
+++ b/dashboard/tests/profitabilityChart.test.ts
@@ -16,7 +16,7 @@ const batchData = [
     priority_fee: 100000000,
     base_fee: 200000000,
     l1_data_cost: 50000000,
-    amortized_prove_cost: 25000000,
+    prove_cost: 25000000,
   },
 ];
 

--- a/dashboard/tests/revenueChart.test.ts
+++ b/dashboard/tests/revenueChart.test.ts
@@ -14,7 +14,7 @@ const batchData = [{
   priority_fee: 100000000,
   base_fee: 200000000,
   l1_data_cost: 50000000,
-  amortized_prove_cost: 25000000,
+  prove_cost: 25000000,
 }];
 
 describe('RevenueChart', () => {

--- a/dashboard/types.ts
+++ b/dashboard/types.ts
@@ -77,7 +77,7 @@ export interface BatchFeeComponent {
   priority: number;
   base: number;
   l1Cost: number | null;
-  amortizedProveCost: number | null;
+  proveCost: number | null;
 }
 
 export interface BlockProfit {


### PR DESCRIPTION
## Summary
- track `prove_cost` for each batch across API, messages, and ClickHouse models
- join ClickHouse `prove_costs` table and expose per-batch values via the API
- update API routes, aggregators, and dashboard to consume `prove_cost` directly

## Testing
- `just ci`

------
https://chatgpt.com/codex/tasks/task_b_6891d4e9be70832885b25dc26fc91030