### PR TITLE
fix(extractor): extend taikoAuth_lastBlockIDByBatchID retry window to 3m

### DIFF
--- a/crates/extractor/src/lib.rs
+++ b/crates/extractor/src/lib.rs
@@ -517,7 +517,19 @@ impl Extractor {
     }
 
     async fn get_last_block_id_by_batch_id_with_retry(&self, batch_id: u64) -> Result<u64> {
-        const MAX_RETRIES: u32 = 20;
+        // Observed on mainnet Shasta (2026-04-15): the L2 node sometimes needs
+        // longer than 10s (= 20 * 500ms) to populate the
+        // `taikoAuth_lastBlockIDByBatchID` mapping for a fresh proposal,
+        // because it waits for the L2 blocks derived from the proposal's
+        // blob sources to be seen and executed. When the mapping isn't ready
+        // in time, the retry loop gives up and the proposal is dropped,
+        // which widens the gap between ingested batches and trips false
+        // "No BatchProposed events" alerts.
+        //
+        // Give the node up to 3 minutes (360 attempts * 500ms). The loop
+        // short-circuits immediately on Ok(Some), so this only increases the
+        // latency for proposals that actually need to wait.
+        const MAX_RETRIES: u32 = 360;
         const DELAY_MS: u64 = 500;
 
         for attempt in 0..MAX_RETRIES {


### PR DESCRIPTION
## Summary

Follow-up to #1137. The previous 20 * 500ms = 10s retry window is too tight for mainnet Shasta. The L2 node sometimes needs longer than 10s to populate the `lastBlockID` mapping for a fresh proposal — it only sets the mapping once the L2 blocks derived from the proposal's blob sources have been seen and executed.

## Observed on mainnet 2026-04-15

- Proposals **2824** and **2827** dropped with `missing taikoAuth_lastBlockIDByBatchID` warnings
- Dropped proposals widened the gap between successful `batches` inserts to >12 min
- This tripped false instatus "No BatchProposed events - Possible Outage" alerts
- Clickhouse stats over the 6h preceding the fix:
  ```
  n_batches: 34
  avg_gap:   530s
  p50:       392s
  p90:       768s
  max:       1151s
  gaps > 600s:  11 / 34  (32% false-alert rate)
  ```

## Fix

Bump `MAX_RETRIES` from 20 to 360 (still at 500ms cadence) so the retry loop waits up to 180s before giving up. The loop short-circuits on `Ok(Some)`, so steady-state latency is unchanged — only proposals that actually need to wait see higher latency.

## Test plan

- [x] `cargo check -p extractor`
- [x] `cargo clippy -p extractor --all-targets -- -D warnings`
- [x] `cargo +nightly fmt --all`
- [ ] After deploy: zero `missing taikoAuth` warnings under normal shasta cadence; `batches` insert gap stays under instatus threshold (1500s once taiko-infra-mono ships the corresponding configmap update)