### PR TITLE
fix(dashboard): default batch-data views to wider range

### DIFF
--- a/dashboard/components/DashboardHeader.tsx
+++ b/dashboard/components/DashboardHeader.tsx
@@ -2,7 +2,11 @@ import React from 'react';
 import { TimeRange } from '../types';
 import { RefreshCountdown } from './RefreshCountdown';
 import { isValidRefreshRate } from '../utils';
-import { isValidTimeRange, formatTimeRangeDisplay } from '../utils/timeRange';
+import {
+  isValidTimeRange,
+  formatTimeRangeDisplay,
+  MAX_TIME_RANGE_DAYS,
+} from '../utils/timeRange';
 import { useRouterNavigation } from '../hooks/useRouterNavigation';
 import { DEFAULT_VIEW } from '../constants';
 import { useErrorHandler } from '../hooks/useErrorHandler';
@@ -29,7 +33,7 @@ const NETWORK_NAME =
   rawNetworkName.charAt(0).toUpperCase() +
   rawNetworkName.slice(1).toLowerCase();
 const DASHBOARD_TITLE = `Taikoscope ${NETWORK_NAME}`;
-const MAX_CUSTOM_DAYS = 7;
+const MAX_CUSTOM_DAYS = MAX_TIME_RANGE_DAYS;
 const CUSTOM_RANGE_LIMIT_MESSAGE = `Custom time range is limited to ${MAX_CUSTOM_DAYS} days.`;
 
 interface DashboardHeaderProps {
@@ -137,6 +141,8 @@ export const TimeRangeSelector: React.FC<TimeRangeSelectorProps> = ({
     '12h',
     '24h',
     '7d',
+    '14d',
+    '30d',
   ];
   const isCustom = /^\d+-\d+$/.test(currentTimeRange);
   const [open, setOpen] = React.useState(false);

--- a/dashboard/hooks/useTimeRangeSync.ts
+++ b/dashboard/hooks/useTimeRangeSync.ts
@@ -4,7 +4,8 @@ import { TimeRange } from '../types';
 import { isValidTimeRange } from '../utils/timeRange';
 
 const DEFAULT_TIME_RANGE: TimeRange = '24h';
-const BATCH_DATA_DEFAULT_TIME_RANGE: TimeRange = '14d';
+const ECONOMICS_DEFAULT_TIME_RANGE: TimeRange = '14d';
+const HEALTH_DEFAULT_TIME_RANGE: TimeRange = '30d';
 
 /**
  * Hook that synchronizes time range state with URL parameters to prevent navigation loops
@@ -17,9 +18,9 @@ export const useTimeRangeSync = () => {
   const getDefaultTimeRange = useCallback((): TimeRange => {
     const params = new URLSearchParams(location.search);
     const view = params.get('view');
-    return view === 'economics' || view === 'health'
-      ? BATCH_DATA_DEFAULT_TIME_RANGE
-      : DEFAULT_TIME_RANGE;
+    if (view === 'economics') return ECONOMICS_DEFAULT_TIME_RANGE;
+    if (view === 'health') return HEALTH_DEFAULT_TIME_RANGE;
+    return DEFAULT_TIME_RANGE;
   }, [location.search]);
 
   // Get initial time range from URL or use default

--- a/dashboard/hooks/useTimeRangeSync.ts
+++ b/dashboard/hooks/useTimeRangeSync.ts
@@ -4,6 +4,7 @@ import { TimeRange } from '../types';
 import { isValidTimeRange } from '../utils/timeRange';
 
 const DEFAULT_TIME_RANGE: TimeRange = '24h';
+const BATCH_DATA_DEFAULT_TIME_RANGE: TimeRange = '14d';
 
 /**
  * Hook that synchronizes time range state with URL parameters to prevent navigation loops
@@ -12,6 +13,14 @@ const DEFAULT_TIME_RANGE: TimeRange = '24h';
 export const useTimeRangeSync = () => {
   const location = useLocation();
   const navigate = useNavigate();
+
+  const getDefaultTimeRange = useCallback((): TimeRange => {
+    const params = new URLSearchParams(location.search);
+    const view = params.get('view');
+    return view === 'economics' || view === 'health'
+      ? BATCH_DATA_DEFAULT_TIME_RANGE
+      : DEFAULT_TIME_RANGE;
+  }, [location.search]);
 
   // Get initial time range from URL or use default
   const getInitialTimeRange = useCallback((): TimeRange => {
@@ -29,8 +38,8 @@ export const useTimeRangeSync = () => {
     const urlRange = params.get('range');
     return urlRange && isValidTimeRange(urlRange)
       ? (urlRange as TimeRange)
-      : DEFAULT_TIME_RANGE;
-  }, [location.search]);
+      : getDefaultTimeRange();
+  }, [getDefaultTimeRange, location.search]);
 
   const [timeRange, setTimeRangeState] =
     useState<TimeRange>(getInitialTimeRange);
@@ -52,7 +61,7 @@ export const useTimeRangeSync = () => {
         newParams.set('end', e);
         newParams.delete('range');
       } else {
-        if (newRange === DEFAULT_TIME_RANGE) {
+        if (newRange === getDefaultTimeRange()) {
           newParams.delete('range');
         } else {
           newParams.set('range', newRange);
@@ -66,7 +75,7 @@ export const useTimeRangeSync = () => {
         { replace: true },
       );
     },
-    [location.search, navigate],
+    [getDefaultTimeRange, location.search, navigate],
   );
 
   // Sync state when URL changes (e.g., browser back/forward)

--- a/dashboard/tests/navigationUtils.test.ts
+++ b/dashboard/tests/navigationUtils.test.ts
@@ -128,6 +128,9 @@ describe('navigationUtils', () => {
       const params = new URLSearchParams('range=1h');
       expect(validateSearchParams(params)).toBe(true);
 
+      const widerParams = new URLSearchParams('range=14d');
+      expect(validateSearchParams(widerParams)).toBe(true);
+
       const invalidParams = new URLSearchParams('range=invalid');
       expect(validateSearchParams(invalidParams)).toBe(false);
     });
@@ -220,6 +223,25 @@ describe('navigationUtils', () => {
   });
 
   describe('useTimeRangeSync', () => {
+    it('defaults batch-data views to 14d when no range is provided', async () => {
+      const { useTimeRangeSync } = await import('../hooks/useTimeRangeSync');
+      let value = '';
+
+      function Wrapper() {
+        const { timeRange } = useTimeRangeSync();
+        value = timeRange;
+        return null;
+      }
+
+      currentSearch = '?view=economics';
+      renderToStaticMarkup(React.createElement(Wrapper));
+      expect(value).toBe('14d');
+
+      currentSearch = '?view=health';
+      renderToStaticMarkup(React.createElement(Wrapper));
+      expect(value).toBe('14d');
+    });
+
     it('handles rapid range changes via history navigation', async () => {
       const { useTimeRangeSync } = await import('../hooks/useTimeRangeSync');
       let setFn: (r: string) => void = () => {};

--- a/dashboard/tests/navigationUtils.test.ts
+++ b/dashboard/tests/navigationUtils.test.ts
@@ -223,7 +223,7 @@ describe('navigationUtils', () => {
   });
 
   describe('useTimeRangeSync', () => {
-    it('defaults batch-data views to 14d when no range is provided', async () => {
+    it('uses wider defaults for batch-data views when no range is provided', async () => {
       const { useTimeRangeSync } = await import('../hooks/useTimeRangeSync');
       let value = '';
 
@@ -239,7 +239,7 @@ describe('navigationUtils', () => {
 
       currentSearch = '?view=health';
       renderToStaticMarkup(React.createElement(Wrapper));
-      expect(value).toBe('14d');
+      expect(value).toBe('30d');
     });
 
     it('handles rapid range changes via history navigation', async () => {

--- a/dashboard/tests/timeRange.test.ts
+++ b/dashboard/tests/timeRange.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { normalizeTimeRange } from '../utils/timeRange';
+import { isValidTimeRange, normalizeTimeRange } from '../utils/timeRange';
 
 describe('normalizeTimeRange', () => {
   const now = Date.UTC(2024, 0, 1, 0, 0, 0);
@@ -17,5 +17,14 @@ describe('normalizeTimeRange', () => {
   it('trims whitespace and defaults to 24 hours for invalid input', () => {
     expect(normalizeTimeRange(' 1h ', now)).toBe(`${now - 3_600_000}-${now}`);
     expect(normalizeTimeRange('foo', now)).toBe(`${now - 86_400_000}-${now}`);
+  });
+
+  it('accepts wider preset and custom ranges up to 30 days', () => {
+    expect(isValidTimeRange('14d')).toBe(true);
+    expect(isValidTimeRange('30d')).toBe(true);
+    expect(isValidTimeRange(`${now}-${now + 30 * 24 * 60 * 60 * 1000}`)).toBe(
+      true,
+    );
+    expect(isValidTimeRange('31d')).toBe(false);
   });
 });

--- a/dashboard/utils/timeRange.ts
+++ b/dashboard/utils/timeRange.ts
@@ -1,3 +1,7 @@
+export const MAX_TIME_RANGE_DAYS = 30;
+const MAX_TIME_RANGE_MINUTES = MAX_TIME_RANGE_DAYS * 24 * 60;
+const MAX_TIME_RANGE_MS = MAX_TIME_RANGE_DAYS * 24 * 60 * 60 * 1000;
+
 export const isValidTimeRange = (range: string): boolean => {
   const trimmed = range.trim();
   const match = trimmed.match(/^(\d+)([mhd])$/i);
@@ -7,7 +11,7 @@ export const isValidTimeRange = (range: string): boolean => {
     const unit = match[2].toLowerCase();
     const minutes =
       unit === 'h' ? value * 60 : unit === 'd' ? value * 24 * 60 : value;
-    return minutes <= 7 * 24 * 60;
+    return minutes <= MAX_TIME_RANGE_MINUTES;
   }
 
   const custom = trimmed.match(/^(\d+)-(\d+)$/);
@@ -15,7 +19,7 @@ export const isValidTimeRange = (range: string): boolean => {
     const start = parseInt(custom[1], 10);
     const end = parseInt(custom[2], 10);
     if (isNaN(start) || isNaN(end) || end <= start) return false;
-    return end - start <= 7 * 24 * 60 * 60 * 1000;
+    return end - start <= MAX_TIME_RANGE_MS;
   }
 
   return false;


### PR DESCRIPTION
## Summary
- Default economics and health views to 14d when no explicit range is selected
- Allow 14d and 30d ranges in the dashboard picker and URL validation
- Cover wider range validation and batch-data default views with tests

## Verification
- just ci-dashboard

## Production
- Already deployed frontend image to taikoscope mainnet GKE: us-central1-docker.pkg.dev/taikoscope/taikoscope/frontend@sha256:25ea70037f170cc3da91e1402637c35f42b98d755b6e72de645d4632829e3214