### PR TITLE
fix(extractor): route taikoAuth_* calls through JWT-signed HTTP provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,6 +458,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-rpc-types-engine"
+version = "1.0.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301962bdc2f084bf25e86abe64d41c8a3ca1398d41d6f3416b6fffe2fe1620fc"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "derive_more 2.0.1",
+ "jsonwebtoken",
+ "rand 0.8.5",
+ "serde",
+ "strum",
+]
+
+[[package]]
 name = "alloy-rpc-types-eth"
 version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -624,7 +642,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3c4d2c0052de0d82fcb2acea16bf3fe105fd4c37d108a331c777942648e8711"
 dependencies = [
  "alloy-json-rpc",
+ "alloy-rpc-types-engine",
  "alloy-transport",
+ "http-body-util",
+ "hyper",
+ "hyper-tls",
+ "hyper-util",
+ "jsonwebtoken",
  "reqwest",
  "serde_json",
  "tower",
@@ -1857,16 +1881,22 @@ dependencies = [
  "alloy-json-rpc",
  "alloy-network-primitives",
  "alloy-rpc-client",
+ "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
  "alloy-sol-types",
+ "alloy-transport-http",
  "chainio",
  "dashmap",
  "derive_more 1.0.0",
  "eyre",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
  "network",
  "primitives",
  "tokio",
  "tokio-stream",
+ "tower",
  "tracing",
  "url",
 ]
@@ -2648,6 +2678,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "k256"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3085,6 +3130,16 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -4164,6 +4219,18 @@ name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.16",
+ "time",
+]
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,16 @@ repository = "https://github.com/chainbound/taikoscope"
 [workspace.dependencies]
 # Alloy dependencies - optimize features for faster compilation while preserving functionality
 alloy = { version = "1.0.34", features = ["provider-ws", "contract", "rpc-types", "sol-types", "reqwest"] }
+# JWT-auth HTTP transport for Shasta's `taikoAuth_*` engine-auth RPC methods.
+# Pulled in directly because the alloy umbrella crate does not expose the
+# `jwt-auth` feature on `alloy-transport-http`.
+alloy-transport-http = { version = "1.0.34", default-features = false, features = ["jwt-auth"] }
+alloy-rpc-types-engine = { version = "1.0.34", default-features = false, features = ["jwt", "serde"] }
+# Transitive hyper ecosystem deps, pulled in directly so the extractor can
+# construct a JWT-auth HTTP RPC client against Taiko's engine-auth endpoint.
+hyper = { version = "1", default-features = false }
+hyper-util = { version = "0.1", features = ["client", "client-legacy", "http1", "tokio"], default-features = false }
+http-body-util = { version = "0.1", default-features = false }
 alloy-contract = { version = "1.0.34" }
 alloy-json-rpc = { version = "1.0.34" }
 alloy-rpc-client = { version = "1.0.34" }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -36,6 +36,24 @@ pub struct RpcOpts {
     /// Public RPC URL for health checks
     #[clap(long, env = "PUBLIC_RPC")]
     pub public_url: Option<Url>,
+    /// Optional L2 authenticated HTTP RPC URL used for Shasta-era
+    /// `taikoAuth_*` methods (e.g. `taikoAuth_lastBlockIDByBatchID`).
+    ///
+    /// Shasta stores per-proposal metadata off-chain: the inbox contract
+    /// does not expose a read method that returns the last L2 block for a
+    /// proposal, so the extractor has to ask the L2 node, which in turn
+    /// only serves `taikoAuth_*` over its JWT-protected engine endpoint.
+    ///
+    /// When unset, the extractor falls back to the unauthenticated
+    /// `l2_url`, which works on Pacaya-era networks but will fail on
+    /// Shasta with `missing taikoAuth_lastBlockIDByBatchID mapping`.
+    #[clap(long, env = "L2_AUTH_RPC_URL")]
+    pub l2_auth_url: Option<Url>,
+    /// Path to a file containing the JWT secret used to authenticate against
+    /// [`Self::l2_auth_url`]. The file must contain a 32-byte hex string,
+    /// optionally prefixed with `0x`. Required iff `l2_auth_url` is set.
+    #[clap(long, env = "L2_JWT_SECRET_PATH")]
+    pub l2_jwt_secret_path: Option<std::path::PathBuf>,
 }
 
 /// Taiko contract address configuration options

--- a/crates/driver/src/driver.rs
+++ b/crates/driver/src/driver.rs
@@ -87,9 +87,21 @@ impl Driver {
             info!("Instatus monitors disabled; no incidents will be reported");
         }
 
+        // Optional Shasta-era JWT auth for `taikoAuth_*` methods. Read the secret
+        // file once here so any IO error surfaces at startup rather than per-proposal.
+        let l2_jwt_secret_hex =
+            match opts.rpc.l2_jwt_secret_path.as_ref() {
+                Some(path) => Some(std::fs::read_to_string(path).wrap_err_with(|| {
+                    format!("failed to read L2 JWT secret at {}", path.display())
+                })?),
+                None => None,
+            };
+
         let extractor = Extractor::new(
             opts.rpc.l1_url.clone(),
             opts.rpc.l2_url.clone(),
+            opts.rpc.l2_auth_url.clone(),
+            l2_jwt_secret_hex,
             opts.taiko_addresses.inbox_address,
             opts.taiko_addresses.preconf_whitelist_address,
             opts.taiko_addresses.anchor_address,

--- a/crates/extractor/Cargo.toml
+++ b/crates/extractor/Cargo.toml
@@ -15,10 +15,18 @@ alloy.workspace = true
 alloy-json-rpc.workspace = true
 alloy-rpc-client.workspace = true
 alloy-rpc-types-eth.workspace = true
+alloy-rpc-types-engine.workspace = true
+alloy-transport-http.workspace = true
 alloy-consensus.workspace = true
 alloy-network-primitives.workspace = true
 derive_more.workspace = true
 eyre.workspace = true
+# Used to construct the JWT-signing HTTP transport for Shasta's
+# `taikoAuth_*` engine-auth RPC methods.
+hyper.workspace = true
+hyper-util.workspace = true
+http-body-util.workspace = true
+tower.workspace = true
 tokio.workspace = true
 tokio-stream.workspace = true
 tracing.workspace = true

--- a/crates/extractor/src/lib.rs
+++ b/crates/extractor/src/lib.rs
@@ -15,11 +15,16 @@ use alloy::{
     sol_types::{SolCall, SolValue},
 };
 use alloy_consensus::{BlockHeader, Transaction};
-use alloy_rpc_client::ClientBuilder;
+use alloy_rpc_client::{ClientBuilder, RpcClient};
+use alloy_rpc_types_engine::JwtSecret;
+use alloy_transport_http::{AuthLayer, Http, HyperClient};
 use chainio::TaikoInbox;
 use dashmap::DashMap;
 use derive_more::Debug;
 use eyre::{Context, Result};
+use http_body_util::Full;
+use hyper::body::Bytes as HyperBytes;
+use hyper_util::{client::legacy::Client as HyperLegacyClient, rt::TokioExecutor};
 use network::retries::{DEFAULT_RETRY_LAYER, RetryWsConnect};
 use primitives::{
     block_stats::compute_block_stats,
@@ -27,6 +32,7 @@ use primitives::{
 };
 use tokio::{sync::mpsc, time::sleep};
 use tokio_stream::{Stream, StreamExt, wrappers::UnboundedReceiverStream};
+use tower::ServiceBuilder;
 use tracing::{debug, error, info, warn};
 use url::Url;
 
@@ -39,6 +45,12 @@ pub struct Extractor {
     l1_provider: DefaultProvider,
     #[debug(skip)]
     l2_provider: DefaultProvider,
+    /// Optional JWT-authenticated L2 HTTP provider used exclusively for
+    /// Shasta-era `taikoAuth_*` RPC methods (e.g. `taikoAuth_lastBlockIDByBatchID`).
+    /// When `None`, the extractor falls back to `l2_provider`, which works on
+    /// Pacaya-era networks but will return `None` for Shasta proposals.
+    #[debug(skip)]
+    l2_auth_provider: Option<DefaultProvider>,
     preconf_whitelist: TaikoPreconfWhitelist,
     taiko_inbox: TaikoInbox,
     anchor_address: Address,
@@ -67,10 +79,17 @@ pub struct DecodedBatchProposed {
 }
 
 impl Extractor {
-    /// Create a new extractor
+    /// Create a new extractor.
+    ///
+    /// `l2_auth_rpc_url` and `l2_jwt_secret_hex` are both optional and must be
+    /// supplied together. When present they configure a dedicated JWT-signing
+    /// HTTP provider used for Shasta-era `taikoAuth_*` methods (see
+    /// [`Self::get_last_block_id_by_batch_id_via_rpc`]).
     pub async fn new(
         l1_rpc_url: Url,
         l2_rpc_url: Url,
+        l2_auth_rpc_url: Option<Url>,
+        l2_jwt_secret_hex: Option<String>,
         inbox_address: Address,
         preconf_whitelist_address: Address,
         anchor_address: Address,
@@ -108,6 +127,21 @@ impl Extractor {
             )?;
         let l2_provider = ProviderBuilder::new().connect_client(l2_client);
 
+        let l2_auth_provider = match (l2_auth_rpc_url.as_ref(), l2_jwt_secret_hex.as_ref()) {
+            (Some(url), Some(secret_hex)) => Some(build_l2_auth_provider(url.clone(), secret_hex)?),
+            (None, None) => None,
+            (Some(_), None) => {
+                return Err(eyre::eyre!(
+                    "L2_AUTH_RPC_URL is set but L2_JWT_SECRET_PATH is not — both must be provided together"
+                ));
+            }
+            (None, Some(_)) => {
+                return Err(eyre::eyre!(
+                    "L2_JWT_SECRET_PATH is set but L2_AUTH_RPC_URL is not — both must be provided together"
+                ));
+            }
+        };
+
         let taiko_inbox = TaikoInbox::new_readonly(inbox_address, l1_provider.clone());
         let preconf_whitelist =
             TaikoPreconfWhitelist::new_readonly(preconf_whitelist_address, l1_provider.clone());
@@ -117,6 +151,7 @@ impl Extractor {
         Ok(Self {
             l1_provider,
             l2_provider,
+            l2_auth_provider,
             preconf_whitelist,
             taiko_inbox,
             anchor_address,
@@ -527,8 +562,12 @@ impl Extractor {
     }
 
     async fn get_last_block_id_by_batch_id_via_rpc(&self, batch_id: u64) -> Result<Option<u64>> {
-        let result: Option<U256> = self
-            .l2_provider
+        // The `taikoAuth_*` namespace only exists on Taiko geth's JWT-protected
+        // engine endpoint. Prefer the dedicated auth provider when configured;
+        // otherwise fall back to the main L2 provider for backwards compat with
+        // Pacaya-era networks where the method was exposed unauthenticated.
+        let provider = self.l2_auth_provider.as_ref().unwrap_or(&self.l2_provider);
+        let result: Option<U256> = provider
             .raw_request(Cow::Borrowed("taikoAuth_lastBlockIDByBatchID"), (U256::from(batch_id),))
             .await?;
         Ok(result.map(|value| value.to::<u64>()))
@@ -691,6 +730,35 @@ impl Extractor {
 
         Err(eyre::eyre!("Transaction not found for transaction hash: {}", tx_hash))
     }
+}
+
+/// Build a JWT-signing HTTP provider against Taiko geth's engine-auth endpoint.
+///
+/// Uses [`alloy_transport_http::AuthLayer`] via a `hyper_util` legacy client,
+/// following the pattern documented in `alloy_provider`'s `test_auth_layer_transport`
+/// test. The resulting provider is a drop-in replacement for any other
+/// [`DefaultProvider`] — it signs a fresh JWT bearer per request and sends it in
+/// the `Authorization` header.
+///
+/// `secret_hex` may be a 64-character hex string with or without a `0x` prefix.
+fn build_l2_auth_provider(url: Url, secret_hex: &str) -> Result<DefaultProvider> {
+    // Tolerate whitespace from file reads and an optional 0x prefix.
+    let trimmed = secret_hex.trim();
+    let trimmed =
+        trimmed.strip_prefix("0x").or_else(|| trimmed.strip_prefix("0X")).unwrap_or(trimmed);
+    let secret = JwtSecret::from_hex(trimmed)
+        .wrap_err("invalid L2 JWT secret: expected 32-byte hex string")?;
+
+    let hyper_client =
+        HyperLegacyClient::builder(TokioExecutor::new()).build_http::<Full<HyperBytes>>();
+    let service = ServiceBuilder::new().layer(AuthLayer::new(secret)).service(hyper_client);
+    let hyper_transport = HyperClient::with_service(service);
+    let http = Http::with_client(hyper_transport, url);
+    // The engine-auth endpoint is effectively local from the extractor's
+    // perspective (single-hop to a Taiko geth we control), so `is_local=true`
+    // is fine — it only affects batching heuristics in alloy.
+    let rpc_client = RpcClient::new(http, true);
+    Ok(ProviderBuilder::new().connect_client(rpc_client))
 }
 
 fn retry_delay_ms(attempt: u32) -> u64 {

--- a/crates/extractor/tests/integration.rs
+++ b/crates/extractor/tests/integration.rs
@@ -61,6 +61,8 @@ async fn test_get_block_stream() -> Result<()> {
     let ext = Extractor::new(
         ws.clone(),
         ws,
+        None, // no L2 auth RPC for local anvil test
+        None, // no JWT secret
         address!("0xa7B208DE7F35E924D59C2b5f7dE3bb346E8A138C"),
         address!("0x3ea351Db28A9d4833Bf6c519F52766788DE14eC1"),
         // address!("0x962C95233f04Ef08E7FaA84DBd1c5171f06f5616"),


### PR DESCRIPTION
## Summary

After the Shasta fork on 2026-04-02 the mainnet extractor stopped ingesting batches. Every proposal hits:

```
WARN extractor: Failed to decode Proposed log
  error=missing taikoAuth_lastBlockIDByBatchID mapping for proposal 2764
```

Root cause: the Shasta inbox contract does not expose a read method that returns a proposal's `lastBlockId`, so the extractor has to ask the L2 node via `taikoAuth_lastBlockIDByBatchID`. That method only exists on Taiko geth's **engine-auth** endpoint (port 8551) and requires **JWT** authentication, which the extractor did not support.

I verified directly against the live shasta inbox:
```
$ cast call shasta_inbox 'getBatch(uint64)'  2761  → execution reverted
$ cast call shasta_inbox 'getProposal(uint48)' 2761 → execution reverted
$ cast call shasta_inbox 'proposals(uint48)'   2761 → execution reverted
$ cast call shasta_inbox 'owner()'                  → ok
```
The previously-merged on-chain fallback (`contract.getBatch`) cannot help here — the shasta inbox has no such method and reverts on every call, so the fallback silently returns `Ok(None)` 20 times in a row and the retry loop eventually emits the same warning.

## Fix

1. Add optional `L2_AUTH_RPC_URL` + `L2_JWT_SECRET_PATH` env vars. Both optional, both-or-neither.
2. Extractor builds a second alloy provider via `alloy_transport_http::AuthLayer` + a `hyper_util` legacy client when both env vars are set. This follows the same pattern alloy's own `test_auth_layer_transport` uses for engine-API access.
3. `get_last_block_id_by_batch_id_via_rpc` prefers the auth provider when configured, falling back to the original L2 provider otherwise (backwards compat with Pacaya-era networks).
4. Driver reads the JWT secret file once at startup so IO errors surface early.

## Deploy plan (mainnet)

1. Copy `jwt-secret` from `mainnet-trailblazer/mainnet` namespace into `taikoscope-mainnet`
2. Add `L2_AUTH_RPC_URL=http://34.134.197.241:8551` (public LB on the `l2-node-debug` service) + mount the JWT secret at `/etc/l2/jwt.hex` via taiko-infra-mono
3. Publish new processor image
4. Rollout restart `statefulset/taikoscope`
5. Verify `taikoscope.batches.max_batch_id` in ClickHouse starts climbing above `1363317`

## Test plan

- [x] `cargo check -p config -p extractor -p driver`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`  (clean)
- [x] `cargo nextest run -p config -p extractor`  (22/22 passing)
- [x] `cargo +nightly fmt --all`
- [ ] After deploy: fresh proposals ingested into `taikoscope.batches`