### PR TITLE
feat(l1): add L1 reorg filtering via orphaned hashes and query-side e…

### DIFF
--- a/crates/clickhouse/migrations/001_create_tables.sql
+++ b/crates/clickhouse/migrations/001_create_tables.sql
@@ -86,4 +86,3 @@ CREATE TABLE IF NOT EXISTS ${DB}.l1_data_costs (
     inserted_at DateTime64(3) DEFAULT now64()
 ) ENGINE = MergeTree()
 ORDER BY (l1_block_number);
-

--- a/crates/clickhouse/migrations/016_add_data_skipping_indices.sql
+++ b/crates/clickhouse/migrations/016_add_data_skipping_indices.sql
@@ -66,6 +66,7 @@ ALTER TABLE ${DB}.orphaned_l2_hashes
     ADD INDEX IF NOT EXISTS idx_orphaned_l2_block_hash_bf block_hash TYPE bloom_filter(0.01) GRANULARITY 1;
 ALTER TABLE ${DB}.orphaned_l2_hashes MATERIALIZE INDEX idx_orphaned_l2_block_hash_bf;
 
+
 -- preconf_data: filters by operator fields
 ALTER TABLE ${DB}.preconf_data
     ADD INDEX IF NOT EXISTS idx_preconf_current_op_bf current_operator TYPE bloom_filter(0.01) GRANULARITY 1,

--- a/crates/clickhouse/migrations/019_create_orphaned_l1_hashes.sql
+++ b/crates/clickhouse/migrations/019_create_orphaned_l1_hashes.sql
@@ -1,0 +1,13 @@
+-- Migration 019: Create orphaned_l1_hashes table and index
+
+CREATE TABLE IF NOT EXISTS ${DB}.orphaned_l1_hashes (
+    block_hash FixedString(32),
+    l1_block_number UInt64,
+    inserted_at DateTime64(3) DEFAULT now64()
+) ENGINE = MergeTree()
+ORDER BY (l1_block_number, block_hash);
+
+-- orphaned_l1_hashes: lookups by block_hash
+ALTER TABLE ${DB}.orphaned_l1_hashes
+    ADD INDEX IF NOT EXISTS idx_orphaned_l1_block_hash_bf block_hash TYPE bloom_filter(0.01) GRANULARITY 1;
+ALTER TABLE ${DB}.orphaned_l1_hashes MATERIALIZE INDEX idx_orphaned_l1_block_hash_bf;

--- a/crates/clickhouse/src/models.rs
+++ b/crates/clickhouse/src/models.rs
@@ -175,6 +175,15 @@ pub struct OrphanedL2HashRow {
     pub l2_block_number: u64,
 }
 
+/// Orphaned L1 block hash row
+#[derive(Debug, Row, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OrphanedL1HashRow {
+    /// Block hash of orphaned block
+    pub block_hash: HashBytes,
+    /// L1 block number of orphaned block
+    pub l1_block_number: u64,
+}
+
 /// Verified batch row
 #[derive(Debug, Row, Serialize, Deserialize, PartialEq, Eq)]
 pub struct VerifiedBatchRow {

--- a/crates/clickhouse/src/reader/client.rs
+++ b/crates/clickhouse/src/reader/client.rs
@@ -78,6 +78,18 @@ impl ClickhouseReader {
         )
     }
 
+    /// Anti-subquery for L1: hides L1 blocks later rolled back by a reorg.
+    /// Use with `NOT IN (SELECT block_hash FROM ...)` against `l1_head_events` aliases.
+    fn reorg_filter_l1(&self, table_alias: &str) -> String {
+        format!(
+            "{table_alias}.block_hash NOT IN ( \
+                SELECT block_hash \
+                FROM {db}.orphaned_l1_hashes\
+            )",
+            db = self.db_name,
+        )
+    }
+
     /// Get last L2 head time
     pub async fn get_last_l2_head_time(&self) -> Result<Option<DateTime<Utc>>> {
         let client = self.base.clone();
@@ -220,7 +232,8 @@ impl ClickhouseReader {
         let sql = "SELECT max(l1_events.block_ts) AS block_ts \
              FROM ?.batches b \
              INNER JOIN ?.l1_head_events l1_events \
-               ON b.l1_block_number = l1_events.l1_block_number";
+               ON b.l1_block_number = l1_events.l1_block_number \
+             WHERE l1_events.block_hash NOT IN (SELECT block_hash FROM ?.orphaned_l1_hashes)";
 
         let start = Instant::now();
         let result = client
@@ -2961,9 +2974,11 @@ impl ClickhouseReader {
              INNER JOIN {db}.l1_head_events l1_events \
                ON b.l1_block_number = l1_events.l1_block_number \
              WHERE l1_events.block_ts >= toUnixTimestamp(now64() - INTERVAL {interval}) \
+               AND {l1_filter} \
              ORDER BY b.l1_block_number ASC",
             interval = range.interval(),
             db = self.db_name,
+            l1_filter = self.reorg_filter_l1("l1_events"),
         );
 
         let rows = self.execute::<BatchBlobCountRow>(&query).await?;
@@ -2994,6 +3009,8 @@ impl ClickhouseReader {
         if let Some(end) = ending_before {
             query.push_str(&format!(" AND b.batch_id > {}", end));
         }
+        // Exclude L1 orphaned hashes
+        query.push_str(&format!(" AND {}", self.reorg_filter_l1("l1_events")));
         query.push_str(" ORDER BY b.batch_id DESC");
         query.push_str(&format!(" LIMIT {}", limit));
 
@@ -3161,6 +3178,40 @@ impl ClickhouseReader {
 
         let rows = self.execute::<HashRow>(&query).await?;
         Ok(rows.into_iter().map(|r| (r.block_hash, r.l2_block_number)).collect())
+    }
+
+    /// Get the most recent L1 block hashes for the specified L1 block numbers
+    /// This is used to identify orphaned L1 blocks during reorgs
+    pub async fn get_latest_l1_hashes_for_blocks(
+        &self,
+        block_numbers: &[u64],
+    ) -> Result<Vec<(HashBytes, u64)>> {
+        if block_numbers.is_empty() {
+            return Ok(vec![]);
+        }
+
+        #[derive(Row, Deserialize)]
+        struct HashRow {
+            block_hash: HashBytes,
+            l1_block_number: u64,
+        }
+
+        let block_list = block_numbers.iter().map(|n| n.to_string()).collect::<Vec<_>>().join(",");
+        let query = format!(
+            "SELECT block_hash, l1_block_number \
+             FROM (\
+                 SELECT block_hash, l1_block_number, \
+                        ROW_NUMBER() OVER (PARTITION BY l1_block_number ORDER BY inserted_at DESC) as rn \
+                 FROM {db}.l1_head_events \
+                 WHERE l1_block_number IN ({block_list})\
+             ) ranked \
+             WHERE rn = 1 \
+             ORDER BY l1_block_number",
+            db = self.db_name,
+        );
+
+        let rows = self.execute::<HashRow>(&query).await?;
+        Ok(rows.into_iter().map(|r| (r.block_hash, r.l1_block_number)).collect())
     }
 
     /// Get combined L2 fees and batch components data for a unified endpoint

--- a/crates/clickhouse/src/schema.rs
+++ b/crates/clickhouse/src/schema.rs
@@ -27,6 +27,7 @@ pub const TABLES: &[&str] = &[
     "prove_costs",
     "verify_costs",
     "orphaned_l2_hashes",
+    "orphaned_l1_hashes",
 ];
 
 /// Names of all materialized views
@@ -200,5 +201,12 @@ pub const TABLE_SCHEMAS: &[TableSchema] = &[
                  l2_block_number UInt64,
                  inserted_at DateTime64(3) DEFAULT now64()",
         order_by: "l2_block_number, block_hash",
+    },
+    TableSchema {
+        name: "orphaned_l1_hashes",
+        columns: "block_hash FixedString(32),
+                 l1_block_number UInt64,
+                 inserted_at DateTime64(3) DEFAULT now64()",
+        order_by: "l1_block_number, block_hash",
     },
 ];


### PR DESCRIPTION
…xclusion

Introduces `orphaned_l1_hashes` table and writer support, adds L1 anti- reorg filter to ClickHouse reader, and wires L1 reorg detection in the processor to record orphaned L1 block hashes (one-block and traditional reorgs). Moves schema changes into a new forward migration to avoid modifying initial schema.